### PR TITLE
Change aggregated properties

### DIFF
--- a/OPAL/br/src/main/scala/org/opalj/br/fpcf/properties/AggregatableValueProperty.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/fpcf/properties/AggregatableValueProperty.scala
@@ -25,14 +25,14 @@ trait IndividualProperty[S <: IndividualProperty[S, T], T <: AggregatedProperty[
     extends AggregatableValueProperty[S, T] {
     override type self = S
 
-    val aggregatedProperty: T
+    def aggregatedProperty: T
 }
 
 trait AggregatedProperty[S <: IndividualProperty[S, T], T <: AggregatedProperty[S, T]]
     extends AggregatableValueProperty[S, T] {
     override type self = T
 
-    val individualProperty: S
+    def individualProperty: S
 
     override def meet(other: T): T =
         other.individualProperty.meet(this.individualProperty).aggregatedProperty

--- a/OPAL/br/src/main/scala/org/opalj/br/fpcf/properties/Purity.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/fpcf/properties/Purity.scala
@@ -152,7 +152,7 @@ sealed abstract class Purity
     def modifiesParameters: Boolean = (flags & ModifiesParameters) != 0
     def usesDomainSpecificActions: Boolean = (flags & PerformsDomainSpecificOperations) != 0
 
-    final val aggregatedProperty = new VirtualMethodPurity(this)
+    final def aggregatedProperty = new VirtualMethodPurity(this)
 
     /**
      * Combines this purity value with another one to represent the progress by a purity


### PR DESCRIPTION
Using a def instead of a val should improve memory usage, especially if the corresponding aggregation analysis isn't even scheduled.