### PR TITLE
Update tutorials to current version of OPAL, fix typos

### DIFF
--- a/src/site/JDK8Complexity.snippet.html
+++ b/src/site/JDK8Complexity.snippet.html
@@ -46,7 +46,7 @@
 	<p>
 	The analysis was written using the OPAL Bytecode toolkit and is shown next (5 lines of boilerplate and 12 lines for the analysis).
 
-	<pre><code>object InstructionStatistics extends AnalysisExecutor {
+	<pre><code>object InstructionStatistics extends AnalysisApplication {
 
   val analysis = new Analysis[URL, BasicReport] {
 
@@ -57,7 +57,7 @@
       // FQPN = FullyQualifiedPackageName
       val instructionsPerFQPN = HashMap.empty[String, Int]
       for {
-        classFile ← project.classFiles
+        classFile ← project.allClassFiles
         packageName = classFile.thisType.packageName
         MethodWithBody(body) ← classFile.methods
       } {

--- a/src/site/UselessBoxing.snippet.html
+++ b/src/site/UselessBoxing.snippet.html
@@ -28,7 +28,7 @@ for {
     method @ MethodWithBody(body) ← classFile.methods // for all non-abstract, non-native methods
     pc ← body.matchPair { // find a sequence of two instructions where...
         case (
-            INVOKESPECIAL(receiver1, _, TheArgument(parameterType: BaseType)),
+            INVOKESPECIAL(receiver1, _, _, TheArgument(parameterType: BaseType)),
             INVOKEVIRTUAL(receiver2, name, NoArgumentMethodDescriptor(returnType: BaseType))
             ) ⇒ { (receiver1 eq receiver2) &amp;&amp;
                    receiver1.isPrimitiveTypeWrapper &amp;&amp;

--- a/src/site/examples/BytecodeEngineering.md
+++ b/src/site/examples/BytecodeEngineering.md
@@ -123,14 +123,14 @@ To specify exception handlers use `TRY`, `TRYEND` and `CATCH` in combination wit
                     'tryEnd,
                     TRYEND('Try1),
                     GOTO('finally),
-                    CATCH('Try1, "java/lang/Exception"),
+                    CATCH('Try1, 0, "java/lang/Exception"),
                     POP,
                     ICONST_0,
                     ISTORE_2,
                     TRYEND('FinallyTry2),
                     GOTO('finally),
-                    CATCH('FinallyTry2),
-                    CATCH('LastPCTry3),
+                    CATCH('FinallyTry2, 1),
+                    CATCH('LastPCTry3, 2),
                     POP,
                     'finally,
                     ILOAD_1,
@@ -178,10 +178,10 @@ The DSL interacts seamlessly with the bytecode representation and all attibutes 
             METHOD(
                 FINAL.SYNTHETIC.PUBLIC, "testMethod", "(Ljava/lang/String;)Ljava/lang/String;",
                 CODE(ACONST_NULL, ARETURN),
-                Seq(EXCEPTIONS("java/lang/Exception"), Deprecated)
+                RefArray(EXCEPTIONS("java/lang/Exception"), Deprecated)
             )
         ),
-        attributes = Seq(SourceFile("ClassFileBuilderTest.scala"), Synthetic)
+        attributes = RefArray(SourceFile("ClassFileBuilderTest.scala"), Synthetic)
     )
 
 

--- a/src/site/examples/ClassHierarchy.md
+++ b/src/site/examples/ClassHierarchy.md
@@ -2,7 +2,7 @@
 
 One of the most common tasks when implementing static analyses is to get information about the inheritance relation between different classes, to traverse all super/sub classes/interfaces or to compute the least upper bound given some classes. Support for answering such questions or for processing a project's class hierarchy is directly provided by OPAL's `org.opalj.br.ClassHierarchy`. The easiest way to get the class hierarchy is to first instantiate a project and then ask the project for the class hierarchy.
 
-    import import org.opalj.br._ ; import org.opalj.br.analyses._ ; import java.io.File
+    import org.opalj.br._ ; import org.opalj.br.analyses._ ; import java.io.File
     val projectJAR = "./OPAL/bi/target/scala-2.12/resource_managed/test/method_types.jar"
     implicit val p = Project(new File(projectJAR),org.opalj.bytecode.RTJar)
     val classHierarchy = p.classHierarchy
@@ -14,7 +14,7 @@ The class hierarchy, e.g., directly makes the information about a type's super/s
 
 To get, e.g., all subtypes of `java.io.Serializable`, it is sufficient to query the subtypes information:
 
-    val subtypesOfSerializable = subtypeInformation(ObjectType("java/io/Serializable"))
+    val subtypesOfSerializable = classHierarchy.subtypeInformation(ObjectType("java/io/Serializable"))
 
 >Recall that in Java bytecode package names are separated using "/" and not "." as used in Java/Scala/... source code.
 
@@ -22,4 +22,4 @@ To get, e.g., all subtypes of `java.io.Serializable`, it is sufficient to query 
 
 If you don't know whether a given type is known to the class hierarchy, you should call the `get` method to avoid potential `NoSuchElementExceptions`.
 
-    subtypes.get(ObjectType("java/io/Serializable")).foreach{subtypeInformation => ... }
+    classHierarchy.subtypeInformation.get(ObjectType("java/io/Serializable")).foreach{subtypeInformation => ... }

--- a/src/site/examples/TAC.md
+++ b/src/site/examples/TAC.md
@@ -26,7 +26,7 @@ A very straight forward way to get a method's TAC is to use the respective `Proj
 
 *Step 2* - Tell the project that it should make the 3-address code of the method available, when required:
 
-    val tac = p.get(SimpleTACAIKey)
+    val tac = p.get(ComputeACAIKey)
 
 *Step 3* - To get the TAC of a specific method with a body just look it up:
 
@@ -34,10 +34,13 @@ A very straight forward way to get a method's TAC is to use the respective `Proj
     val m = cf.findMethod("someSwitch").head
     val taCode = tac(m)
 
- In some cases it is desirable to exchange the underlying data-flow analysis that is used as a foundation for creating the TAC. This can easily be done by updating `SimpleTACAIKey`'s `domain factory`. The latter is used when computing the TAC and can be changed ***before*** the key (`SimpleTACAIKey`) is passed to the project (`<Project>.get(SimpleTACAIKey)`).
+ In some cases it is desirable to exchange the underlying data-flow analysis that is used as a foundation for creating the TAC. This can easily be done by updating the project's `AIDomainFactoryKey`. The latter is used when computing the TAC and can be changed ***before*** the key (`ComputeTACAIKey`) is passed to the project (`<Project>.get(ComputeTACAIKey)`).
  E.g., to set the domain to the simplest/most basic supported domain, you can use:
 
-    SimpleTACAIKey.domainFactory = (p :SomeProject, cf : ClassFile,m : Method) => new domain.l0.BaseDomainWithDefUse(p,cf,m)
+    p.updateProjectInformationKeyInitializationData(AIDomainFactoryKey) {
+      case None               ⇒ Set(classOf[domain.l0.BaseDomainWithDefUse[_]])
+      case Some(requirements) ⇒ requirements + classOf[domain.l0.BaseDomainWithDefUse[_]]
+    }
 
  For example, creating the TAC using the simplest domain – and a production build of OPAL – takes roughly one third of the time of using the default domain. However, the default domain provides much more information and is therefore the recommended base analysis. To be more precise, on a Core i7 (4 Cores - Sandy Bridge, 2011) generating the standard TAC for the rt.jar of the JDK 8u121 using the simplest possible domain takes 13 seconds and for the default domain 33 seconds.
 
@@ -145,7 +148,7 @@ We can get the 3-address code (using, e.g., the `sbt console`) as follows (the m
 
     import org.opalj._
     val p = br.analyses.Project(new java.io.File("OPAL/bi/target/scala-2.12/resource_managed/test/ai.jar"))
-    val tacAIKey = p.get(tac.DefaultTACAIKey)
+    val tacAIKey = p.get(tac.ComputeTACAIKey)
     val code = tacAIKey(p.classFile(br.ObjectType("ai/MethodsWithTypeChecks")).get.findMethod("requiredCast").head)
 
 The 3-address code of the above method is shown next:


### PR DESCRIPTION
Several tutorials did not keep up with changes in OPAL's interfaces