### PR TITLE
Fix call graphs

### DIFF
--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/DoPrivilegedPointsToCGAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/DoPrivilegedPointsToCGAnalysis.scala
@@ -199,7 +199,7 @@ class DoPrivilegedPointsToCGAnalysis private[cg] (
             self.createPointsToSet(pc, declaredMethod, allocatedType, isConstant, isEmptyArray)
         }
 
-        override protected[this] def currentPointsTo(
+        @inline override protected[this] def currentPointsTo(
             depender:   DependerType,
             dependee:   Entity,
             typeFilter: ReferenceType ⇒ Boolean
@@ -207,8 +207,16 @@ class DoPrivilegedPointsToCGAnalysis private[cg] (
             self.currentPointsTo(depender, dependee, typeFilter)
         }
 
-        override protected[this] def getTypeOf(element: ElementType): ReferenceType = {
+        @inline override protected[this] def getTypeOf(element: ElementType): ReferenceType = {
             self.getTypeOf(element)
+        }
+
+        @inline override protected[this] def getTypeIdOf(element: ElementType): Int = {
+            self.getTypeIdOf(element)
+        }
+
+        @inline override protected[this] def isEmptyArray(element: ElementType): Boolean = {
+            self.isEmptyArray(element)
         }
     }
 

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/AbstractPointsToBasedAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/AbstractPointsToBasedAnalysis.scala
@@ -50,7 +50,11 @@ trait AbstractPointsToBasedAnalysis extends FPCFAnalysis {
         isEmptyArray:   Boolean        = false
     ): PointsToSet
 
-    protected[this] def getTypeOf(element: ElementType): ReferenceType
+    @inline protected[this] def getTypeOf(element: ElementType): ReferenceType
+
+    @inline protected[this] def getTypeIdOf(element: ElementType): Int
+
+    @inline protected[this] def isEmptyArray(element: ElementType): Boolean
 
     @inline protected[this] def currentPointsTo(
         depender:   DependerType,

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/AllocationSiteBasedAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/AllocationSiteBasedAnalysis.scala
@@ -23,6 +23,7 @@ import org.opalj.br.fpcf.properties.pointsto.NoAllocationSites
 import org.opalj.br.DeclaredMethod
 import org.opalj.br.fpcf.properties.pointsto.AllocationSite
 import org.opalj.br.fpcf.properties.pointsto.allocationSiteLongToTypeId
+import org.opalj.br.fpcf.properties.pointsto.isEmptyArrayAllocationSite
 
 trait AllocationSiteBasedAnalysis extends AbstractPointsToBasedAnalysis {
 
@@ -98,15 +99,23 @@ trait AllocationSiteBasedAnalysis extends AbstractPointsToBasedAnalysis {
         }
     }
 
-    override protected[this] def getTypeOf(element: AllocationSite): ReferenceType = {
+    @inline protected[this] def getTypeOf(element: AllocationSite): ReferenceType = {
         ReferenceType.lookup(allocationSiteLongToTypeId(element))
+    }
+
+    @inline protected[this] def getTypeIdOf(element: AllocationSite): Int = {
+        allocationSiteLongToTypeId(element)
+    }
+
+    @inline protected[this] def isEmptyArray(element: AllocationSite): Boolean = {
+        isEmptyArrayAllocationSite(element)
     }
 
     override protected[this] val pointsToPropertyKey: PropertyKey[AllocationSitePointsToSet] = {
         AllocationSitePointsToSet.key
     }
 
-    override protected[this] def emptyPointsToSet: AllocationSitePointsToSet = {
+    @inline protected[this] def emptyPointsToSet: AllocationSitePointsToSet = {
         NoAllocationSites
     }
 }

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/ConfiguredMethodsPointsToAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/ConfiguredMethodsPointsToAnalysis.scala
@@ -72,7 +72,8 @@ abstract class ConfiguredMethodsPointsToAnalysis private[analyses] (
             // the method is reachable, so we analyze it!
         }
 
-        if (nativeMethodData.contains(dm) && nativeMethodData(dm).nonEmpty)
+        if (nativeMethodData.contains(dm) && nativeMethodData(dm).nonEmpty &&
+            dm.hasSingleDefinedMethod) // FIXME Find way to do this even if no Method object exists
             handleNativeMethod(dm.asDefinedMethod, nativeMethodData(dm).get)
         else
             NoResult

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/PointsToAnalysisBase.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/PointsToAnalysisBase.scala
@@ -23,10 +23,8 @@ import org.opalj.fpcf.SomeEPK
 import org.opalj.fpcf.SomeEPS
 import org.opalj.fpcf.UBP
 import org.opalj.br.ArrayType
-import org.opalj.br.fpcf.properties.pointsto.allocationSiteLongToTypeId
 import org.opalj.br.Field
 import org.opalj.br.ReferenceType
-import org.opalj.br.fpcf.properties.pointsto.isEmptyArrayAllocationSite
 import org.opalj.br.fpcf.properties.pointsto.PointsToSetLike
 import org.opalj.br.DeclaredMethod
 import org.opalj.tac.common.DefinitionSite
@@ -156,7 +154,7 @@ trait PointsToAnalysisBase extends AbstractPointsToBasedAnalysis {
         state.includeSharedPointsToSet(defSiteObject, emptyPointsToSet, PointsToSetLike.noFilter)
         currentPointsToOfDefSites(fakeEntity, arrayDefSites).foreach { pts ⇒
             pts.forNewestNElements(pts.numElements) { as ⇒
-                val typeId = allocationSiteLongToTypeId(as.asInstanceOf[Long])
+                val typeId = getTypeIdOf(as)
                 if (typeId < 0 &&
                     classHierarchy.isSubtypeOf(ArrayType.lookup(typeId), arrayType)) {
                     state.includeSharedPointsToSet(
@@ -213,10 +211,10 @@ trait PointsToAnalysisBase extends AbstractPointsToBasedAnalysis {
         state.addArrayStoreEntity(fakeEntity)
         currentPointsToOfDefSites(fakeEntity, arrayDefSites).foreach { pts ⇒
             pts.forNewestNElements(pts.numElements) { as ⇒
-                val typeId = allocationSiteLongToTypeId(as.asInstanceOf[Long])
+                val typeId = getTypeIdOf(as)
                 if (typeId < 0 &&
                     classHierarchy.isSubtypeOf(ArrayType.lookup(typeId), arrayType) &&
-                    !isEmptyArrayAllocationSite(as.asInstanceOf[Long])) {
+                    !isEmptyArray(as)) {
                     val arrayEntity = ArrayEntity(as)
                     val componentType = ArrayType.lookup(typeId).componentType.asReferenceType
                     val filter = { t: ReferenceType ⇒
@@ -340,10 +338,10 @@ trait PointsToAnalysisBase extends AbstractPointsToBasedAnalysis {
                 val newDependees = updatedDependees(eps, dependees)
                 var results: List[ProperPropertyComputationResult] = List.empty
                 newDependeePointsTo.forNewestNElements(newDependeePointsTo.numElements - getNumElements(dependees(eps.toEPK)._1)) { as ⇒
-                    val typeId = allocationSiteLongToTypeId(as.asInstanceOf[Long])
+                    val typeId = getTypeIdOf(as)
                     if (typeId < 0 &&
                         classHierarchy.isSubtypeOf(ArrayType.lookup(typeId), arrayType) &&
-                        !isEmptyArrayAllocationSite(as.asInstanceOf[Long])) {
+                        !isEmptyArray(as)) {
                         val componentType = ArrayType.lookup(typeId).componentType.asReferenceType
                         val typeFilter = { t: ReferenceType ⇒
                             classHierarchy.isSubtypeOf(t, componentType)
@@ -426,7 +424,7 @@ trait PointsToAnalysisBase extends AbstractPointsToBasedAnalysis {
                 var nextDependees: List[SomeEOptionP] = Nil
                 var newPointsTo = emptyPointsToSet
                 newDependeePointsTo.forNewestNElements(newDependeePointsTo.numElements - getNumElements(dependees(eps.toEPK)._1)) { as ⇒
-                    val typeId = allocationSiteLongToTypeId(as.asInstanceOf[Long])
+                    val typeId = getTypeIdOf(as)
                     if (typeId < 0 && classHierarchy.isSubtypeOf(ArrayType.lookup(typeId), arrayType)) {
                         val arrayEntries = ps(ArrayEntity(as), pointsToPropertyKey)
                         newPointsTo = newPointsTo.included(pointsToUB(arrayEntries), filter)

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/TamiFlexPointsToAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/TamiFlexPointsToAnalysis.scala
@@ -67,7 +67,7 @@ abstract class AllocationSiteBasedTamiFlexPointsToAnalysis private[analyses] (
             self.createPointsToSet(pc, declaredMethod, allocatedType, isConstant, isEmptyArray)
         }
 
-        override protected[this] def currentPointsTo(
+        @inline override protected[this] def currentPointsTo(
             depender:   DependerType,
             dependee:   Entity,
             typeFilter: ReferenceType ⇒ Boolean
@@ -75,8 +75,16 @@ abstract class AllocationSiteBasedTamiFlexPointsToAnalysis private[analyses] (
             self.currentPointsTo(depender, dependee, typeFilter)
         }
 
-        override protected[this] def getTypeOf(element: ElementType): ReferenceType = {
+        @inline override protected[this] def getTypeOf(element: ElementType): ReferenceType = {
             self.getTypeOf(element)
+        }
+
+        @inline override protected[this] def getTypeIdOf(element: ElementType): Int = {
+            self.getTypeIdOf(element)
+        }
+
+        @inline override protected[this] def isEmptyArray(element: ElementType): Boolean = {
+            self.isEmptyArray(element)
         }
     }
 

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/TypeBasedAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/TypeBasedAnalysis.scala
@@ -36,5 +36,9 @@ trait TypeBasedAnalysis extends AbstractPointsToBasedAnalysis {
         isEmptyArray:   Boolean        = false
     ): TypeBasedPointsToSet = TypeBasedPointsToSet(UIDSet(allocatedType))
 
-    override protected[this] def getTypeOf(element: ReferenceType): ReferenceType = element
+    @inline protected[this] def getTypeOf(element: ReferenceType): ReferenceType = element
+
+    @inline protected[this] def getTypeIdOf(element: ReferenceType): Int = element.id
+
+    @inline protected[this] def isEmptyArray(element: ReferenceType): Boolean = false
 }

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/UnsafePointsToAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/UnsafePointsToAnalysis.scala
@@ -69,7 +69,7 @@ abstract class UnsafePointsToAnalysis private[pointsto] ( final val project: Som
             self.createPointsToSet(pc, declaredMethod, allocatedType, isConstant, isEmptyArray)
         }
 
-        override protected[this] def currentPointsTo(
+        @inline override protected[this] def currentPointsTo(
             depender:   DependerType,
             dependee:   Entity,
             typeFilter: ReferenceType ⇒ Boolean
@@ -77,8 +77,16 @@ abstract class UnsafePointsToAnalysis private[pointsto] ( final val project: Som
             self.currentPointsTo(depender, dependee, typeFilter)
         }
 
-        override protected[this] def getTypeOf(element: ElementType): ReferenceType = {
+        @inline override protected[this] def getTypeOf(element: ElementType): ReferenceType = {
             self.getTypeOf(element)
+        }
+
+        @inline override protected[this] def getTypeIdOf(element: ElementType): Int = {
+            self.getTypeIdOf(element)
+        }
+
+        @inline override protected[this] def isEmptyArray(element: ElementType): Boolean = {
+            self.isEmptyArray(element)
         }
     }
 


### PR DESCRIPTION
Fixed two bugs in the call graphs:
1. Don't assume points-to elements are Longs, they are only for allocation sites based analysis, not for type based analysis
2. We can't yet handle configured points-to sets for native methods if there is not Method object to associate them with