### PR TITLE
Java18framework

### DIFF
--- a/OPAL/bi/src/main/scala/org/opalj/bi/package.scala
+++ b/OPAL/bi/src/main/scala/org/opalj/bi/package.scala
@@ -58,7 +58,7 @@ package object bi {
      * class file.
      */
     def jdkVersion(majorVersion: Int): String = {
-        // 61 == 17, 60 == 16, 59 == 15, 58 == 14, 57 == 13, 56 == 12, 55 == 11, 54 == 10, 53 == 9,
+        // 62 == 18, 61 == 17, 60 == 16, 59 == 15, 58 == 14, 57 == 13, 56 == 12, 55 == 11, 54 == 10, 53 == 9,
         // 52 == 8, 51 == 7, 50 == 6, 49 == 5.0, 48 == 1.4, 47 == 1.3, 46 == 1.2, 45 == 1.1/1.0.2
         if (majorVersion >= 49) {
             "Java "+(majorVersion - 44)
@@ -97,17 +97,19 @@ package object bi {
     final val Java16Version = UShortPair(0, Java16MajorVersion)
     final val Java17MajorVersion = 61
     final val Java17Version = UShortPair(0, Java17MajorVersion)
+    final val Java18MajorVersion = 62
+    final val Java18Version = UShortPair(0, Java18MajorVersion)
 
     /**
      * The latest major version supported by OPAL; this constant is adapted whenever a new version
      * is supported.
      */
-    final val LatestSupportedJavaMajorVersion = Java17MajorVersion
+    final val LatestSupportedJavaMajorVersion = Java18MajorVersion
     /**
      * The latest version supported by OPAL; this constant is adapted whenever a new version
      * is supported.
      */
-    final val LatestSupportedJavaVersion = Java17Version
+    final val LatestSupportedJavaVersion = Java18Version
 
     /**
      * Returns `true` if the current JRE is at least Java 8 or a newer version.

--- a/OPAL/br/src/main/scala/org/opalj/br/analyses/Project.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/analyses/Project.scala
@@ -47,8 +47,8 @@ import org.opalj.br.instructions.INVOKESTATIC
 import org.opalj.br.instructions.NEW
 import org.opalj.br.instructions.NonVirtualMethodInvocationInstruction
 import org.opalj.br.reader.BytecodeInstructionsCache
-import org.opalj.br.reader.Java17FrameworkWithDynamicRewritingAndCaching
-import org.opalj.br.reader.Java17LibraryFramework
+import org.opalj.br.reader.Java18FrameworkWithDynamicRewritingAndCaching
+import org.opalj.br.reader.Java18LibraryFramework
 
 /**
  * Primary abstraction of a Java project; i.e., a set of classes that constitute a
@@ -1071,7 +1071,7 @@ class Project[Source] private (
  */
 object Project {
 
-    lazy val JavaLibraryClassFileReader: Java17LibraryFramework.type = Java17LibraryFramework
+    lazy val JavaLibraryClassFileReader: Java18LibraryFramework.type = Java18LibraryFramework
 
     @volatile private[this] var theCache: SoftReference[BytecodeInstructionsCache] = {
         new SoftReference(new BytecodeInstructionsCache)
@@ -1094,12 +1094,12 @@ object Project {
         implicit
         theLogContext: LogContext = GlobalLogContext,
         theConfig:     Config     = BaseConfig
-    ): Java17FrameworkWithDynamicRewritingAndCaching = {
+    ): Java18FrameworkWithDynamicRewritingAndCaching = {
         // The following makes use of early initializers
         class ConfiguredFramework extends {
             override implicit val logContext: LogContext = theLogContext
             override implicit val config: Config = theConfig
-        } with Java17FrameworkWithDynamicRewritingAndCaching(cache)
+        } with Java18FrameworkWithDynamicRewritingAndCaching(cache)
         new ConfiguredFramework
     }
 

--- a/OPAL/br/src/main/scala/org/opalj/br/reader/Java18Framework.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/reader/Java18Framework.scala
@@ -1,0 +1,12 @@
+/* BSD 2-Clause License - see OPAL/LICENSE for details. */
+package org.opalj.br.reader
+
+/**
+ * This configuration can be used to read in Java 18 (version 62) class files. All
+ * standard information (as defined in the Java Virtual Machine Specification)
+ * is represented.
+ *
+ * @author Julius Naeumann
+ */
+trait Java18Framework extends Java17Framework with Java18LibraryFramework
+

--- a/OPAL/br/src/main/scala/org/opalj/br/reader/Java18FrameworkWithCaching.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/reader/Java18FrameworkWithCaching.scala
@@ -1,0 +1,13 @@
+/* BSD 2-Clause License - see OPAL/LICENSE for details. */
+package org.opalj.br.reader
+
+/**
+ * This configuration can be used to read in Java 18 (version 62) class files. All
+ * standard information (as defined in the Java Virtual Machine Specification)
+ * is represented. Instructions will be cached.
+ *
+ * @author Julius Naeumann
+ */
+class Java18FrameworkWithCaching(
+        cache: BytecodeInstructionsCache
+) extends Java17FrameworkWithCaching(cache) with Java18LibraryFramework

--- a/OPAL/br/src/main/scala/org/opalj/br/reader/Java18FrameworkWithDynamicRewritingAndCaching.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/reader/Java18FrameworkWithDynamicRewritingAndCaching.scala
@@ -1,0 +1,15 @@
+/* BSD 2-Clause License - see OPAL/LICENSE for details. */
+package org.opalj.br.reader
+
+/**
+ * This configuration can be used to read in Java 18 (version 62) class files with full
+ * support for rewriting `invokedynamic` instructions created by the JDK compiler for
+ * lambda and method reference expressions as well as opportunistic support for rewriting dynamic
+ * constants. All standard information (as defined in the Java Virtual Machine Specification) is
+ * represented. Instructions will be cached.
+ *
+ * @author Julius Naeumann
+ */
+class Java18FrameworkWithDynamicRewritingAndCaching(
+        cache: BytecodeInstructionsCache
+) extends Java17FrameworkWithDynamicRewritingAndCaching(cache) with Java18LibraryFramework

--- a/OPAL/br/src/main/scala/org/opalj/br/reader/Java18LibraryFramework.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/reader/Java18LibraryFramework.scala
@@ -13,7 +13,7 @@ trait Java18LibraryFramework
 
 object Java18LibraryFramework extends Java18LibraryFramework {
 
-  final override def loadsInterfacesOnly: Boolean = true
+    final override def loadsInterfacesOnly: Boolean = true
 
 }
 

--- a/OPAL/br/src/main/scala/org/opalj/br/reader/Java18LibraryFramework.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/reader/Java18LibraryFramework.scala
@@ -1,0 +1,19 @@
+/* BSD 2-Clause License - see OPAL/LICENSE for details. */
+package org.opalj.br.reader
+
+/**
+ * This configuration can be used to read in Java 18 (version 62) class files. All
+ * standard information (as defined in the Java Virtual Machine Specification)
+ * is represented except of method implementations.
+ *
+ * @author Julius Naeumann
+ */
+trait Java18LibraryFramework
+    extends Java17LibraryFramework
+
+object Java18LibraryFramework extends Java18LibraryFramework {
+
+  final override def loadsInterfacesOnly: Boolean = true
+
+}
+

--- a/OPAL/common/src/main/scala/org/opalj/util/PerformanceEvaluation.scala
+++ b/OPAL/common/src/main/scala/org/opalj/util/PerformanceEvaluation.scala
@@ -9,7 +9,6 @@ import scala.collection.mutable.Map
 import org.opalj.concurrent.Locking
 import org.opalj.log.OPALLogger
 import org.opalj.log.GlobalLogContext
-import org.opalj.log.LogContext
 
 /**
  * Measures the execution time of some code.
@@ -144,9 +143,6 @@ object PerformanceEvaluation {
         f: ⇒ T
     )(
         mu: Long ⇒ Unit
-    )(
-        implicit
-        logContext: Option[LogContext] = None
     ): T = {
         val memoryMXBean = ManagementFactory.getMemoryMXBean
         gc(memoryMXBean)

--- a/OPAL/common/src/main/scala/org/opalj/util/package.scala
+++ b/OPAL/common/src/main/scala/org/opalj/util/package.scala
@@ -10,7 +10,6 @@ import scala.util.Properties.versionNumberString
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigRenderOptions
 
-
 /**
  * Utility methods.
  *


### PR DESCRIPTION
This increases the latest supported java version to 18. With a possibly breaking change:
I have Removed calls to getObjectPendingFinalizationCount() in util.package.gc(), which were deprecated in java 18. The behavior of util.package.gc() has been changed to a single gc()-call. This new implementation is ok for future java versions, in which finalization will be removed. But is it ok for current versions?