### PR TITLE
Only ObjectTypes for newInstance

### DIFF
--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/reflection/MatcherUtil.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/reflection/MatcherUtil.scala
@@ -124,6 +124,7 @@ object MatcherUtil {
         project:                   SomeProject,
         failure:                   () ⇒ Unit,
         onlyMethodsExactlyInClass: Boolean,
+        onlyObjectTypes:           Boolean        = false,
         considerSubclasses:        Boolean        = false
     )(
         implicit
@@ -134,7 +135,7 @@ object MatcherUtil {
         highSoundness:       Boolean
     ): MethodMatcher = {
         val typesOpt = Some(TypesUtil.getPossibleClasses(
-            context, ref, depender, stmts, project, failure
+            context, ref, depender, stmts, project, failure, onlyObjectTypes
         ).flatMap { tpe ⇒
             if (considerSubclasses) project.classHierarchy.allSubtypes(tpe.asObjectType, true)
             else Set(tpe.asObjectType)

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/reflection/ReflectionRelatedCallsAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/reflection/ReflectionRelatedCallsAnalysis.scala
@@ -215,7 +215,8 @@ class ClassForNameAnalysis private[analyses] (
         className: V, callContext: ContextType, pc: Int, stmts: Array[Stmt[V]]
     )(implicit state: State, incompleteCallSites: IncompleteCallSites): Unit = {
         val loadedClasses = TypesUtil.getPossibleForNameClasses(
-            className, callContext, pc.asInstanceOf[Entity], stmts, project, () ⇒ failure(pc)
+            className, callContext, pc.asInstanceOf[Entity],
+            stmts, project, () ⇒ failure(pc), onlyObjectTypes = false
         )
         state.addNewLoadedClasses(loadedClasses)
     }
@@ -233,7 +234,7 @@ class ClassForNameAnalysis private[analyses] (
             _.isInstanceOf[Int], callPC ⇒ failure(callPC)
         ) { (callPC, _, allocationIndex, stmts) ⇒
                 val classOpt = TypesUtil.getPossibleForNameClass(
-                    allocationIndex, stmts, project
+                    allocationIndex, stmts, project, onlyObjectTypes = false
                 )
                 if (classOpt.isDefined) state.addNewLoadedClasses(classOpt)
                 else failure(callPC)
@@ -321,7 +322,7 @@ class ClassNewInstanceAnalysis private[analyses] (
         ) { (callPC, allocationContext, allocationIndex, stmts) ⇒
                 val classes = TypesUtil.getPossibleClasses(
                     allocationContext, allocationIndex, callPC.asInstanceOf[Entity],
-                    stmts, project, () ⇒ failure(callPC), noArrayTypes = true
+                    stmts, project, () ⇒ failure(callPC), onlyObjectTypes = true
                 )
 
                 val matchers = Set(
@@ -342,7 +343,7 @@ class ClassNewInstanceAnalysis private[analyses] (
             _.isInstanceOf[(_, _)], data ⇒ failure(data._1)
         ) { (data, _, allocationIndex, stmts) ⇒
                 val classOpt = TypesUtil.getPossibleForNameClass(
-                    allocationIndex, stmts, project, noArrayTypes = true
+                    allocationIndex, stmts, project, onlyObjectTypes = true
                 )
 
                 val matchers = Set(
@@ -385,7 +386,8 @@ class ClassNewInstanceAnalysis private[analyses] (
                 stmts,
                 project,
                 () ⇒ failure(callPC),
-                onlyMethodsExactlyInClass = true
+                onlyMethodsExactlyInClass = true,
+                onlyObjectTypes = true
             )
         )
 
@@ -488,7 +490,7 @@ class ConstructorNewInstanceAnalysis private[analyses] (
         ) { (data, allocationContext, allocationIndex, stmts) ⇒
                 val classes = TypesUtil.getPossibleClasses(
                     allocationContext, allocationIndex, data,
-                    stmts, project, () ⇒ failure(data._1, data._3), noArrayTypes = true
+                    stmts, project, () ⇒ failure(data._1, data._3), onlyObjectTypes = true
                 )
 
                 val matchers = data._3 +
@@ -510,7 +512,7 @@ class ConstructorNewInstanceAnalysis private[analyses] (
             _.isInstanceOf[(_, _)], data ⇒ failure(data._1._1, data._1._3)
         ) { (data, _, allocationIndex, stmts) ⇒
                 val classOpt = TypesUtil.getPossibleForNameClass(
-                    allocationIndex, stmts, project, noArrayTypes = true
+                    allocationIndex, stmts, project, onlyObjectTypes = true
                 )
 
                 val matchers = data._1._3 +
@@ -615,7 +617,8 @@ class ConstructorNewInstanceAnalysis private[analyses] (
                         stmts,
                         project,
                         () ⇒ failure(callPC, matchers),
-                        onlyMethodsExactlyInClass = true
+                        onlyMethodsExactlyInClass = true,
+                        onlyObjectTypes = true
                     )
 
             /*
@@ -756,7 +759,8 @@ class MethodInvokeAnalysis private[analyses] (
         ) { (data, allocationContext, allocationIndex, stmts) ⇒
                 val classes = TypesUtil.getPossibleClasses(
                     allocationContext, allocationIndex, data,
-                    stmts, project, () ⇒ failure(data._1, data._2, data._3, data._4)
+                    stmts, project, () ⇒ failure(data._1, data._2, data._3, data._4),
+                    onlyObjectTypes = false
                 )
 
                 val matchers = data._4 +
@@ -773,7 +777,9 @@ class MethodInvokeAnalysis private[analyses] (
             eps, state.callContext, data ⇒ (data._2, data._1._6),
             _.isInstanceOf[(_, _)], data ⇒ failure(data._1._1, data._1._2, data._1._3, data._1._4)
         ) { (data, _, allocationIndex, stmts) ⇒
-                val classOpt = TypesUtil.getPossibleForNameClass(allocationIndex, stmts, project)
+                val classOpt = TypesUtil.getPossibleForNameClass(
+                    allocationIndex, stmts, project, onlyObjectTypes = false
+                )
 
                 val matchers = data._1._4 +
                     retrieveSuitableMatcher[Set[ObjectType]](
@@ -1048,7 +1054,8 @@ class MethodHandleInvokeAnalysis private[analyses] (
         ) { (data, allocationContext, allocationIndex, stmts) ⇒
                 val classes = TypesUtil.getPossibleClasses(
                     allocationContext, allocationIndex, data,
-                    stmts, project, () ⇒ failure(data._1, data._3, data._4)
+                    stmts, project, () ⇒ failure(data._1, data._3, data._4),
+                    onlyObjectTypes = false
                 ).flatMap { tpe ⇒
                     if (data._2) project.classHierarchy.allSubtypes(tpe.asObjectType, true)
                     else Set(tpe.asObjectType)
@@ -1068,7 +1075,9 @@ class MethodHandleInvokeAnalysis private[analyses] (
             eps, state.callContext, data ⇒ (data._2, data._1._6),
             _.isInstanceOf[(_, _)], data ⇒ failure(data._1._1, data._1._3, data._1._4)
         ) { (data, _, allocationIndex, stmts) ⇒
-                val classOpt = TypesUtil.getPossibleForNameClass(allocationIndex, stmts, project).map { tpe ⇒
+                val classOpt = TypesUtil.getPossibleForNameClass(
+                    allocationIndex, stmts, project, onlyObjectTypes = false
+                ).map { tpe ⇒
                     if (data._1._2) project.classHierarchy.allSubtypes(tpe.asObjectType, true)
                     else Set(tpe.asObjectType)
                 }

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/reflection/ReflectionRelatedCallsAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/reflection/ReflectionRelatedCallsAnalysis.scala
@@ -321,7 +321,7 @@ class ClassNewInstanceAnalysis private[analyses] (
         ) { (callPC, allocationContext, allocationIndex, stmts) ⇒
                 val classes = TypesUtil.getPossibleClasses(
                     allocationContext, allocationIndex, callPC.asInstanceOf[Entity],
-                    stmts, project, () ⇒ failure(callPC)
+                    stmts, project, () ⇒ failure(callPC), noArrayTypes = true
                 )
 
                 val matchers = Set(
@@ -341,7 +341,9 @@ class ClassNewInstanceAnalysis private[analyses] (
             eps, state.callContext, data ⇒ (data._2, state.tac.stmts),
             _.isInstanceOf[(_, _)], data ⇒ failure(data._1)
         ) { (data, _, allocationIndex, stmts) ⇒
-                val classOpt = TypesUtil.getPossibleForNameClass(allocationIndex, stmts, project)
+                val classOpt = TypesUtil.getPossibleForNameClass(
+                    allocationIndex, stmts, project, noArrayTypes = true
+                )
 
                 val matchers = Set(
                     MatcherUtil.constructorMatcher,
@@ -486,12 +488,12 @@ class ConstructorNewInstanceAnalysis private[analyses] (
         ) { (data, allocationContext, allocationIndex, stmts) ⇒
                 val classes = TypesUtil.getPossibleClasses(
                     allocationContext, allocationIndex, data,
-                    stmts, project, () ⇒ failure(data._1, data._3)
+                    stmts, project, () ⇒ failure(data._1, data._3), noArrayTypes = true
                 )
 
                 val matchers = data._3 +
                     retrieveSuitableMatcher[Set[ObjectType]](
-                        Some(classes.map(_.asObjectType)),
+                        Some(classes.asInstanceOf[Set[ObjectType]]),
                         data._1,
                         v ⇒ new ClassBasedMethodMatcher(v, true)
                     )
@@ -507,7 +509,9 @@ class ConstructorNewInstanceAnalysis private[analyses] (
             eps, state.callContext, data ⇒ (data._2, data._1._5),
             _.isInstanceOf[(_, _)], data ⇒ failure(data._1._1, data._1._3)
         ) { (data, _, allocationIndex, stmts) ⇒
-                val classOpt = TypesUtil.getPossibleForNameClass(allocationIndex, stmts, project)
+                val classOpt = TypesUtil.getPossibleForNameClass(
+                    allocationIndex, stmts, project, noArrayTypes = true
+                )
 
                 val matchers = data._1._3 +
                     retrieveSuitableMatcher[Set[ObjectType]](

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/reflection/TypesUtil.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/reflection/TypesUtil.scala
@@ -23,14 +23,18 @@ object TypesUtil {
      * Returns classes that may be loaded by an invocation of Class.forName.
      */
     def getPossibleForNameClasses(
-        className: Expr[V],
-        stmts:     Array[Stmt[V]],
-        project:   SomeProject
+        className:       Expr[V],
+        stmts:           Array[Stmt[V]],
+        project:         SomeProject,
+        onlyObjectTypes: Boolean = false
     ): Option[Set[ObjectType]] = {
         StringUtil.getPossibleStrings(className, stmts).map(_.flatMap { cls ⇒
             try {
                 val tpe = ReferenceType(cls.replace('.', '/'))
-                Some(if (tpe.isArrayType) ObjectType.Object else tpe.asObjectType)
+                if(tpe.isArrayType)
+                    if (onlyObjectTypes) None
+                    else Some(ObjectType.Object)
+                else Some(tpe.asObjectType)
             } catch {
                 case _: Exception ⇒ None
             }
@@ -46,12 +50,13 @@ object TypesUtil {
      * and the dependee provides allocation sites of Strings that give class names of such classes
      */
     def getPossibleForNameClasses(
-        className: V,
-        context:   Context,
-        depender:  Entity,
-        stmts:     Array[Stmt[V]],
-        project:   SomeProject,
-        failure:   () ⇒ Unit
+        className:       V,
+        context:         Context,
+        depender:        Entity,
+        stmts:           Array[Stmt[V]],
+        project:         SomeProject,
+        failure:         () ⇒ Unit,
+        onlyObjectTypes: Boolean = false
     )(
         implicit
         typeProvider: TypeProvider,
@@ -61,7 +66,10 @@ object TypesUtil {
         StringUtil.getPossibleStrings(className, context, depender, stmts, failure).flatMap { cls ⇒
             try {
                 val tpe = ReferenceType(cls.replace('.', '/'))
-                Some(if (tpe.isArrayType) ObjectType.Object else tpe.asObjectType)
+                if(tpe.isArrayType)
+                    if (onlyObjectTypes) None
+                    else Some(ObjectType.Object)
+                else Some(tpe.asObjectType)
             } catch {
                 case _: Exception ⇒ None
             }
@@ -74,12 +82,16 @@ object TypesUtil {
     def getPossibleForNameClass(
         classNameDefSite: Int,
         stmts:            Array[Stmt[V]],
-        project:          SomeProject
+        project:          SomeProject,
+        onlyObjectTypes:     Boolean = false
     ): Option[ObjectType] = {
         StringUtil.getString(classNameDefSite, stmts).flatMap { cls ⇒
             try {
                 val tpe = ReferenceType(cls.replace('.', '/'))
-                Some(if (tpe.isArrayType) ObjectType.Object else tpe.asObjectType)
+                if(tpe.isArrayType)
+                    if (onlyObjectTypes) None
+                    else Some(ObjectType.Object)
+                else Some(tpe.asObjectType)
             } catch {
                 case _: Exception ⇒ None
             }
@@ -92,9 +104,10 @@ object TypesUtil {
      * by accesses to a primitive type's class as well as from Object.getClass.
      */
     def getPossibleClasses(
-        value:   Expr[V],
-        stmts:   Array[Stmt[V]],
-        project: SomeProject
+        value:           Expr[V],
+        stmts:           Array[Stmt[V]],
+        project:         SomeProject,
+        onlyObjectTypes: Boolean = false
     ): Option[Iterator[Type]] = {
 
         def isForName(expr: Expr[V]): Boolean = { // static call to Class.forName
@@ -105,7 +118,8 @@ object TypesUtil {
 
         def isGetClass(expr: Expr[V]): Boolean = { // virtual call to Object.getClass
             expr.isVirtualFunctionCall && expr.asVirtualFunctionCall.name == "getClass" &&
-                expr.asVirtualFunctionCall.descriptor == MethodDescriptor.withNoArgs(ObjectType.Class)
+                expr.asVirtualFunctionCall.descriptor ==
+                    MethodDescriptor.withNoArgs(ObjectType.Class)
         }
 
         var possibleTypes: Set[Type] = Set.empty
@@ -118,12 +132,15 @@ object TypesUtil {
             }
             val expr = stmts(defSite).asAssignment.expr
 
-            if (!expr.isClassConst && !isForName(expr) && !isBaseTypeLoad(expr) & !isGetClass(expr)) {
+            if (!expr.isClassConst && !isForName(expr) && !isBaseTypeLoad(expr) &
+                !isGetClass(expr)) {
                 return None;
             }
 
             if (expr.isClassConst) {
-                possibleTypes += stmts(defSite).asAssignment.expr.asClassConst.value
+                val tpe = stmts(defSite).asAssignment.expr.asClassConst.value
+                if (tpe.isObjectType || !onlyObjectTypes)
+                    possibleTypes += tpe
             } else if (expr.isStaticFunctionCall) {
                 val className =
                     if (expr.asFunctionCall.descriptor.parameterTypes.head eq ObjectType.String)
@@ -132,7 +149,7 @@ object TypesUtil {
                         expr.asStaticFunctionCall.params(1)
 
                 val possibleClassesOpt = getPossibleForNameClasses(
-                    className, stmts, project
+                    className, stmts, project, onlyObjectTypes
                 )
                 if (possibleClassesOpt.isEmpty) {
                     return None;
@@ -145,8 +162,10 @@ object TypesUtil {
                     return None;
                 }
 
-                possibleTypes ++= typesOfVarOpt.get
-            } else {
+                possibleTypes ++= typesOfVarOpt.get.filter{ tpe ⇒
+                    tpe.isObjectType || !onlyObjectTypes
+                }
+            } else if (!onlyObjectTypes) {
                 possibleTypes += getBaseType(expr)
             }
 
@@ -166,12 +185,13 @@ object TypesUtil {
      * and the dependee provides allocation sites of Strings that give class names of such classes
      */
     private[reflection] def getPossibleClasses(
-        context:  Context,
-        value:    V,
-        depender: Entity,
-        stmts:    Array[Stmt[V]],
-        project:  SomeProject,
-        failure:  () ⇒ Unit
+        context:         Context,
+        value:           V,
+        depender:        Entity,
+        stmts:           Array[Stmt[V]],
+        project:         SomeProject,
+        failure:         () ⇒ Unit,
+        onlyObjectTypes: Boolean = false
     )(
         implicit
         typeProvider: TypeProvider,
@@ -184,7 +204,7 @@ object TypesUtil {
             value, context, depender, stmts, _ eq ObjectType.Class, failure
         ) { (allocationContext, defSite, _stmts) ⇒
             possibleTypes ++= getPossibleClasses(
-                allocationContext, defSite, depender, _stmts, project, failure
+                allocationContext, defSite, depender, _stmts, project, failure, onlyObjectTypes
             )
         }
 
@@ -202,12 +222,13 @@ object TypesUtil {
      * and the dependee provides allocation sites of Strings that give class names of such classes
      */
     private[reflection] def getPossibleClasses(
-        context:  Context,
-        defSite:  Int,
-        depender: Entity,
-        stmts:    Array[Stmt[V]],
-        project:  SomeProject,
-        failure:  () ⇒ Unit
+        context:         Context,
+        defSite:         Int,
+        depender:        Entity,
+        stmts:           Array[Stmt[V]],
+        project:         SomeProject,
+        failure:         () ⇒ Unit,
+        onlyObjectTypes: Boolean = false
     )(
         implicit
         typeProvider: TypeProvider,
@@ -228,15 +249,17 @@ object TypesUtil {
                     expr.asStaticFunctionCall.params(1).asVar
 
             possibleTypes ++= getPossibleForNameClasses(
-                className, context, (depender, className), stmts, project, failure
+                className, context, (depender, className), stmts, project, failure, onlyObjectTypes
             )
         } else if (isGetClass(expr)) {
             val typesOfVarOpt = getTypesOfVar(expr.asVirtualFunctionCall.receiver.asVar)
             if (typesOfVarOpt.isEmpty)
                 failure()
             else
-                possibleTypes ++= typesOfVarOpt.get
-        } else if (isBaseTypeLoad(expr)) {
+                possibleTypes ++= typesOfVarOpt.get.filter { tpe ⇒
+                    tpe.isObjectType || !onlyObjectTypes
+                }
+        } else if (isBaseTypeLoad(expr) && !onlyObjectTypes) {
             possibleTypes += getBaseType(expr)
         }
 

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/reflection/TypesUtil.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/reflection/TypesUtil.scala
@@ -26,12 +26,12 @@ object TypesUtil {
         className:       Expr[V],
         stmts:           Array[Stmt[V]],
         project:         SomeProject,
-        onlyObjectTypes: Boolean = false
+        onlyObjectTypes: Boolean
     ): Option[Set[ObjectType]] = {
         StringUtil.getPossibleStrings(className, stmts).map(_.flatMap { cls ⇒
             try {
                 val tpe = ReferenceType(cls.replace('.', '/'))
-                if(tpe.isArrayType)
+                if (tpe.isArrayType)
                     if (onlyObjectTypes) None
                     else Some(ObjectType.Object)
                 else Some(tpe.asObjectType)
@@ -56,7 +56,7 @@ object TypesUtil {
         stmts:           Array[Stmt[V]],
         project:         SomeProject,
         failure:         () ⇒ Unit,
-        onlyObjectTypes: Boolean = false
+        onlyObjectTypes: Boolean
     )(
         implicit
         typeProvider: TypeProvider,
@@ -66,7 +66,7 @@ object TypesUtil {
         StringUtil.getPossibleStrings(className, context, depender, stmts, failure).flatMap { cls ⇒
             try {
                 val tpe = ReferenceType(cls.replace('.', '/'))
-                if(tpe.isArrayType)
+                if (tpe.isArrayType)
                     if (onlyObjectTypes) None
                     else Some(ObjectType.Object)
                 else Some(tpe.asObjectType)
@@ -83,12 +83,12 @@ object TypesUtil {
         classNameDefSite: Int,
         stmts:            Array[Stmt[V]],
         project:          SomeProject,
-        onlyObjectTypes:     Boolean = false
+        onlyObjectTypes:  Boolean
     ): Option[ObjectType] = {
         StringUtil.getString(classNameDefSite, stmts).flatMap { cls ⇒
             try {
                 val tpe = ReferenceType(cls.replace('.', '/'))
-                if(tpe.isArrayType)
+                if (tpe.isArrayType)
                     if (onlyObjectTypes) None
                     else Some(ObjectType.Object)
                 else Some(tpe.asObjectType)
@@ -107,7 +107,7 @@ object TypesUtil {
         value:           Expr[V],
         stmts:           Array[Stmt[V]],
         project:         SomeProject,
-        onlyObjectTypes: Boolean = false
+        onlyObjectTypes: Boolean        = false
     ): Option[Iterator[Type]] = {
 
         def isForName(expr: Expr[V]): Boolean = { // static call to Class.forName
@@ -119,7 +119,7 @@ object TypesUtil {
         def isGetClass(expr: Expr[V]): Boolean = { // virtual call to Object.getClass
             expr.isVirtualFunctionCall && expr.asVirtualFunctionCall.name == "getClass" &&
                 expr.asVirtualFunctionCall.descriptor ==
-                    MethodDescriptor.withNoArgs(ObjectType.Class)
+                MethodDescriptor.withNoArgs(ObjectType.Class)
         }
 
         var possibleTypes: Set[Type] = Set.empty
@@ -162,7 +162,7 @@ object TypesUtil {
                     return None;
                 }
 
-                possibleTypes ++= typesOfVarOpt.get.filter{ tpe ⇒
+                possibleTypes ++= typesOfVarOpt.get.filter { tpe ⇒
                     tpe.isObjectType || !onlyObjectTypes
                 }
             } else if (!onlyObjectTypes) {
@@ -191,7 +191,7 @@ object TypesUtil {
         stmts:           Array[Stmt[V]],
         project:         SomeProject,
         failure:         () ⇒ Unit,
-        onlyObjectTypes: Boolean = false
+        onlyObjectTypes: Boolean
     )(
         implicit
         typeProvider: TypeProvider,
@@ -228,7 +228,7 @@ object TypesUtil {
         stmts:           Array[Stmt[V]],
         project:         SomeProject,
         failure:         () ⇒ Unit,
-        onlyObjectTypes: Boolean = false
+        onlyObjectTypes: Boolean
     )(
         implicit
         typeProvider: TypeProvider,


### PR DESCRIPTION
More cases where a type that is not an ObjectType could end up at a `newInstance` (which only constructs objects).