### PR TITLE
Remove obsolete JVM option AggressiveOpts

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -75,8 +75,7 @@ javaOptions in ThisBuild ++= Seq(
   "-Xnoclassgc",
   "-XX:NewRatio=1",
   "-XX:SurvivorRatio=8",
-  "-XX:+UseParallelGC",
-  "-XX:+AggressiveOpts"
+  "-XX:+UseParallelGC"
 )
 
 addCommandAlias(


### PR DESCRIPTION
AggressiveOpts has been removed from recent JVM versions. It has not done anything particularly useful for the versions where it still existed either.