### PR TITLE
Unify Call Graphs

### DIFF
--- a/OPAL/tac/src/main/scala/org/opalj/tac/cg/AllocationSiteBasedPointsToCallGraphKey.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/cg/AllocationSiteBasedPointsToCallGraphKey.scala
@@ -9,8 +9,8 @@ import org.opalj.br.analyses.VirtualFormalParametersKey
 import org.opalj.br.fpcf.FPCFAnalysisScheduler
 import org.opalj.tac.common.DefinitionSitesKey
 import org.opalj.tac.fpcf.analyses.cg.pointsto.AllocationSiteBasedPointsToBasedCallGraphAnalysisScheduler
-import org.opalj.tac.fpcf.analyses.cg.DoPrivilegedPointsToCGAnalysisScheduler
 import org.opalj.tac.fpcf.analyses.cg.pointsto.AllocationSiteBasedPointsToBasedThreadRelatedCallsAnalysisScheduler
+import org.opalj.tac.fpcf.analyses.cg.AllocationSiteBasedDoPrivilegedPointsToCGAnalysisScheduler
 import org.opalj.tac.fpcf.analyses.pointsto.AllocationSiteBasedArraycopyPointsToAnalysisScheduler
 import org.opalj.tac.fpcf.analyses.pointsto.AllocationSiteBasedConfiguredMethodsPointsToAnalysisScheduler
 import org.opalj.tac.fpcf.analyses.pointsto.AllocationSiteBasedPointsToAnalysisScheduler
