### PR TITLE
Call graph fixes

### DIFF
--- a/OPAL/ai/src/main/scala/org/opalj/ai/common/DomainRegistry.scala
+++ b/OPAL/ai/src/main/scala/org/opalj/ai/common/DomainRegistry.scala
@@ -260,7 +260,7 @@ object DomainRegistry {
     register(
         "computations related to reference types track nullness, must alias and origin information; records the ai-time def-use information",
         classOf[domain.l1.DefaultReferenceValuesDomainWithCFGAndDefUse[_]],
-        lessPreciseDomains = Set(classOf[domain.l0.BaseDomain[_]]),
+        lessPreciseDomains = Set(classOf[domain.l0.PrimitiveTACAIDomain]),
         (project: SomeProject, method: Method) ⇒ {
             new domain.l1.DefaultReferenceValuesDomainWithCFGAndDefUse(project, method)
         }

--- a/OPAL/tac/src/main/resources/reference.conf
+++ b/OPAL/tac/src/main/resources/reference.conf
@@ -604,6 +604,26 @@ org.opalj {
             ]
           },
           {
+            cf = "java/lang/Class",
+            name = "cast",
+            desc = "(Ljava/lang/Object;)Ljava/lang/Object;"
+            pointsTo = [
+              {
+                lhs = {
+                  cf = "java/lang/Class",
+                  name = "cast",
+                  desc = "(Ljava/lang/Object;)Ljava/lang/Object;"
+                },
+                rhs = {
+                  cf = "java/lang/Class",
+                  name = "cast",
+                  desc = "(Ljava/lang/Object;)Ljava/lang/Object;",
+                  index = 1
+                }
+              }
+            ]
+          },
+          {
             cf = "java/lang/invoke/MethodHandles",
             name = "lookup",
             desc = "()Ljava/lang/invoke/MethodHandles$Lookup;",

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/CallGraphAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/CallGraphAnalysis.scala
@@ -121,7 +121,7 @@ class CallGraphAnalysis private[cg] (
         callContext: ContextType, tacEP: EPS[Method, TACAI]
     ): ProperPropertyComputationResult = {
         val state = new CGState[ContextType](callContext, tacEP)
-        if(tacEP ne null)
+        if (tacEP ne null)
             processMethod(state, new DirectCalls())
         else
             returnResult(new DirectCalls(), enforceCalleesResult = true)(state)

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/CallGraphAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/CallGraphAnalysis.scala
@@ -121,8 +121,13 @@ class CallGraphAnalysis private[cg] (
         callContext: ContextType, tacEP: EPS[Method, TACAI]
     ): ProperPropertyComputationResult = {
         val state = new CGState[ContextType](callContext, tacEP)
-        processMethod(state, new DirectCalls())
+        if(tacEP ne null)
+            processMethod(state, new DirectCalls())
+        else
+            returnResult(new DirectCalls(), enforceCalleesResult = true)(state)
     }
+
+    override final val processesMethodsWithoutBody = true
 
     protected[this] def doHandleVirtualCall(
         callContext:                   ContextType,

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/CallGraphAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/CallGraphAnalysis.scala
@@ -290,13 +290,13 @@ class CallGraphAnalysis private[cg] (
             case _ ⇒ //nothing to do
         }
 
-        returnResult(calls)(state)
+        returnResult(calls, true)(state)
     }
 
     protected[this] def returnResult(
-        calleesAndCallers: DirectCalls
+        calleesAndCallers: DirectCalls, enforceCalleesResult: Boolean = false
     )(implicit state: CGState[ContextType]): ProperPropertyComputationResult = {
-        val results = calleesAndCallers.partialResults(state.callContext)
+        val results = calleesAndCallers.partialResults(state.callContext, enforceCalleesResult)
 
         // FIXME: This won't work for refinable TACs as state.hasNonFinalCallSite may return false
         //  even if an update for the tac might add a non-final call site

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/CalleesAndCallers.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/CalleesAndCallers.scala
@@ -38,11 +38,14 @@ import org.opalj.tac.fpcf.properties.cg.OnlyVMLevelCallers
  */
 sealed trait CalleesAndCallers {
     final def partialResults(
-        callerContext: Context
+        callerContext: Context, enforceCalleesResult: Boolean = false
     ): TraversableOnce[PartialResult[_, _ >: Null <: Property]] =
-        if (directCallees.isEmpty && indirectCallees.isEmpty && incompleteCallSites.isEmpty)
-            partialResultsForCallers
-        else
+        if (directCallees.isEmpty && indirectCallees.isEmpty && incompleteCallSites.isEmpty) {
+            if (enforceCalleesResult)
+                Iterator(partialResultForCallees(callerContext)) ++ partialResultsForCallers
+            else
+                partialResultsForCallers
+        } else
             Iterator(partialResultForCallees(callerContext)) ++ partialResultsForCallers
 
     protected def directCallees: IntMap[IntTrieSet] = IntMap.empty

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/ReachableMethodAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/ReachableMethodAnalysis.scala
@@ -52,7 +52,7 @@ trait ReachableMethodAnalysis extends FPCFAnalysis with TypeConsumerAnalysis {
 
         // we only allow defined methods
         if (!declaredMethod.hasSingleDefinedMethod)
-            return NoResult;
+            return processMethodWithoutBody(callersEOptP);
 
         val method = declaredMethod.definedMethod
 
@@ -62,7 +62,7 @@ trait ReachableMethodAnalysis extends FPCFAnalysis with TypeConsumerAnalysis {
 
         if (method.body.isEmpty)
             // happens in particular for native methods
-            return NoResult;
+            return processMethodWithoutBody(callersEOptP);
 
         val tacEP = propertyStore(method, TACAI.key)
 
@@ -71,6 +71,17 @@ trait ReachableMethodAnalysis extends FPCFAnalysis with TypeConsumerAnalysis {
         } else {
             InterimPartialResult(Set(tacEP), continuationForTAC(declaredMethod))
         }
+    }
+
+    protected val processesMethodsWithoutBody = false
+
+    protected def processMethodWithoutBody(
+                                              eOptP: EOptionP[DeclaredMethod, Callers]
+                                          ): PropertyComputationResult = {
+        if (processesMethodsWithoutBody){
+            processMethod(eOptP, null, null)
+        } else
+            NoResult
     }
 
     private[this] def processMethod(

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/ReachableMethodAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/ReachableMethodAnalysis.scala
@@ -76,9 +76,9 @@ trait ReachableMethodAnalysis extends FPCFAnalysis with TypeConsumerAnalysis {
     protected val processesMethodsWithoutBody = false
 
     protected def processMethodWithoutBody(
-                                              eOptP: EOptionP[DeclaredMethod, Callers]
-                                          ): PropertyComputationResult = {
-        if (processesMethodsWithoutBody){
+        eOptP: EOptionP[DeclaredMethod, Callers]
+    ): PropertyComputationResult = {
+        if (processesMethodsWithoutBody) {
             processMethod(eOptP, null, null)
         } else
             NoResult

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/SerializationRelatedCallsAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/SerializationRelatedCallsAnalysis.scala
@@ -18,6 +18,7 @@ import org.opalj.fpcf.PropertyComputationResult
 import org.opalj.fpcf.PropertyStore
 import org.opalj.fpcf.Results
 import org.opalj.fpcf.SomeEPS
+import org.opalj.value.ASObjectValue
 import org.opalj.value.ValueInformation
 import org.opalj.br.analyses.SomeProject
 import org.opalj.br.fpcf.BasicFPCFEagerAnalysisScheduler
@@ -253,8 +254,6 @@ class OISReadObjectAnalysis private[analyses] (
     final val ReadObjectDescriptor = MethodDescriptor.JustTakes(ObjectInputStreamType)
     final val ReadExternalDescriptor = MethodDescriptor.JustTakes(ObjectInputType)
 
-    final val UnknownParam = Seq(None)
-
     override val apiMethod: DeclaredMethod = declaredMethods(
         ObjectInputStreamType,
         "",
@@ -301,133 +300,146 @@ class OISReadObjectAnalysis private[analyses] (
     ): Unit = {
         var foundCast = false
         val parameterList = Seq(inputStream.flatMap(is ⇒ persistentUVar(is.asVar)))
-        for { Checkcast(_, _, ElementReferenceType(castType)) ← stmts } {
-            foundCast = true
+        for {
+            use ← targetVar.usedBy
+        } stmts(use) match {
+            case Checkcast(_, value, ElementReferenceType(castType)) ⇒
+                foundCast = true
 
-            // for each subtype of the type declared at cast we add calls to the relevant methods
-            for {
-                t ← ch.allSubtypes(castType.asObjectType, reflexive = true)
-                cf ← project.classFile(t) // we ignore cases were no class file exists
-                if !cf.isInterfaceDeclaration
-                if ch.isSubtypeOf(castType, ObjectType.Serializable)
-            } {
+                // for each subtype of the cast type we add calls to the relevant methods
+                for {
+                    t ← ch.allSubtypes(castType, reflexive = true)
+                    cf ← project.classFile(t) // we ignore cases were no class file exists
+                    if !cf.isInterfaceDeclaration
+                    if ch.isSubtypeOf(castType, ObjectType.Serializable)
+                } {
 
-                if (ch.isSubtypeOf(castType, ObjectType.Externalizable)) {
-                    // call to `readExternal`
-                    val readExternal = p.instanceCall(t, t, "readExternal", ReadExternalDescriptor)
-
-                    calleesAndCallers.addCallOrFallback(
-                        context,
-                        pc,
-                        readExternal,
-                        ObjectType.Externalizable.packageName,
-                        ObjectType.Externalizable,
-                        "readExternal",
-                        ReadExternalDescriptor,
-                        parameterList,
-                        None,
-                        tgt ⇒ typeProvider.expandContext(context, tgt, pc)
+                    val receiver = Some(
+                        (ASObjectValue(isNull = No, isPrecise = false, castType), IntTrieSet(pc))
                     )
 
-                    // call to no-arg constructor
-                    cf.findMethod("<init>", NoArgsAndReturnVoid) foreach { c ⇒
-                        calleesAndCallers.addCall(
+                    if (ch.isSubtypeOf(castType, ObjectType.Externalizable)) {
+                        // call to `readExternal`
+                        val readExternal =
+                            p.instanceCall(t, t, "readExternal", ReadExternalDescriptor)
+
+                        calleesAndCallers.addCallOrFallback(
                             context,
                             pc,
-                            typeProvider.expandContext(context, declaredMethods(c), pc),
-                            Seq.empty,
-                            None
+                            readExternal,
+                            ObjectType.Externalizable.packageName,
+                            ObjectType.Externalizable,
+                            "readExternal",
+                            ReadExternalDescriptor,
+                            parameterList,
+                            receiver,
+                            tgt ⇒ typeProvider.expandContext(context, tgt, pc)
                         )
-                    }
-                } else {
 
-                    // call to `readObject`
-                    val readObjectMethod =
-                        p.specialCall(t, t, isInterface = false, "readObject", ReadObjectDescriptor)
-                    calleesAndCallers.addCallOrFallback(
-                        context, pc, readObjectMethod,
-                        ObjectType.Object.packageName,
-                        ObjectType.Object,
-                        "readObject",
-                        ReadObjectDescriptor,
-                        parameterList,
-                        None,
-                        tgt ⇒ typeProvider.expandContext(context, tgt, pc)
-                    )
-
-                    // call to first super no-arg constructor
-                    val nonSerializableSuperclass = firstNotSerializableSupertype(t)
-                    if (nonSerializableSuperclass.isDefined) {
-                        val constructor = p.classFile(nonSerializableSuperclass.get).flatMap { cf ⇒
-                            cf.findMethod("<init>", NoArgsAndReturnVoid)
+                        // call to no-arg constructor
+                        cf.findMethod("<init>", NoArgsAndReturnVoid) foreach { c ⇒
+                            calleesAndCallers.addCall(
+                                context,
+                                pc,
+                                typeProvider.expandContext(context, declaredMethods(c), pc),
+                                Seq.empty,
+                                receiver
+                            )
                         }
-                        // otherwise an exception will thrown at runtime
-                        if (constructor.isDefined) {
+                    } else {
+
+                        // call to `readObject`
+                        val readObjectMethod = p.specialCall(
+                            t, t, isInterface = false, "readObject", ReadObjectDescriptor
+                        )
+                        calleesAndCallers.addCallOrFallback(
+                            context, pc, readObjectMethod,
+                            ObjectType.Object.packageName,
+                            ObjectType.Object,
+                            "readObject",
+                            ReadObjectDescriptor,
+                            parameterList,
+                            receiver,
+                            tgt ⇒ typeProvider.expandContext(context, tgt, pc)
+                        )
+
+                        // call to first super no-arg constructor
+                        val nonSerializableSuperclass = firstNotSerializableSupertype(t)
+                        if (nonSerializableSuperclass.isDefined) {
+                            val constructor =
+                                p.classFile(nonSerializableSuperclass.get).flatMap { cf ⇒
+                                    cf.findMethod("<init>", NoArgsAndReturnVoid)
+                                }
+                            // otherwise an exception will thrown at runtime
+                            if (constructor.isDefined) {
+                                calleesAndCallers.addCall(
+                                    context,
+                                    pc,
+                                    typeProvider.expandContext(
+                                        context, declaredMethods(constructor.get), pc
+                                    ),
+                                    Seq.empty,
+                                    receiver
+                                )
+                            }
+                        }
+
+                        // for the type to be instantiated, we need to call a constructor of the
+                        // type t in order to let the instantiated types be correct. Note, that the
+                        // JVM would not call the constructor
+                        // Note, that we assume that there is a constructor
+                        // Note that we have to do a String comparison since methods with ObjectType
+                        // descriptors are not sorted consistently across runs
+                        val constructors = cf.constructors.map[(String, Method)] { ctor ⇒
+                            (ctor.descriptor.toJava, ctor)
+                        }
+
+                        if (constructors.nonEmpty) {
+                            val constructor = constructors.minBy(t ⇒ t._1)._2
+
                             calleesAndCallers.addCall(
                                 context,
                                 pc,
                                 typeProvider.expandContext(
-                                    context, declaredMethods(constructor.get), pc
+                                    context, declaredMethods(constructor), pc
                                 ),
                                 Seq.empty,
-                                None
+                                receiver
                             )
                         }
                     }
 
-                    // for the type to be instantiated, we need to call a constructor of the type t
-                    // in order to let the instantiated types be correct. Note, that the JVM would
-                    // not call the constructor
-                    // Note, that we assume that there is a constructor
-                    // Note that we have to do a String comparison since methods with ObjectType
-                    // descriptors are not sorted consistently across runs
-                    val constructors = cf.constructors.map[(String, Method)] { ctor ⇒
-                        (ctor.descriptor.toJava, ctor)
-                    }
+                    // call to `readResolve`
+                    val readResolve = p.specialCall(
+                        t, t, isInterface = false, "readResolve", JustReturnsObject
+                    )
+                    calleesAndCallers.addCallOrFallback(
+                        context, pc, readResolve,
+                        ObjectType.Object.packageName,
+                        ObjectType.Object,
+                        "readResolve",
+                        JustReturnsObject,
+                        Seq.empty,
+                        receiver,
+                        tgt ⇒ typeProvider.expandContext(context, tgt, pc)
+                    )
 
-                    if (constructors.nonEmpty) {
-                        val constructor = constructors.minBy(t ⇒ t._1)._2
-
-                        calleesAndCallers.addCall(
-                            context,
-                            pc,
-                            typeProvider.expandContext(context, declaredMethods(constructor), pc),
-                            UnknownParam,
-                            None
+                    // call to `validateObject`
+                    if (ch.isSubtypeOf(t, ObjectInputValidationType)) {
+                        val validateObject =
+                            p.instanceCall(t, t, "validateObject", JustReturnsObject)
+                        calleesAndCallers.addCallOrFallback(
+                            context, pc, validateObject,
+                            ObjectType.Object.packageName,
+                            ObjectType.Object,
+                            "validateObject",
+                            JustReturnsObject,
+                            Seq.empty,
+                            receiver,
+                            tgt ⇒ typeProvider.expandContext(context, tgt, pc)
                         )
                     }
                 }
-
-                // call to `readResolve`
-                val readResolve =
-                    p.specialCall(t, t, isInterface = false, "readResolve", JustReturnsObject)
-                calleesAndCallers.addCallOrFallback(
-                    context, pc, readResolve,
-                    ObjectType.Object.packageName,
-                    ObjectType.Object,
-                    "readResolve",
-                    JustReturnsObject,
-                    Seq.empty,
-                    None,
-                    tgt ⇒ typeProvider.expandContext(context, tgt, pc)
-                )
-
-                // call to `validateObject`
-                if (ch.isSubtypeOf(t, ObjectInputValidationType)) {
-                    val validateObject =
-                        p.instanceCall(t, t, "validateObject", JustReturnsObject)
-                    calleesAndCallers.addCallOrFallback(
-                        context, pc, validateObject,
-                        ObjectType.Object.packageName,
-                        ObjectType.Object,
-                        "validateObject",
-                        JustReturnsObject,
-                        Seq.empty,
-                        None,
-                        tgt ⇒ typeProvider.expandContext(context, tgt, pc)
-                    )
-                }
-            }
         }
 
         if (!foundCast) {

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/xta/InstantiatedTypesAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/xta/InstantiatedTypesAnalysis.scala
@@ -304,8 +304,9 @@ class InstantiatedTypesAnalysisScheduler(
         }
 
         // Some cooperative analyses originally meant for RTA may require the global type set
-        // to be pre-initialized. For that purpose, an empty type set is sufficient.
-        initialize(p, UIDSet.empty)
+        // to be pre-initialized. Strings and classes can be introduced via constants anywhere.
+        // TODO Only introduce these types to the per-entity type sets where constants are used
+        initialize(p, UIDSet(ObjectType.String, ObjectType.Class))
 
         def isRelevantArrayType(rt: Type): Boolean =
             rt.isArrayType && rt.asArrayType.elementType.isObjectType


### PR DESCRIPTION
Multiple fixes to our call graph algorithms:
- Fix all CGs to properly report empty callees instead of not reporting anything and thus falling back to NoCalleesDueToUnreachableMethod
- Fix XTA dealing with String and Class constants (quick fix, not a perfect solution)
- Fix points-to analyses to actually create points-to values for indirectly constructed objects (via reflection or deserialization)
- Model method java.lang.Class.cast if JDK is not analyzed
- Also includes a fix for the hierarchy of abstract interpretation domains that were not ordered correctly