### PR TITLE
Disable another transformation for NoTransformations.conf

### DIFF
--- a/OPAL/framework/src/main/resources/NoTransformations.conf
+++ b/OPAL/framework/src/main/resources/NoTransformations.conf
@@ -7,5 +7,8 @@
         Invokedynamic {
             rewrite=false
         }
+        DynamicConstants {
+            rewrite=false
+        }
     }
 }


### PR DESCRIPTION
NoTransformations.conf is meant to keep the bytecode in the original format, so we should disable the recent rewriting of dynamic constants too.