### PR TITLE
Fix the DA transformation of the NestMembers attribute

### DIFF
--- a/OPAL/ba/src/main/scala/org/opalj/ba/package.scala
+++ b/OPAL/ba/src/main/scala/org/opalj/ba/package.scala
@@ -1113,7 +1113,7 @@ package object ba { ba ⇒
                 val br.NestMembers(classes /*:IndexedSeq[ObjectType]*/ ) = attribute
                 val attributeNameIndex = CPEUtf8(bi.NestMembersAttribute.Name)
                 val classIndices = classes.map(CPEClass(_, false))
-                Some(da.ModulePackages_attribute(attributeNameIndex, classIndices))
+                Some(da.NestMembers_attribute(attributeNameIndex, classIndices))
 
             case br.Record.KindId ⇒
                 val br.Record(components) = attribute


### PR DESCRIPTION
Fix a copy&paste error on the toDA transformation of the NestMembers attribute