### PR TITLE
Application mode for CG integration test

### DIFF
--- a/DEVELOPING_OPAL/validate/src/it/scala/org/opalj/tac/fpcf/analyses/cg/CallGraphIntegrationTest.scala
+++ b/DEVELOPING_OPAL/validate/src/it/scala/org/opalj/tac/fpcf/analyses/cg/CallGraphIntegrationTest.scala
@@ -45,7 +45,7 @@ class CallGraphIntegrationTest extends AnyFlatSpec with Matchers {
     )
 
     allBIProjects(
-        config = ConfigFactory.load("LibraryProject.conf")
+        config = ConfigFactory.load("CommandLineProject.conf")
     ) foreach { biProject =>
             val (name, projectFactory) = biProject
             if (!ignoredProjects.contains(name))


### PR DESCRIPTION
Library mode was using too much memory with the library points-to analysis.