@@ -40,8 +40,8 @@ object AllocationSiteBasedPointsToCallGraphKey extends AbstractCallGraphKey {
             AllocationSiteBasedPointsToBasedCallGraphAnalysisScheduler, // TODO make this one independent
             AllocationSiteBasedPointsToAnalysisScheduler,
             AllocationSiteBasedConfiguredMethodsPointsToAnalysisScheduler,
+            AllocationSiteBasedDoPrivilegedPointsToCGAnalysisScheduler,
             AllocationSiteBasedTamiFlexPointsToAnalysisScheduler,
-            DoPrivilegedPointsToCGAnalysisScheduler,
             AllocationSiteBasedArraycopyPointsToAnalysisScheduler,
             AllocationSiteBasedUnsafePointsToAnalysisScheduler,
             AllocationSiteBasedPointsToBasedThreadRelatedCallsAnalysisScheduler

--- a/OPAL/tac/src/main/scala/org/opalj/tac/cg/TypeBasedPointsToCallGraphKey.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/cg/TypeBasedPointsToCallGraphKey.scala
@@ -6,9 +6,13 @@ package cg
 import org.opalj.br.analyses.SomeProject
 import org.opalj.br.fpcf.FPCFAnalysisScheduler
 import org.opalj.tac.fpcf.analyses.cg.pointsto.TypeBasedPointsToBasedCallGraphAnalysisScheduler
-import org.opalj.tac.fpcf.analyses.cg.DoPrivilegedPointsToCGAnalysisScheduler
+import org.opalj.tac.fpcf.analyses.cg.TypeBasedDoPrivilegedPointsToCGAnalysisScheduler
+import org.opalj.tac.fpcf.analyses.cg.pointsto.TypeBasedPointsToBasedThreadRelatedCallsAnalysisScheduler
+import org.opalj.tac.fpcf.analyses.pointsto.TypeBasedArraycopyPointsToAnalysisScheduler
 import org.opalj.tac.fpcf.analyses.pointsto.TypeBasedPointsToAnalysisScheduler
 import org.opalj.tac.fpcf.analyses.pointsto.TypeBasedConfiguredMethodsPointsToAnalysisScheduler
+import org.opalj.tac.fpcf.analyses.pointsto.TypeBasedTamiFlexPointsToAnalysisScheduler
+import org.opalj.tac.fpcf.analyses.pointsto.TypeBasedUnsafePointsToAnalysisScheduler
 
 /**
  * A [[org.opalj.br.analyses.ProjectInformationKey]] to compute a [[CallGraph]] based on
@@ -26,7 +30,11 @@ object TypeBasedPointsToCallGraphKey extends AbstractCallGraphKey {
             TypeBasedPointsToBasedCallGraphAnalysisScheduler,
             TypeBasedPointsToAnalysisScheduler,
             TypeBasedConfiguredMethodsPointsToAnalysisScheduler,
-            DoPrivilegedPointsToCGAnalysisScheduler
+            TypeBasedDoPrivilegedPointsToCGAnalysisScheduler,
+            TypeBasedTamiFlexPointsToAnalysisScheduler,
+            TypeBasedArraycopyPointsToAnalysisScheduler,
+            TypeBasedUnsafePointsToAnalysisScheduler,
+            TypeBasedPointsToBasedThreadRelatedCallsAnalysisScheduler
         )
     }
 

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/CHACallGraphAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/CHACallGraphAnalysis.scala
@@ -5,6 +5,7 @@ package fpcf
 package analyses
 package cg
 
+import org.opalj.collection.immutable.IntTrieSet
 import org.opalj.fpcf.EOptionP
 import org.opalj.fpcf.EPS
 import org.opalj.br.Method
@@ -32,6 +33,7 @@ class CHACallGraphAnalysis private[analyses] (
         final val project: SomeProject
 ) extends AbstractCallGraphAnalysis {
     override type State = CHAState
+    override type LocalTypeInformation = Null
 
     override def createInitialState(
         definedMethod: DefinedMethod, tacEP: EPS[Method, TACAI]
@@ -40,19 +42,22 @@ class CHACallGraphAnalysis private[analyses] (
     }
 
     @inline override protected[this] def canResolveCall(
-        implicit
-        state: CHAState
+        localTypeInformation: LocalTypeInformation,
+        state:                CHAState
     ): ObjectType ⇒ Boolean = {
         _ ⇒ true
     }
 
     @inline protected[this] def handleUnresolvedCall(
-        possibleTgtType: ObjectType,
-        call:            Call[V] with VirtualCall[V],
-        pc:              Int
+        unresolvedTypes: IntTrieSet,
+        callSite:        CallSite
     )(implicit state: CHAState): Unit = {
         throw new UnsupportedOperationException()
     }
+
+    @inline protected[this] def getLocalTypeInformation(
+        callSite: CallSite, call: Call[V] with VirtualCall[V]
+    )(implicit state: CHAState): LocalTypeInformation = null
 }
 
 object CHACallGraphAnalysisScheduler extends CallGraphAnalysisScheduler {

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/CallSite.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/CallSite.scala
@@ -1,0 +1,13 @@
+/* BSD 2-Clause License - see OPAL/LICENSE for details. */
+package org.opalj
+package tac
+package fpcf
+package analyses
+package cg
+
+import org.opalj.br.MethodDescriptor
+import org.opalj.br.ReferenceType
+
+case class CallSite(
+        pc: Int, methodName: String, methodDescriptor: MethodDescriptor, receiver: ReferenceType
+)

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/DoPrivilegedPointsToCGAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/DoPrivilegedPointsToCGAnalysis.scala
@@ -15,6 +15,7 @@ import org.opalj.fpcf.ProperPropertyComputationResult
 import org.opalj.fpcf.PropertyBounds
 import org.opalj.fpcf.PropertyComputationResult
 import org.opalj.fpcf.PropertyKey
+import org.opalj.fpcf.PropertyMetaInformation
 import org.opalj.fpcf.PropertyStore
 import org.opalj.fpcf.Results
 import org.opalj.fpcf.SomeEPS
@@ -33,10 +34,13 @@ import org.opalj.br.analyses.ProjectInformationKeys
 import org.opalj.br.analyses.VirtualFormalParametersKey
 import org.opalj.br.DefinedMethod
 import org.opalj.br.fpcf.properties.pointsto.PointsToSetLike
+import org.opalj.br.fpcf.properties.pointsto.TypeBasedPointsToSet
+import org.opalj.br.fpcf.FPCFAnalysisScheduler
 import org.opalj.tac.common.DefinitionSitesKey
 import org.opalj.tac.fpcf.analyses.cg.pointsto.PointsToBasedCGState
 import org.opalj.tac.fpcf.analyses.pointsto.AbstractPointsToBasedAnalysis
 import org.opalj.tac.fpcf.analyses.pointsto.AllocationSiteBasedAnalysis
+import org.opalj.tac.fpcf.analyses.pointsto.TypeBasedAnalysis
 import org.opalj.tac.fpcf.properties.TheTACAI
 
 /**
@@ -59,7 +63,7 @@ import org.opalj.tac.fpcf.properties.TheTACAI
  *
  * @author Florian Kuebler
  */
-abstract class AbstractDoPrivilegedPointsToCGAnalysis private[cg] (
+abstract class AbstractDoPrivilegedMethodPointsToCGAnalysis private[cg] (
         final val doPrivilegedMethod: DeclaredMethod,
         final val declaredRunMethod:  DeclaredMethod,
         final val project:            SomeProject
@@ -148,9 +152,9 @@ abstract class AbstractDoPrivilegedPointsToCGAnalysis private[cg] (
     override val apiMethod: DeclaredMethod = doPrivilegedMethod
 }
 
-class DoPrivilegedPointsToCGAnalysis private[cg] (
+abstract class DoPrivilegedPointsToCGAnalysis private[cg] (
         final val project: SomeProject
-) extends AllocationSiteBasedAnalysis { self ⇒
+) extends AbstractPointsToBasedAnalysis { self ⇒
 
     @inline override protected[this] def currentPointsTo(
         depender:   DependerType,
@@ -221,7 +225,7 @@ class DoPrivilegedPointsToCGAnalysis private[cg] (
     }
 
     def analyze(p: SomeProject): PropertyComputationResult = {
-        var analyses: List[AbstractDoPrivilegedPointsToCGAnalysis] = Nil
+        var analyses: List[AbstractDoPrivilegedMethodPointsToCGAnalysis] = Nil
 
         val accessControllerType = ObjectType("java/security/AccessController")
         val privilegedActionType = ObjectType("java/security/PrivilegedAction")
@@ -247,7 +251,7 @@ class DoPrivilegedPointsToCGAnalysis private[cg] (
             MethodDescriptor(privilegedActionType, ObjectType.Object)
         )
         if (doPrivileged1.hasSingleDefinedMethod)
-            analyses ::= new AbstractDoPrivilegedPointsToCGAnalysis(doPrivileged1, runMethod, p) with PointsToBase
+            analyses ::= new AbstractDoPrivilegedMethodPointsToCGAnalysis(doPrivileged1, runMethod, p) with PointsToBase
 
         val doPrivileged2 = declaredMethods(
             accessControllerType,
@@ -260,7 +264,7 @@ class DoPrivilegedPointsToCGAnalysis private[cg] (
             )
         )
         if (doPrivileged2.hasSingleDefinedMethod)
-            analyses ::= new AbstractDoPrivilegedPointsToCGAnalysis(doPrivileged2, runMethod, p) with PointsToBase
+            analyses ::= new AbstractDoPrivilegedMethodPointsToCGAnalysis(doPrivileged2, runMethod, p) with PointsToBase
 
         val doPrivileged3 = declaredMethods(
             accessControllerType,
@@ -273,7 +277,7 @@ class DoPrivilegedPointsToCGAnalysis private[cg] (
             )
         )
         if (doPrivileged3.hasSingleDefinedMethod)
-            analyses ::= new AbstractDoPrivilegedPointsToCGAnalysis(doPrivileged3, runMethod, p) with PointsToBase
+            analyses ::= new AbstractDoPrivilegedMethodPointsToCGAnalysis(doPrivileged3, runMethod, p) with PointsToBase
 
         val doPrivileged4 = declaredMethods(
             accessControllerType,
@@ -283,7 +287,7 @@ class DoPrivilegedPointsToCGAnalysis private[cg] (
             MethodDescriptor(privilegedExceptionActionType, ObjectType.Object)
         )
         if (doPrivileged4.hasSingleDefinedMethod)
-            analyses ::= new AbstractDoPrivilegedPointsToCGAnalysis(doPrivileged4, runMethod, p) with PointsToBase
+            analyses ::= new AbstractDoPrivilegedMethodPointsToCGAnalysis(doPrivileged4, runMethod, p) with PointsToBase
 
         val doPrivileged5 = declaredMethods(
             accessControllerType,
@@ -296,7 +300,7 @@ class DoPrivilegedPointsToCGAnalysis private[cg] (
             )
         )
         if (doPrivileged5.hasSingleDefinedMethod)
-            analyses ::= new AbstractDoPrivilegedPointsToCGAnalysis(doPrivileged5, runMethod, p) with PointsToBase
+            analyses ::= new AbstractDoPrivilegedMethodPointsToCGAnalysis(doPrivileged5, runMethod, p) with PointsToBase
 
         val doPrivileged6 = declaredMethods(
             accessControllerType,
@@ -309,7 +313,7 @@ class DoPrivilegedPointsToCGAnalysis private[cg] (
             )
         )
         if (doPrivileged6.hasSingleDefinedMethod)
-            analyses ::= new AbstractDoPrivilegedPointsToCGAnalysis(doPrivileged6, runMethod, p) with PointsToBase
+            analyses ::= new AbstractDoPrivilegedMethodPointsToCGAnalysis(doPrivileged6, runMethod, p) with PointsToBase
 
         val doPrivilegedWithCombiner1 = declaredMethods(
             accessControllerType,
@@ -319,7 +323,7 @@ class DoPrivilegedPointsToCGAnalysis private[cg] (
             MethodDescriptor(privilegedActionType, ObjectType.Object)
         )
         if (doPrivilegedWithCombiner1.hasSingleDefinedMethod)
-            analyses ::= new AbstractDoPrivilegedPointsToCGAnalysis(doPrivilegedWithCombiner1, runMethod, p) with PointsToBase
+            analyses ::= new AbstractDoPrivilegedMethodPointsToCGAnalysis(doPrivilegedWithCombiner1, runMethod, p) with PointsToBase
 
         val doPrivilegedWithCombiner2 = declaredMethods(
             accessControllerType,
@@ -332,7 +336,7 @@ class DoPrivilegedPointsToCGAnalysis private[cg] (
             )
         )
         if (doPrivilegedWithCombiner2.hasSingleDefinedMethod)
-            analyses ::= new AbstractDoPrivilegedPointsToCGAnalysis(doPrivilegedWithCombiner2, runMethod, p) with PointsToBase
+            analyses ::= new AbstractDoPrivilegedMethodPointsToCGAnalysis(doPrivilegedWithCombiner2, runMethod, p) with PointsToBase
 
         val doPrivilegedWithCombiner3 = declaredMethods(
             accessControllerType,
@@ -345,7 +349,7 @@ class DoPrivilegedPointsToCGAnalysis private[cg] (
             )
         )
         if (doPrivilegedWithCombiner3.hasSingleDefinedMethod)
-            analyses ::= new AbstractDoPrivilegedPointsToCGAnalysis(doPrivilegedWithCombiner3, runMethod, p) with PointsToBase
+            analyses ::= new AbstractDoPrivilegedMethodPointsToCGAnalysis(doPrivilegedWithCombiner3, runMethod, p) with PointsToBase
 
         val doPrivilegedWithCombiner4 = declaredMethods(
             accessControllerType,
@@ -358,30 +362,52 @@ class DoPrivilegedPointsToCGAnalysis private[cg] (
             )
         )
         if (doPrivilegedWithCombiner4.hasSingleDefinedMethod)
-            analyses ::= new AbstractDoPrivilegedPointsToCGAnalysis(doPrivilegedWithCombiner4, runMethod, p) with PointsToBase
+            analyses ::= new AbstractDoPrivilegedMethodPointsToCGAnalysis(doPrivilegedWithCombiner4, runMethod, p) with PointsToBase
 
         Results(analyses.iterator.map(_.registerAPIMethod())) //analyze()))
     }
 }
 
-object DoPrivilegedPointsToCGAnalysisScheduler extends BasicFPCFEagerAnalysisScheduler {
+trait DoPrivilegedPointsToCGAnalysisScheduler extends FPCFAnalysisScheduler {
+
+    def pointsToSet: PropertyMetaInformation
 
     override def requiredProjectInformation: ProjectInformationKeys =
         Seq(DeclaredMethodsKey, VirtualFormalParametersKey, DefinitionSitesKey)
 
-    override def uses: Set[PropertyBounds] = Set(PropertyBounds.ub(AllocationSitePointsToSet))
+    override def uses: Set[PropertyBounds] = Set(PropertyBounds.ub(pointsToSet))
 
     override def derivesCollaboratively: Set[PropertyBounds] =
-        PropertyBounds.ubs(AllocationSitePointsToSet, Callers, Callees)
+        PropertyBounds.ubs(pointsToSet, Callers, Callees)
 
     override def derivesEagerly: Set[PropertyBounds] = Set.empty
+
+}
+
+object TypeBasedDoPrivilegedPointsToCGAnalysisScheduler
+    extends DoPrivilegedPointsToCGAnalysisScheduler with BasicFPCFEagerAnalysisScheduler {
+
+    val pointsToSet = TypeBasedPointsToSet
 
     override def start(
         p: SomeProject, ps: PropertyStore, unused: Null
     ): DoPrivilegedPointsToCGAnalysis = {
-        val analysis = new DoPrivilegedPointsToCGAnalysis(p)
+        val analysis = new DoPrivilegedPointsToCGAnalysis(p) with TypeBasedAnalysis
         ps.scheduleEagerComputationForEntity(p)(analysis.analyze)
         analysis
     }
 }
 
+object AllocationSiteBasedDoPrivilegedPointsToCGAnalysisScheduler
+    extends DoPrivilegedPointsToCGAnalysisScheduler with BasicFPCFEagerAnalysisScheduler {
+
+    val pointsToSet = AllocationSitePointsToSet
+
+    override def start(
+        p: SomeProject, ps: PropertyStore, unused: Null
+    ): DoPrivilegedPointsToCGAnalysis = {
+        val analysis = new DoPrivilegedPointsToCGAnalysis(p) with AllocationSiteBasedAnalysis
+        ps.scheduleEagerComputationForEntity(p)(analysis.analyze)
+        analysis
+    }
+}

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/package.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/package.scala
@@ -17,12 +17,6 @@ import org.opalj.ai.MethodExternalExceptionsOriginOffset
 import org.opalj.ai.ImmediateVMExceptionsOriginOffset
 import org.opalj.ai.isMethodExternalExceptionOrigin
 import org.opalj.ai.isImmediateVMException
-import org.opalj.br.MethodDescriptor
-import org.opalj.br.ReferenceType
-
-case class CallSite(
-        pc: Int, methodName: String, methodDescriptor: MethodDescriptor, receiver: ReferenceType
-)
 
 package object cg {
 

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/pointsto/PointsToBasedCGState.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/pointsto/PointsToBasedCGState.scala
@@ -112,14 +112,14 @@ class PointsToBasedCGState[PointsToSet <: PointsToSetLike[_, _, PointsToSet]](
     }
 
     final def removeTypeForCallSite(callSite: CallSite, instantiatedType: ObjectType): Unit = {
-        if (!_virtualCallSites.contains(callSite))
-            assert(_virtualCallSites(callSite).contains(instantiatedType.id))
-        val typesLeft = _virtualCallSites(callSite) - instantiatedType.id
-        if (typesLeft.isEmpty) {
-            _virtualCallSites -= callSite
-            removePointsToDepender(callSite)
-        } else {
-            _virtualCallSites(callSite) = typesLeft
+        if (_virtualCallSites.contains(callSite)) {
+            val typesLeft = _virtualCallSites(callSite) - instantiatedType.id
+            if (typesLeft.isEmpty) {
+                _virtualCallSites -= callSite
+                removePointsToDepender(callSite)
+            } else {
+                _virtualCallSites(callSite) = typesLeft
+            }
         }
     }
 

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/pointsto/PointsToBasedCGState.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/pointsto/PointsToBasedCGState.scala
@@ -176,7 +176,7 @@ class PointsToBasedCGState[PointsToSet <: PointsToSetLike[_, _, PointsToSet]](
     private[this] val _virtualCallSites: mutable.Map[CallSite, IntTrieSet] = mutable.Map.empty
 
     def typesForCallSite(callSite: CallSite): IntTrieSet = {
-        _virtualCallSites(callSite)
+        _virtualCallSites.getOrElse(callSite, IntTrieSet.empty)
     }
 
     def addPotentialTypesOfCallSite(

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/pointsto/PointsToBasedThreadRelatedCallsAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/pointsto/PointsToBasedThreadRelatedCallsAnalysis.scala
@@ -487,7 +487,7 @@ trait PointsToBasedThreadRelatedCallsAnalysisScheduler extends BasicFPCFEagerAna
 }
 
 object TypeBasedPointsToBasedThreadRelatedCallsAnalysisScheduler
-        extends PointsToBasedThreadRelatedCallsAnalysisScheduler {
+    extends PointsToBasedThreadRelatedCallsAnalysisScheduler {
 
     override val propertyKind: PropertyMetaInformation = TypeBasedPointsToSet
 
@@ -499,7 +499,7 @@ object TypeBasedPointsToBasedThreadRelatedCallsAnalysisScheduler
 }
 
 object AllocationSiteBasedPointsToBasedThreadRelatedCallsAnalysisScheduler
-        extends PointsToBasedThreadRelatedCallsAnalysisScheduler {
+    extends PointsToBasedThreadRelatedCallsAnalysisScheduler {
 
     override val propertyKind: PropertyMetaInformation = AllocationSitePointsToSet
 

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/rta/RTAState.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/rta/RTAState.scala
@@ -73,12 +73,12 @@ class RTAState(
 
     override def hasNonFinalCallSite: Boolean = _virtualCallSites.nonEmpty
 
-    def addVirtualCallSite(objectType: ObjectType, callSite: CallSite): Unit = {
-        val oldValOpt = _virtualCallSites.get(objectType.id.toLong)
+    def addVirtualCallSite(typeId: Long, callSite: CallSite): Unit = {
+        val oldValOpt = _virtualCallSites.get(typeId)
         if (oldValOpt.isDefined)
             oldValOpt.get += callSite
         else {
-            _virtualCallSites += (objectType.id.toLong → mutable.Set(callSite))
+            _virtualCallSites += (typeId → mutable.Set(callSite))
         }
     }
 

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/xta/PropagationBasedCGState.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/xta/PropagationBasedCGState.scala
@@ -57,9 +57,7 @@ class PropagationBasedCGState(
             UIDSet.empty
     }
 
-    def instantiatedTypesContains(tpe: ReferenceType): Boolean = {
-        _instantiatedTypesDependeeMap.keys.exists(instantiatedTypes(_).contains(tpe))
-    }
+    def typeSetEntities(): Iterable[TypeSetEntity] = _instantiatedTypesDependeeMap.keys
 
     def newInstantiatedTypes(typeSetEntity: TypeSetEntity, seenTypes: Int): TraversableOnce[ReferenceType] = {
         val typeDependee = _instantiatedTypesDependeeMap(typeSetEntity)
@@ -78,12 +76,12 @@ class PropagationBasedCGState(
 
     override def hasNonFinalCallSite: Boolean = _virtualCallSites.nonEmpty
 
-    def addVirtualCallSite(objectType: ObjectType, callSite: CallSite): Unit = {
-        val oldValOpt = _virtualCallSites.get(objectType.id.toLong)
+    def addVirtualCallSite(typeId: Long, callSite: CallSite): Unit = {
+        val oldValOpt = _virtualCallSites.get(typeId)
         if (oldValOpt.isDefined)
             oldValOpt.get += callSite
         else {
-            _virtualCallSites += (objectType.id.toLong → mutable.Set(callSite))
+            _virtualCallSites += (typeId → mutable.Set(callSite))
         }
     }
 

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/AbstractPointsToBasedAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/AbstractPointsToBasedAnalysis.scala
@@ -78,7 +78,7 @@ trait AbstractPointsToBasedAnalysis extends FPCFAnalysis {
         if (ai.isImmediateVMException(dependeeDefSite)) {
             // FIXME -  we need to get the actual exception type here
             createPointsToSet(
-                ai.pcOfImmediateVMException(dependeeDefSite),
+                state.tac.stmts(ai.pcOfImmediateVMException(dependeeDefSite)).pc,
                 state.method,
                 ObjectType.Throwable,
                 isConstant = false

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/ArraycopyPointsToAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/ArraycopyPointsToAnalysis.scala
@@ -111,13 +111,13 @@ trait ArraycopyPointsToAnalysisScheduler extends BasicFPCFEagerAnalysisScheduler
 }
 
 object TypeBasedArraycopyPointsToAnalysisScheduler extends ArraycopyPointsToAnalysisScheduler {
-    override val propertyKind = TypeBasedPointsToSet
+    override val propertyKind: PropertyMetaInformation = TypeBasedPointsToSet
     override val createAnalysis: SomeProject ⇒ ArraycopyPointsToAnalysis =
         new ArraycopyPointsToAnalysis(_) with TypeBasedAnalysis
 }
 
 object AllocationSiteBasedArraycopyPointsToAnalysisScheduler extends ArraycopyPointsToAnalysisScheduler {
-    override val propertyKind = AllocationSitePointsToSet
+    override val propertyKind: PropertyMetaInformation = AllocationSitePointsToSet
     override val createAnalysis: SomeProject ⇒ ArraycopyPointsToAnalysis =
         new ArraycopyPointsToAnalysis(_) with AllocationSiteBasedAnalysis
 }

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/UnsafePointsToAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/UnsafePointsToAnalysis.scala
@@ -33,6 +33,7 @@ import org.opalj.br.BooleanType
 import org.opalj.br.IntegerType
 import org.opalj.br.ReferenceType
 import org.opalj.br.VoidType
+import org.opalj.br.analyses.DeclaredMethods
 import org.opalj.tac.common.DefinitionSitesKey
 import org.opalj.tac.fpcf.analyses.cg.V
 import org.opalj.tac.fpcf.properties.TheTACAI
@@ -46,7 +47,7 @@ abstract class UnsafePointsToAnalysis private[pointsto] ( final val project: Som
     extends PointsToAnalysisBase { self ⇒
 
     private[this] val UnsafeT = ObjectType("sun/misc/Unsafe")
-    val declaredMethods = project.get(DeclaredMethodsKey)
+    val declaredMethods: DeclaredMethods = project.get(DeclaredMethodsKey)
 
     trait PointsToBase extends AbstractPointsToBasedAnalysis {
         override protected[this] type ElementType = self.ElementType
@@ -247,14 +248,14 @@ trait UnsafePointsToAnalysisScheduler extends BasicFPCFEagerAnalysisScheduler {
 }
 
 object TypeBasedUnsafePointsToAnalysisScheduler extends UnsafePointsToAnalysisScheduler {
-    override val propertyKind = TypeBasedPointsToSet
+    override val propertyKind: PropertyMetaInformation = TypeBasedPointsToSet
     override val createAnalysis: SomeProject ⇒ UnsafePointsToAnalysis =
         new UnsafePointsToAnalysis(_) with TypeBasedAnalysis
 }
 
 object AllocationSiteBasedUnsafePointsToAnalysisScheduler
     extends UnsafePointsToAnalysisScheduler {
-    override val propertyKind = AllocationSitePointsToSet
+    override val propertyKind: PropertyMetaInformation = AllocationSitePointsToSet
     override val createAnalysis: SomeProject ⇒ UnsafePointsToAnalysis =
         new UnsafePointsToAnalysis(_) with AllocationSiteBasedAnalysis
 }


### PR DESCRIPTION
Fixed a few inconsistencies between call graphs & points-to modules, simplifying some of the implementation.

Depends on #33 which should be merged first.