### PR TITLE
Allow for flushing cached types when initializing multiple projects in a row

### DIFF
--- a/OPAL/br/src/main/scala/org/opalj/br/Type.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/Type.scala
@@ -1127,7 +1127,7 @@ object ObjectType {
         try {
             // Remove all non-predefined OTs from the cache
             Range(highestPredefinedTypeId + 1, objectTypes.length)
-              .foreach( i => cache.remove(objectTypes(i).fqn) )
+                .foreach(i => cache.remove(objectTypes(i).fqn))
 
             // Truncate the ObjectType cache array to lose all not-predefined ObjectTypes
             objectTypes = JArrays.copyOf(objectTypes, highestPredefinedTypeId + 1)
@@ -1617,7 +1617,7 @@ object ArrayType {
 
             // Remove all non-predefined ATs from the cache
             Range(-lowestPredefinedTypeId + 1, arrayTypes.length)
-              .foreach( i => cache.remove(arrayTypes(i).componentType) )
+                .foreach(i => cache.remove(arrayTypes(i).componentType))
 
             // Reset array to only contain predefined ATs
             arrayTypes = JArrays.copyOf(arrayTypes, -lowestPredefinedTypeId + 1)

--- a/OPAL/br/src/main/scala/org/opalj/br/Type.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/Type.scala
@@ -3,13 +3,16 @@ package org.opalj
 package br
 
 import scala.annotation.tailrec
+
 import java.lang.ref.WeakReference
 import java.util.WeakHashMap
 import java.util.{Arrays => JArrays}
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.locks.ReentrantReadWriteLock
+
 import scala.collection.{SortedSet, mutable}
 import scala.math.Ordered
+
 import org.opalj.collection.UIDValue
 import org.opalj.collection.immutable.UIDSet
 import org.opalj.collection.immutable.UIDSet2
@@ -1068,7 +1071,7 @@ object ObjectType {
             val keysToRemove = mutable.HashSet[String]()
 
             this.cache.forEach { case (key: String, obj: WeakReference[ObjectType]) =>
-                if( obj.get().id > HighestPredefinedTypId ){
+                if( obj.get().id > HighestPredefinedTypeId ){
                     keysToRemove.add(key)
                 }
             }
@@ -1077,10 +1080,10 @@ object ObjectType {
             keysToRemove.foreach { cache.remove }
 
             // Truncate the ObjectType cache array to loose all not-predefined ObjectTypes are removed
-           this.objectTypes = JArrays.copyOf( this.objectTypes, HighestPredefinedTypId)
+           this.objectTypes = JArrays.copyOf( this.objectTypes, HighestPredefinedTypeId)
 
             // Reset ID counter to highest id in the cache
-            this.nextId.set( HighestPredefinedTypId + 1 )
+            this.nextId.set( HighestPredefinedTypeId + 1 )
         } finally {
             writeLock.unlock()
         }
@@ -1364,7 +1367,7 @@ object ObjectType {
     final val ObjectInputStream = ObjectType("java/io/ObjectInputStream")
     final val ObjectOutputStream = ObjectType("java/io/ObjectOutputStream")
 
-    private[br] final val HighestPredefinedTypId = ObjectOutputStream.id
+    private[br] final val HighestPredefinedTypeId = nextId.get() - 1
 
     /**
      * Implicit mapping from a wrapper type to its primitive type.
@@ -1561,16 +1564,16 @@ object ArrayType {
             val keysToRemove = mutable.HashSet[FieldType]()
 
             this.cache.forEach { case (compT: FieldType, refAT: WeakReference[ArrayType]) =>
-                if( refAT.get().id < LowestPredefinedTypId ){
+                if( refAT.get().id < LowestPredefinedTypeId ){
                     keysToRemove.add(compT)
                 }
             }
 
             keysToRemove.foreach { cache.remove }
 
-            this.arrayTypes = JArrays.copyOf( this.arrayTypes , -LowestPredefinedTypId + 1)
+            this.arrayTypes = JArrays.copyOf( this.arrayTypes , -LowestPredefinedTypeId + 1)
 
-            this.nextId.set( LowestPredefinedTypId - 1 )
+            this.nextId.set( LowestPredefinedTypeId - 1 )
 
         }
     }
@@ -1665,7 +1668,7 @@ object ArrayType {
     final val ArrayOfObject = ArrayType(ObjectType.Object)
     final val ArrayOfMethodHandle = ArrayType(ObjectType.MethodHandle)
 
-    private[br] final val LowestPredefinedTypId = ArrayOfMethodHandle.id
+    private[br] final val LowestPredefinedTypeId = nextId.get() + 1
 }
 
 /**

--- a/OPAL/br/src/test/scala/org/opalj/br/ClassFileTest.scala
+++ b/OPAL/br/src/test/scala/org/opalj/br/ClassFileTest.scala
@@ -18,10 +18,10 @@ class ClassFileTest extends AnyFunSuite with Matchers {
 
     import reader.Java8Framework.ClassFile
 
-    val codeJARFile = locateTestResources("code.jar", "bi")
-    val immutableList = ClassFile(codeJARFile, "code/ImmutableList.class").head
-    val boundedBuffer = ClassFile(codeJARFile, "code/BoundedBuffer.class").head
-    val quicksort = ClassFile(codeJARFile, "code/Quicksort.class").head
+    lazy val codeJARFile = locateTestResources("code.jar", "bi")
+    lazy val immutableList = ClassFile(codeJARFile, "code/ImmutableList.class").head
+    lazy val boundedBuffer = ClassFile(codeJARFile, "code/BoundedBuffer.class").head
+    lazy val quicksort = ClassFile(codeJARFile, "code/Quicksort.class").head
 
     test("test that it can find the first constructor") {
         assert(
@@ -99,10 +99,10 @@ class ClassFileTest extends AnyFunSuite with Matchers {
         boundedBuffer.findField("AnumberInBuffers") should be(List.empty)
     }
 
-    val innerclassesProject = TestSupport.biProject("innerclasses-1.8-g-parameters-genericsignature.jar")
-    val outerClass = innerclassesProject.classFile(ObjectType("innerclasses/MyRootClass")).get
-    val innerPrinterOfXClass = innerclassesProject.classFile(ObjectType("innerclasses/MyRootClass$InnerPrinterOfX")).get
-    val formatterClass = innerclassesProject.classFile(ObjectType("innerclasses/MyRootClass$Formatter")).get
+    lazy val innerclassesProject = TestSupport.biProject("innerclasses-1.8-g-parameters-genericsignature.jar")
+    lazy val outerClass = innerclassesProject.classFile(ObjectType("innerclasses/MyRootClass")).get
+    lazy val innerPrinterOfXClass = innerclassesProject.classFile(ObjectType("innerclasses/MyRootClass$InnerPrinterOfX")).get
+    lazy val formatterClass = innerclassesProject.classFile(ObjectType("innerclasses/MyRootClass$Formatter")).get
 
     test("that all direct nested classes of a top-level class are correctly identified") {
         outerClass.nestedClasses(innerclassesProject).toSet should be(Set(

--- a/OPAL/br/src/test/scala/org/opalj/br/TypeTest.scala
+++ b/OPAL/br/src/test/scala/org/opalj/br/TypeTest.scala
@@ -24,31 +24,31 @@ class TypeTest extends AnyFunSpec {
         it("should remove all non-predefined types on flush") {
 
             ObjectType.flushTypeCache()
-            assert(ObjectType.objectTypesCount == ObjectType.HighestPredefinedTypId + 1)
+            assert(ObjectType.objectTypesCount == ObjectType.HighestPredefinedTypeId + 1)
 
             // Create 100 dummy OTs and assert their ID assignment is correct
             for(i <- 1 to 100){
                 val t = ObjectType(s"some/type/name$i")
-                assert(t.id == ObjectType.HighestPredefinedTypId + i, "invalid id for newly constructed type")
+                assert(t.id == ObjectType.HighestPredefinedTypeId + i, "invalid id for newly constructed type")
             }
 
             // Check that highest OT ID is in fact present and can be looked up
             try {
-                ObjectType.lookup(ObjectType.HighestPredefinedTypId + 99)
+                ObjectType.lookup(ObjectType.HighestPredefinedTypeId + 99)
             } catch {
-                case _: Exception => fail(s"defined type with id ${ObjectType.HighestPredefinedTypId + 99} was not found in cache")
+                case _: Exception => fail(s"defined type with id ${ObjectType.HighestPredefinedTypeId + 99} was not found in cache")
             }
 
             // Flush OT cache and assert ID counter is reset
             ObjectType.flushTypeCache()
-            assert(ObjectType.objectTypesCount == ObjectType.HighestPredefinedTypId + 1)
+            assert(ObjectType.objectTypesCount == ObjectType.HighestPredefinedTypeId + 1)
 
             // Assert ID was properly reset and new OTs are assigned an id starting from the predefined types
             val newType = ObjectType("some/other/type")
-            assert(newType.id == ObjectType.HighestPredefinedTypId + 1, "invalid id for newly constructed type after flush")
+            assert(newType.id == ObjectType.HighestPredefinedTypeId + 1, "invalid id for newly constructed type after flush")
 
             // Assert pre-flush IDs are no longer valid
-            assertThrows[IllegalArgumentException](ObjectType.lookup(ObjectType.HighestPredefinedTypId + 99))
+            assertThrows[IllegalArgumentException](ObjectType.lookup(ObjectType.HighestPredefinedTypeId + 99))
         }
 
         it("should not remove predefined types on flush"){
@@ -58,7 +58,7 @@ class TypeTest extends AnyFunSpec {
             val obj = ObjectType.lookup(ObjectType.ObjectId)
             assert(obj.fqn.equals("java/lang/Object"))
 
-            val oop = ObjectType.lookup(ObjectType.HighestPredefinedTypId)
+            val oop = ObjectType.lookup(ObjectType.HighestPredefinedTypeId)
             assert(oop.fqn.equals("java/io/ObjectOutputStream"))
         }
     }
@@ -70,25 +70,25 @@ class TypeTest extends AnyFunSpec {
             // Create dummy ATs and assert their IDs are correct
             // Note: Use dimensions = 1 here, otherwise the apply function will internally create more ATs
             val objAT = ArrayType(1, ObjectType("some/type/name"))
-            assert(objAT.id == ArrayType.LowestPredefinedTypId - 1)
+            assert(objAT.id == ArrayType.LowestPredefinedTypeId - 1)
 
             val intAT = ArrayType(1, ObjectType.Integer)
-            assert(intAT.id == ArrayType.LowestPredefinedTypId - 2)
+            assert(intAT.id == ArrayType.LowestPredefinedTypeId - 2)
 
             // Check that highest AT ID is in fact present and can be looked up
-            try { ArrayType.lookup(ArrayType.LowestPredefinedTypId - 2) }
+            try { ArrayType.lookup(ArrayType.LowestPredefinedTypeId - 2) }
             catch { case _: Exception =>
-                fail(s"defined AT with id ${ ArrayType.LowestPredefinedTypId - 2 } was not found in cache")}
+                fail(s"defined AT with id ${ ArrayType.LowestPredefinedTypeId - 2 } was not found in cache")}
 
             // Flush AT Cache
             ArrayType.flushTypeCache()
 
             // Assert ID was properly reset and new ATs are assigned an id starting from the predefined types
             val newAT = ArrayType(1, ObjectType("some/other/name"))
-            assert(newAT.id == ArrayType.LowestPredefinedTypId - 1)
+            assert(newAT.id == ArrayType.LowestPredefinedTypeId - 1)
 
             // Assert pre-flush IDs are no longer valid
-            assertThrows[IllegalArgumentException](ArrayType.lookup(ArrayType.LowestPredefinedTypId - 2))
+            assertThrows[IllegalArgumentException](ArrayType.lookup(ArrayType.LowestPredefinedTypeId - 2))
         }
         it("should not remove predefined types on flush"){
             ArrayType.flushTypeCache()

--- a/OPAL/br/src/test/scala/org/opalj/br/TypeTest.scala
+++ b/OPAL/br/src/test/scala/org/opalj/br/TypeTest.scala
@@ -46,8 +46,10 @@ class TypeTest extends AnyFunSpec {
 
             // Assert ID was properly reset and new OTs are assigned an id starting from the predefined types
             val newType = ObjectType("some/other/type")
-            assert(newType.id == ObjectType.highestPredefinedTypeId + 1,
-                "invalid id for newly constructed type after flush")
+            assert(
+                newType.id == ObjectType.highestPredefinedTypeId + 1,
+                "invalid id for newly constructed type after flush"
+            )
 
             // Assert pre-flush IDs are no longer valid
             assertThrows[IllegalArgumentException](ObjectType.lookup(ObjectType.highestPredefinedTypeId + 99))

--- a/OPAL/br/src/test/scala/org/opalj/br/TypeTest.scala
+++ b/OPAL/br/src/test/scala/org/opalj/br/TypeTest.scala
@@ -27,7 +27,7 @@ class TypeTest extends AnyFunSpec {
             assert(ObjectType.objectTypesCount == ObjectType.HighestPredefinedTypeId + 1)
 
             // Create 100 dummy OTs and assert their ID assignment is correct
-            for(i <- 1 to 100){
+            for (i <- 1 to 100) {
                 val t = ObjectType(s"some/type/name$i")
                 assert(t.id == ObjectType.HighestPredefinedTypeId + i, "invalid id for newly constructed type")
             }
@@ -36,7 +36,8 @@ class TypeTest extends AnyFunSpec {
             try {
                 ObjectType.lookup(ObjectType.HighestPredefinedTypeId + 99)
             } catch {
-                case _: Exception => fail(s"defined type with id ${ObjectType.HighestPredefinedTypeId + 99} was not found in cache")
+                case _: Exception =>
+                    fail(s"defined type with id ${ObjectType.HighestPredefinedTypeId + 99} was not found in cache")
             }
 
             // Flush OT cache and assert ID counter is reset
@@ -45,13 +46,14 @@ class TypeTest extends AnyFunSpec {
 
             // Assert ID was properly reset and new OTs are assigned an id starting from the predefined types
             val newType = ObjectType("some/other/type")
-            assert(newType.id == ObjectType.HighestPredefinedTypeId + 1, "invalid id for newly constructed type after flush")
+            assert(newType.id == ObjectType.HighestPredefinedTypeId + 1,
+                "invalid id for newly constructed type after flush")
 
             // Assert pre-flush IDs are no longer valid
             assertThrows[IllegalArgumentException](ObjectType.lookup(ObjectType.HighestPredefinedTypeId + 99))
         }
 
-        it("should not remove predefined types on flush"){
+        it("should not remove predefined types on flush") {
             ObjectType.flushTypeCache()
 
             // Check that first and last predefined OT are still present after flush
@@ -77,8 +79,10 @@ class TypeTest extends AnyFunSpec {
 
             // Check that highest AT ID is in fact present and can be looked up
             try { ArrayType.lookup(ArrayType.LowestPredefinedTypeId - 2) }
-            catch { case _: Exception =>
-                fail(s"defined AT with id ${ ArrayType.LowestPredefinedTypeId - 2 } was not found in cache")}
+            catch {
+                case _: Exception =>
+                    fail(s"defined AT with id ${ArrayType.LowestPredefinedTypeId - 2} was not found in cache")
+            }
 
             // Flush AT Cache
             ArrayType.flushTypeCache()
@@ -90,7 +94,7 @@ class TypeTest extends AnyFunSpec {
             // Assert pre-flush IDs are no longer valid
             assertThrows[IllegalArgumentException](ArrayType.lookup(ArrayType.LowestPredefinedTypeId - 2))
         }
-        it("should not remove predefined types on flush"){
+        it("should not remove predefined types on flush") {
             ArrayType.flushTypeCache()
 
             // Check that both predefined ATs are still present after flush

--- a/OPAL/br/src/test/scala/org/opalj/br/TypeTest.scala
+++ b/OPAL/br/src/test/scala/org/opalj/br/TypeTest.scala
@@ -24,33 +24,33 @@ class TypeTest extends AnyFunSpec {
         it("should remove all non-predefined types on flush") {
 
             ObjectType.flushTypeCache()
-            assert(ObjectType.objectTypesCount == ObjectType.HighestPredefinedTypeId + 1)
+            assert(ObjectType.objectTypesCount == ObjectType.highestPredefinedTypeId + 1)
 
             // Create 100 dummy OTs and assert their ID assignment is correct
             for (i <- 1 to 100) {
                 val t = ObjectType(s"some/type/name$i")
-                assert(t.id == ObjectType.HighestPredefinedTypeId + i, "invalid id for newly constructed type")
+                assert(t.id == ObjectType.highestPredefinedTypeId + i, "invalid id for newly constructed type")
             }
 
             // Check that highest OT ID is in fact present and can be looked up
             try {
-                ObjectType.lookup(ObjectType.HighestPredefinedTypeId + 99)
+                ObjectType.lookup(ObjectType.highestPredefinedTypeId + 99)
             } catch {
                 case _: Exception =>
-                    fail(s"defined type with id ${ObjectType.HighestPredefinedTypeId + 99} was not found in cache")
+                    fail(s"defined type with id ${ObjectType.highestPredefinedTypeId + 99} was not found in cache")
             }
 
             // Flush OT cache and assert ID counter is reset
             ObjectType.flushTypeCache()
-            assert(ObjectType.objectTypesCount == ObjectType.HighestPredefinedTypeId + 1)
+            assert(ObjectType.objectTypesCount == ObjectType.highestPredefinedTypeId + 1)
 
             // Assert ID was properly reset and new OTs are assigned an id starting from the predefined types
             val newType = ObjectType("some/other/type")
-            assert(newType.id == ObjectType.HighestPredefinedTypeId + 1,
+            assert(newType.id == ObjectType.highestPredefinedTypeId + 1,
                 "invalid id for newly constructed type after flush")
 
             // Assert pre-flush IDs are no longer valid
-            assertThrows[IllegalArgumentException](ObjectType.lookup(ObjectType.HighestPredefinedTypeId + 99))
+            assertThrows[IllegalArgumentException](ObjectType.lookup(ObjectType.highestPredefinedTypeId + 99))
         }
 
         it("should not remove predefined types on flush") {
@@ -60,8 +60,8 @@ class TypeTest extends AnyFunSpec {
             val obj = ObjectType.lookup(ObjectType.ObjectId)
             assert(obj.fqn.equals("java/lang/Object"))
 
-            val oop = ObjectType.lookup(ObjectType.HighestPredefinedTypeId)
-            assert(oop.fqn.equals("java/io/ObjectOutputStream"))
+            val oos = ObjectType.lookup(ObjectType.highestPredefinedTypeId)
+            assert(oos.fqn.equals("java/io/ObjectOutputStream"))
         }
     }
 
@@ -72,16 +72,16 @@ class TypeTest extends AnyFunSpec {
             // Create dummy ATs and assert their IDs are correct
             // Note: Use dimensions = 1 here, otherwise the apply function will internally create more ATs
             val objAT = ArrayType(1, ObjectType("some/type/name"))
-            assert(objAT.id == ArrayType.LowestPredefinedTypeId - 1)
+            assert(objAT.id == ArrayType.lowestPredefinedTypeId - 1)
 
             val intAT = ArrayType(1, ObjectType.Integer)
-            assert(intAT.id == ArrayType.LowestPredefinedTypeId - 2)
+            assert(intAT.id == ArrayType.lowestPredefinedTypeId - 2)
 
             // Check that highest AT ID is in fact present and can be looked up
-            try { ArrayType.lookup(ArrayType.LowestPredefinedTypeId - 2) }
+            try { ArrayType.lookup(ArrayType.lowestPredefinedTypeId - 2) }
             catch {
                 case _: Exception =>
-                    fail(s"defined AT with id ${ArrayType.LowestPredefinedTypeId - 2} was not found in cache")
+                    fail(s"defined AT with id ${ArrayType.lowestPredefinedTypeId - 2} was not found in cache")
             }
 
             // Flush AT Cache
@@ -89,10 +89,10 @@ class TypeTest extends AnyFunSpec {
 
             // Assert ID was properly reset and new ATs are assigned an id starting from the predefined types
             val newAT = ArrayType(1, ObjectType("some/other/name"))
-            assert(newAT.id == ArrayType.LowestPredefinedTypeId - 1)
+            assert(newAT.id == ArrayType.lowestPredefinedTypeId - 1)
 
             // Assert pre-flush IDs are no longer valid
-            assertThrows[IllegalArgumentException](ArrayType.lookup(ArrayType.LowestPredefinedTypeId - 2))
+            assertThrows[IllegalArgumentException](ArrayType.lookup(ArrayType.lowestPredefinedTypeId - 2))
         }
         it("should not remove predefined types on flush") {
             ArrayType.flushTypeCache()

--- a/OPAL/br/src/test/scala/org/opalj/br/TypeTest.scala
+++ b/OPAL/br/src/test/scala/org/opalj/br/TypeTest.scala
@@ -20,4 +20,85 @@ class TypeTest extends AnyFunSpec {
         }
     }
 
+    describe("ObjectType") {
+        it("should remove all non-predefined types on flush") {
+
+            ObjectType.flushTypeCache()
+            assert(ObjectType.objectTypesCount == ObjectType.HighestPredefinedTypId + 1)
+
+            // Create 100 dummy OTs and assert their ID assignment is correct
+            for(i <- 1 to 100){
+                val t = ObjectType(s"some/type/name$i")
+                assert(t.id == ObjectType.HighestPredefinedTypId + i, "invalid id for newly constructed type")
+            }
+
+            // Check that highest OT ID is in fact present and can be looked up
+            try {
+                ObjectType.lookup(ObjectType.HighestPredefinedTypId + 99)
+            } catch {
+                case _: Exception => fail(s"defined type with id ${ObjectType.HighestPredefinedTypId + 99} was not found in cache")
+            }
+
+            // Flush OT cache and assert ID counter is reset
+            ObjectType.flushTypeCache()
+            assert(ObjectType.objectTypesCount == ObjectType.HighestPredefinedTypId + 1)
+
+            // Assert ID was properly reset and new OTs are assigned an id starting from the predefined types
+            val newType = ObjectType("some/other/type")
+            assert(newType.id == ObjectType.HighestPredefinedTypId + 1, "invalid id for newly constructed type after flush")
+
+            // Assert pre-flush IDs are no longer valid
+            assertThrows[IllegalArgumentException](ObjectType.lookup(ObjectType.HighestPredefinedTypId + 99))
+        }
+
+        it("should not remove predefined types on flush"){
+            ObjectType.flushTypeCache()
+
+            // Check that first and last predefined OT are still present after flush
+            val obj = ObjectType.lookup(ObjectType.ObjectId)
+            assert(obj.fqn.equals("java/lang/Object"))
+
+            val oop = ObjectType.lookup(ObjectType.HighestPredefinedTypId)
+            assert(oop.fqn.equals("java/io/ObjectOutputStream"))
+        }
+    }
+
+    describe("ArrayType") {
+        it("should remove all non-predefined types on flush") {
+            ArrayType.flushTypeCache()
+
+            // Create dummy ATs and assert their IDs are correct
+            // Note: Use dimensions = 1 here, otherwise the apply function will internally create more ATs
+            val objAT = ArrayType(1, ObjectType("some/type/name"))
+            assert(objAT.id == ArrayType.LowestPredefinedTypId - 1)
+
+            val intAT = ArrayType(1, ObjectType.Integer)
+            assert(intAT.id == ArrayType.LowestPredefinedTypId - 2)
+
+            // Check that highest AT ID is in fact present and can be looked up
+            try { ArrayType.lookup(ArrayType.LowestPredefinedTypId - 2) }
+            catch { case _: Exception =>
+                fail(s"defined AT with id ${ ArrayType.LowestPredefinedTypId - 2 } was not found in cache")}
+
+            // Flush AT Cache
+            ArrayType.flushTypeCache()
+
+            // Assert ID was properly reset and new ATs are assigned an id starting from the predefined types
+            val newAT = ArrayType(1, ObjectType("some/other/name"))
+            assert(newAT.id == ArrayType.LowestPredefinedTypId - 1)
+
+            // Assert pre-flush IDs are no longer valid
+            assertThrows[IllegalArgumentException](ArrayType.lookup(ArrayType.LowestPredefinedTypId - 2))
+        }
+        it("should not remove predefined types on flush"){
+            ArrayType.flushTypeCache()
+
+            // Check that both predefined ATs are still present after flush
+            val objAT = ArrayType.lookup(-1)
+            assert(objAT.dimensions == 1 && objAT.componentType.equals(ObjectType.Object))
+            val mhAT = ArrayType.lookup(-2)
+            assert(mhAT.dimensions == 1 && mhAT.componentType.equals(ObjectType.MethodHandle))
+        }
+    }
+
 }


### PR DESCRIPTION
**Reason for this PR**
As described in `org.opalj.br.Type:1059` (see [here on develop](https://github.com/opalj/opal/blob/6b89b9d4b9994a8845541fe35015cf8da707f91b/OPAL/br/src/main/scala/org/opalj/br/Type.scala#L1059)), the static caches for objects of type `ObjectType` and `ArrayType` will grow continuously when creating multiple `Project` instances in a row. This is a problem when processing a large number of JAR files, as it will eventually consume all memory and cause the JVM to crash.

**Changes in this PR**
This PR introduces the two methods `ObjectType.flushTypeCache()` and `ArrayType.flushTypeCache()`, which both flush the respective caches. The methods will not flush predefined instances of `ObjectType`s and `ArrayType`s, as those are referenced via final vals. Invalidating those would negate any speedup that they originally achieved.

Obviously those methods can only be safely used when invoked after all analyses for one project are done, and before another one is created. 

This PR also introduces test case to assert that:
* All non-predefined types are in fact removed
* No predefined types are removed


This is my first contribution to OPAL, please let me know if there's anything you'd like me to change 😃 