### PR TITLE
Removes ':' from the temp file path that is invalid on Windows

### DIFF
--- a/OPAL/bi/src/main/scala/org/opalj/bi/reader/ClassFileReader.scala
+++ b/OPAL/bi/src/main/scala/org/opalj/bi/reader/ClassFileReader.scala
@@ -527,8 +527,8 @@ trait ClassFileReader extends ClassFileReaderConfiguration with Constant_PoolAbs
 
         innerJarEntries.iterator().forEachRemaining { jarEntry ⇒
             // TODO make this commons.vfs compatible...
-            // To read the nested jars directly without savin them in temp                                                     
-            // https://stackoverflow.com/questions/9661214/uri-for-nested-zip-files-in-apaches-common-vfs                                                     
+            // To read the nested jars directly without savin them in temp
+            // https://stackoverflow.com/questions/9661214/uri-for-nested-zip-files-in-apaches-common-vfs
             // jar:jar/...!/...!...
             val nextJarFileURL = s"${jarFileURL}jar:${jarEntry.getName}!/"
             try {

--- a/OPAL/bi/src/main/scala/org/opalj/bi/reader/ClassFileReader.scala
+++ b/OPAL/bi/src/main/scala/org/opalj/bi/reader/ClassFileReader.scala
@@ -554,8 +554,8 @@ trait ClassFileReader extends ClassFileReaderConfiguration with Constant_PoolAbs
         classFileHandler: (ClassFile, URL) ⇒ Unit,
         exceptionHandler: ExceptionHandler
     ): Unit = {
-        val pathToEntry = jarFileURL.substring(0, jarFileURL.length - 3)
-        val entry = pathToEntry.substring(pathToEntry.lastIndexOf('/') + 1)
+        val pathToEntry = jarFileURL.substring(0, jarFileURL.length - 2)
+        val entry = pathToEntry.substring(4, pathToEntry.lastIndexOf('/') + 1)
         try {
             val jarFile = File.createTempFile(entry, ".zip")
 

--- a/OPAL/bi/src/main/scala/org/opalj/bi/reader/ClassFileReader.scala
+++ b/OPAL/bi/src/main/scala/org/opalj/bi/reader/ClassFileReader.scala
@@ -527,6 +527,8 @@ trait ClassFileReader extends ClassFileReaderConfiguration with Constant_PoolAbs
 
         innerJarEntries.iterator().forEachRemaining { jarEntry ⇒
             // TODO make this commons.vfs compatible...
+            // To read the nested jars directly without savin them in temp                                                     
+            // https://stackoverflow.com/questions/9661214/uri-for-nested-zip-files-in-apaches-common-vfs                                                     
             // jar:jar/...!/...!...
             val nextJarFileURL = s"${jarFileURL}jar:${jarEntry.getName}!/"
             try {
@@ -555,7 +557,7 @@ trait ClassFileReader extends ClassFileReaderConfiguration with Constant_PoolAbs
         exceptionHandler: ExceptionHandler
     ): Unit = {
         val pathToEntry = jarFileURL.substring(0, jarFileURL.length - 2)
-        val entry = pathToEntry.substring(4, pathToEntry.lastIndexOf('/') + 1)
+        val entry = pathToEntry.substring(pathToEntry.lastIndexOf('/') + 1 /* the '/' */ + 4 /* "jar:" */ )
         try {
             val jarFile = File.createTempFile(entry, ".zip")
 


### PR DESCRIPTION
I'm not sure why this path was prefixed with "jar:" for the temp file. On windows thats not a valid symbol in a path and results in a test failure. 