### PR TITLE
Improved documentation for Java Frameworks with Rewriting support

### DIFF
--- a/OPAL/br/src/main/scala/org/opalj/br/reader/Java11FrameworkWithDynamicRewritingAndCaching.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/reader/Java11FrameworkWithDynamicRewritingAndCaching.scala
@@ -4,9 +4,11 @@ package br
 package reader
 
 /**
- * This configuration can be used to read in Java 11 (version 55) class files. All
- * standard information (as defined in the Java Virtual Machine Specification)
- * is represented. Instructions will be cached.
+ * This configuration can be used to read in Java 11 (version 55) class files with full
+ * support for rewriting `invokedynamic` instructions created by the JDK compiler for
+ * lambda and method reference expressions as well as opportunistic support for rewriting dynamic
+ * constants. All standard information (as defined in the Java Virtual Machine Specification) is
+ * represented. Instructions will be cached.
  *
  * @author Dominik Helm
  */

--- a/OPAL/br/src/main/scala/org/opalj/br/reader/Java16FrameworkWithDynamicRewritingAndCaching.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/reader/Java16FrameworkWithDynamicRewritingAndCaching.scala
@@ -4,9 +4,11 @@ package br
 package reader
 
 /**
- * This configuration can be used to read in Java 16 (version 60) class files. All
- * standard information (as defined in the Java Virtual Machine Specification)
- * is represented. Instructions will be cached.
+ * This configuration can be used to read in Java 16 (version 60) class files with full
+ * support for rewriting `invokedynamic` instructions created by the JDK compiler for
+ * lambda and method reference expressions as well as opportunistic support for rewriting dynamic
+ * constants. All standard information (as defined in the Java Virtual Machine Specification) is
+ * represented. Instructions will be cached.
  *
  * @author Dominik Helm
  */

--- a/OPAL/br/src/main/scala/org/opalj/br/reader/Java17FrameworkWithDynamicRewritingAndCaching.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/reader/Java17FrameworkWithDynamicRewritingAndCaching.scala
@@ -1,10 +1,14 @@
 /* BSD 2-Clause License - see OPAL/LICENSE for details. */
-package org.opalj.br.reader
+package org.opalj
+package br
+package reader
 
 /**
- * This configuration can be used to read in Java 17 (version 61) class files. All
- * standard information (as defined in the Java Virtual Machine Specification)
- * is represented. Instructions will be cached.
+ * This configuration can be used to read in Java 17 (version 61) class files with full
+ * support for rewriting `invokedynamic` instructions created by the JDK compiler for
+ * lambda and method reference expressions as well as opportunistic support for rewriting dynamic
+ * constants. All standard information (as defined in the Java Virtual Machine Specification) is
+ * represented. Instructions will be cached.
  *
  * @author Julius Naeumann
  */

--- a/OPAL/br/src/main/scala/org/opalj/br/reader/Java9FrameworkWithInvokedynamicSupportAndCaching.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/reader/Java9FrameworkWithInvokedynamicSupportAndCaching.scala
@@ -4,9 +4,10 @@ package br
 package reader
 
 /**
- * This configuration can be used to read in Java 9 (version 53) class files. All
- * standard information (as defined in the Java Virtual Machine Specification)
- * is represented. Instructions will be cached.
+ * This configuration can be used to read in Java 9 (version 53) class files with full
+ * support for rewriting `invokedynamic` instructions created by the JDK compiler for
+ * lambda and method reference expressions. All standard information (as defined in the
+ * Java Virtual Machine Specification) is represented. Instructions will be cached.
  *
  * @author Michael Eichberg
  */


### PR DESCRIPTION
Fixes and older copy&paste mistake that lost some documentation and also adds a mention of the recent support for rewriting dynamic constants.