### PR TITLE
JavaScript-Aware Taint Analysis

### DIFF
--- a/DEVELOPING_OPAL/validate/src/test/java/org/opalj/fpcf/fixtures/js/Java2JsTestClass.java
+++ b/DEVELOPING_OPAL/validate/src/test/java/org/opalj/fpcf/fixtures/js/Java2JsTestClass.java
@@ -1,0 +1,345 @@
+package org.opalj.fpcf.fixtures.js;
+
+import org.opalj.fpcf.properties.taint.ForwardFlowPath;
+
+import javax.script.*;
+
+public class Java2JsTestClass {
+    /* Test flows through Javascript. */
+
+    @ForwardFlowPath({"flowThroughJS"})
+    public static void flowThroughJS() throws ScriptException
+    {
+        ScriptEngineManager sem = new ScriptEngineManager();
+        ScriptEngine se = sem.getEngineByName("JavaScript");
+        String pw = source();
+
+        se.put("secret", pw);
+        se.eval("var x = 42;");
+        String fromJS = (String) se.get("secret");
+        sink(fromJS);
+    }
+
+    @ForwardFlowPath({})
+    public static void jsOverwritesBinding() throws ScriptException
+    {
+        ScriptEngineManager sem = new ScriptEngineManager();
+        ScriptEngine se = sem.getEngineByName("JavaScript");
+        String pw = source();
+
+        se.put("secret", pw);
+        se.eval("secret = \"42\";");
+        String fromJS = (String) se.get("secret");
+        sink(fromJS);
+    }
+
+    @ForwardFlowPath({"flowInsideJS"})
+    public static void flowInsideJS() throws ScriptException
+    {
+        ScriptEngineManager sem = new ScriptEngineManager();
+        ScriptEngine se = sem.getEngineByName("JavaScript");
+        String pw = source();
+
+        se.put("secret", pw);
+        se.eval("var xxx = secret;");
+        String fromJS = (String) se.get("xxx");
+        sink(fromJS);
+    }
+
+    @ForwardFlowPath({"flowInsideJS2"})
+    public static void flowInsideJS2() throws ScriptException
+    {
+        ScriptEngineManager sem = new ScriptEngineManager();
+        ScriptEngine se = sem.getEngineByName("JavaScript");
+        String pw = source();
+
+        se.put("secret", pw);
+        se.eval("var xxx = secret;" +
+                "var yyy = xxx;");
+        String fromJS = (String) se.get("yyy");
+        sink(fromJS);
+    }
+
+    @ForwardFlowPath({})
+    public static void flowInsideJSLateOverwrite() throws ScriptException
+    {
+        ScriptEngineManager sem = new ScriptEngineManager();
+        ScriptEngine se = sem.getEngineByName("JavaScript");
+        String pw = source();
+
+        se.put("secret", pw);
+        se.eval("var xxx = secret;" +
+                "var xxx = 42;");
+        String fromJS = (String) se.get("yyy");
+        sink(fromJS);
+    }
+
+    @ForwardFlowPath({"jsInvokeIdentity"})
+    public static void jsInvokeIdentity() throws ScriptException, NoSuchMethodException
+    {
+        ScriptEngineManager sem = new ScriptEngineManager();
+        ScriptEngine se = sem.getEngineByName("JavaScript");
+        String pw = source();
+
+        se.eval("function id(x) { return x; }");
+        String fromJS = (String) ((Invocable) se).invokeFunction("id", pw);
+        sink(fromJS);
+    }
+
+    @ForwardFlowPath({})
+    public static void jsInvokeOverwrite() throws ScriptException, NoSuchMethodException
+    {
+        ScriptEngineManager sem = new ScriptEngineManager();
+        ScriptEngine se = sem.getEngineByName("JavaScript");
+        String pw = source();
+
+        se.eval("function overwrite(x) { return \"42\"; }");
+        String fromJS = (String) ((Invocable) se).invokeFunction("id", pw);
+        sink(fromJS);
+    }
+
+    @ForwardFlowPath({"jsInvokeWithComputation"})
+    public static void jsInvokeWithComputation() throws ScriptException, NoSuchMethodException
+    {
+        ScriptEngineManager sem = new ScriptEngineManager();
+        ScriptEngine se = sem.getEngineByName("JavaScript");
+        se.eval("function check(str) {\n" +
+                "    return str === \"1337\";\n" +
+                "}");
+
+        String pw = source();
+
+        Invocable inv = (Invocable) se;
+        Boolean state = (Boolean) inv.invokeFunction("check", pw);
+        sink(state);
+    }
+
+    @ForwardFlowPath({})
+    public static void jsUnusedTaintedParameter() throws ScriptException, NoSuchMethodException
+    {
+        ScriptEngineManager sem = new ScriptEngineManager();
+        ScriptEngine se = sem.getEngineByName("JavaScript");
+        se.eval("function check(str, unused) {\n" +
+                "    return str === \"1337\";\n" +
+                "}");
+
+        String pw = source();
+        Invocable inv = (Invocable) se;
+        Boolean state = (Boolean) inv.invokeFunction("check", "1337", pw);
+        sink(state);
+    }
+
+    /* More advanced flows. */
+
+    @ForwardFlowPath({"jsInterproceduralFlow"})
+    public static void jsInterproceduralFlow() throws ScriptException, NoSuchMethodException
+    {
+        ScriptEngineManager sem = new ScriptEngineManager();
+        ScriptEngine se = sem.getEngineByName("JavaScript");
+
+        se.eval("function add42(x) {" +
+                "    return x + 42;" +
+                "}" +
+                "function id(x) {" +
+                "    return x;" +
+                "}" +
+                "function check(str) {\n" +
+                "    return id(add42(str)) === id(\"1337\");\n" +
+                "}");
+        String pw = source();
+        Invocable inv = (Invocable) se;
+        Boolean state = (Boolean) inv.invokeFunction("check", pw);
+        sink(state);
+    }
+
+    @ForwardFlowPath({"jsFunctionFlow"})
+    public static void jsFunctionFlow() throws ScriptException, NoSuchMethodException
+    {
+        ScriptEngineManager sem = new ScriptEngineManager();
+        ScriptEngine se = sem.getEngineByName("JavaScript");
+
+        se.eval("function myfun(x) {\n" +
+                "    var xxx = x;\n" +
+                "    return xxx;\n" +
+                "}\n");
+        String pw = source();
+        Invocable inv = (Invocable) se;
+        String value = (String) inv.invokeFunction("myfun", pw);
+        sink(value);
+    }
+
+    /* Test flows through ScriptEngine objects. */
+
+    @ForwardFlowPath({"simplePutGet"})
+    public static void simplePutGet() throws ScriptException
+    {
+        ScriptEngineManager sem = new ScriptEngineManager();
+        ScriptEngine se = sem.getEngineByName("JavaScript");
+
+        String pw = source();
+        se.put("secret", pw);
+        Object out = se.get("secret");
+        sink(out);
+    }
+
+    @ForwardFlowPath({"overapproxPutGet"})
+    public static void overapproxPutGet() throws ScriptException
+    {
+        ScriptEngineManager sem = new ScriptEngineManager();
+        ScriptEngine se = sem.getEngineByName("JavaScript");
+
+        String pw = source();
+        // String is no constant
+        se.put(Integer.toString(1337), pw);
+        // Because the .put had no constant string, we do not know the key here
+        // and taint the return as an over-approximation.
+        Object out = se.get("secret");
+        sink(out);
+    }
+
+    @ForwardFlowPath({})
+    public static void overwritePutGet() throws ScriptException
+    {
+        ScriptEngineManager sem = new ScriptEngineManager();
+        ScriptEngine se = sem.getEngineByName("JavaScript");
+
+        String pw = source();
+        // String is no constant
+        se.put("secret", pw);
+        se.put("secret", "Const");
+        Object out = se.get("secret");
+        sink(out);
+    }
+
+    @ForwardFlowPath({"bindingsSimplePutGet"})
+    public static void bindingsSimplePutGet() throws ScriptException
+    {
+        ScriptEngineManager sem = new ScriptEngineManager();
+        ScriptEngine se = sem.getEngineByName("JavaScript");
+        Bindings b = se.createBindings();
+
+        String pw = source();
+        se.put("secret", pw);
+        Object out = se.get("secret");
+        sink(out);
+    }
+
+    @ForwardFlowPath({"bindingsOverapproxPutGet"})
+    public static void bindingsOverapproxPutGet() throws ScriptException
+    {
+        ScriptEngineManager sem = new ScriptEngineManager();
+        ScriptEngine se = sem.getEngineByName("JavaScript");
+        Bindings b = se.createBindings();
+
+        String pw = source();
+        // String is no constant
+        se.put(Integer.toString(1337), pw);
+        // Because the .put had no constant string, we do not know the key here
+        // and taint the return as an over-approximation.
+        Object out = se.get("secret");
+        sink(out);
+    }
+
+    @ForwardFlowPath({})
+    public static void BindingsOverwritePutGet() throws ScriptException
+    {
+        ScriptEngineManager sem = new ScriptEngineManager();
+        ScriptEngine se = sem.getEngineByName("JavaScript");
+        Bindings b = se.createBindings();
+
+        String pw = source();
+        se.put("secret", pw);
+        se.put("secret", "Const");
+        Object out = se.get("secret");
+        sink(out);
+    }
+
+    @ForwardFlowPath({})
+    public static void bindingsPutRemoveGet() throws ScriptException
+    {
+        ScriptEngineManager sem = new ScriptEngineManager();
+        ScriptEngine se = sem.getEngineByName("JavaScript");
+        Bindings b = se.createBindings();
+
+        String pw = source();
+        b.put("secret", pw);
+        b.remove("secret");
+        Object out = b.get("secret");
+        sink(out);
+    }
+
+    @ForwardFlowPath({})
+    public static void overwritePutRemoveGet() throws ScriptException
+    {
+        ScriptEngineManager sem = new ScriptEngineManager();
+        ScriptEngine se = sem.getEngineByName("JavaScript");
+        Bindings b = se.createBindings();
+
+        String pw = source();
+        b.put("secret", pw);
+        b.remove("secret");
+        Object out = b.get("secret");
+        sink(out);
+    }
+
+    @ForwardFlowPath({"bindingsPutAll"})
+    public static void bindingsPutAll() throws ScriptException
+    {
+        ScriptEngineManager sem = new ScriptEngineManager();
+        ScriptEngine se = sem.getEngineByName("JavaScript");
+        Bindings b = se.createBindings();
+
+        String pw = source();
+        b.put("secret", pw);
+        Bindings newb = se.createBindings();
+        newb.putAll(b);
+        Object out = newb.get("secret");
+        sink(out);
+    }
+
+    @ForwardFlowPath({"interproceduralPutGet"})
+    public static void interproceduralPutGet() throws ScriptException
+    {
+        ScriptEngineManager sem = new ScriptEngineManager();
+        ScriptEngine se = sem.getEngineByName("JavaScript");
+
+        String pw = source();
+        se.put("secret", pw);
+        id (se);
+        Object out = se.get("secret");
+        sink(out);
+    }
+
+    @ForwardFlowPath({})
+    public static void interproceduralOverwrite() throws ScriptException
+    {
+        ScriptEngineManager sem = new ScriptEngineManager();
+        ScriptEngine se = sem.getEngineByName("JavaScript");
+
+        String pw = source();
+        se.put("secret", pw);
+        removeSecret (se);
+        Object out = se.get("secret");
+        sink(out);
+    }
+
+    public static Object id(Object obj) {
+        return obj;
+    }
+
+    public static void removeSecret(ScriptEngine se) {
+        se.put("secret", 42);
+    }
+
+    public static String source() {
+        return "1337";
+    }
+
+    private static void sink(String i) {
+        System.out.println(i);
+    }
+
+    private static void sink(Object i) {
+        System.out.println(i);
+    }
+}

--- a/DEVELOPING_OPAL/validate/src/test/java/org/opalj/fpcf/fixtures/taint/TaintAnalysisTestClass.java
+++ b/DEVELOPING_OPAL/validate/src/test/java/org/opalj/fpcf/fixtures/taint/TaintAnalysisTestClass.java
@@ -301,6 +301,48 @@ public class TaintAnalysisTestClass {
         sink(wrapper.field + 1);
     }
 
+    @ForwardFlowPath({})
+    @BackwardFlowPath({})
+    public void staticCalleeOverwritesTaint() {
+        Wrapper wrapper = new Wrapper(source());
+        overwriteField(wrapper);
+        sink(wrapper.field);
+    }
+
+    @ForwardFlowPath({})
+    @BackwardFlowPath({})
+    public void calleeOverwritesItsOwnField() {
+        Wrapper wrapper = new Wrapper(source());
+        wrapper.overwrite();
+        sink(wrapper.field);
+    }
+
+    // TODO: misses that the parameter and this aliases
+//    @ForwardFlowPath({})
+//    @BackwardFlowPath({})
+//    public void instanceCalleeOverwritesTaint() {
+//        Wrapper wrapper = new Wrapper(source());
+//        wrapper.overwriteArg(wrapper);
+//        sink(wrapper.field);
+//    }
+
+    @ForwardFlowPath({})
+    @BackwardFlowPath({})
+    public void calleeOverwritesStaticFieldTaint() {
+        staticField = source();
+        overwriteStaticField();
+        sink(staticField);
+    }
+
+    @ForwardFlowPath({})
+    @BackwardFlowPath({})
+    public void taintPartOfArrayOverwrite() {
+        int[] arr = new int[1];
+        arr[0] = source();
+        overwriteFirstArrayElement(arr);
+        sink(staticField);
+    }
+
     //TODO Tests für statische Felder über Methodengrenzen
 
     //Does not work, because we do not know which exceptions cannot be thrown.
@@ -324,6 +366,13 @@ public class TaintAnalysisTestClass {
             arr[i] = source();
         }
     }*/
+
+    /* Tests using summaries. */
+    @ForwardFlowPath({"flowWithSummary"})
+    public static void flowWithSummary() {
+        Integer i = Integer.valueOf(source());
+        sink(i.intValue());
+    }
 
     public int callSourcePublic() {
         return source();
@@ -378,12 +427,25 @@ public class TaintAnalysisTestClass {
         return 1;
     }
 
-    private static int sanitize(int i) {return i;}
+    private static int sanitize(int i) {return 42;}
+    private static void overwriteField(Wrapper wrapper) {
+        wrapper.field = 42;
+    }
+
+    private static void overwriteStaticField() {
+        staticField = 42;
+    }
+
+    private static void overwriteFirstArrayElement(int[] arr) {
+        arr[0] = 42;
+    }
 
     private static void sink(int i) {
         System.out.println(i);
     }
-
+    private static void sink(String s) {
+        System.out.println(s);
+    }
 }
 
 abstract class A {
@@ -413,5 +475,13 @@ class Wrapper {
 
     Wrapper(int field) {
         this.field = field;
+    }
+
+    public void overwrite() {
+        this.field = 42;
+    }
+
+    public void overwriteArg(Wrapper wrapper) {
+        wrapper.field = 42;
     }
 }

--- a/DEVELOPING_OPAL/validate/src/test/scala/org/opalj/fpcf/PropertiesTest.scala
+++ b/DEVELOPING_OPAL/validate/src/test/scala/org/opalj/fpcf/PropertiesTest.scala
@@ -4,19 +4,16 @@ package fpcf
 
 import java.io.File
 import java.net.URL
-
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigValueFactory
-
 import org.opalj.bi.reader.ClassFileReader
+import org.opalj.bytecode.RTJar
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-
 import org.opalj.log.LogContext
 import org.opalj.util.ScalaMajorVersion
 import org.opalj.fpcf.properties.PropertyMatcher
 import org.opalj.fpcf.seq.PKESequentialPropertyStore
-import org.opalj.bytecode.RTJar
 import org.opalj.br.DefinedMethod
 import org.opalj.br.analyses.VirtualFormalParameter
 import org.opalj.br.analyses.VirtualFormalParametersKey

--- a/DEVELOPING_OPAL/validate/src/test/scala/org/opalj/fpcf/ifds/ForwardTaintAnalysisFixtureTest.scala
+++ b/DEVELOPING_OPAL/validate/src/test/scala/org/opalj/fpcf/ifds/ForwardTaintAnalysisFixtureTest.scala
@@ -16,6 +16,9 @@ import java.net.URL
  * @author Mario Trageser
  */
 class ForwardTaintAnalysisFixtureTest extends PropertiesTest {
+    override def fixtureProjectPackage: List[String] = List(
+        "org/opalj/fpcf/fixtures/taint"
+    )
 
     override def init(p: Project[URL]): Unit = {
         p.updateProjectInformationKeyInitializationData(

--- a/DEVELOPING_OPAL/validate/src/test/scala/org/opalj/js/JavaScriptAwareTaintProblemFixtureTest.scala
+++ b/DEVELOPING_OPAL/validate/src/test/scala/org/opalj/js/JavaScriptAwareTaintProblemFixtureTest.scala
@@ -1,0 +1,42 @@
+/* BSD 2-Clause License - see OPAL/LICENSE for details. */
+package org.opalj.js
+
+import org.opal.js.IFDSAnalysisJSFixtureScheduler
+import org.opalj.fpcf.PropertiesTest
+import org.opalj.ai.domain.l2
+import org.opalj.ai.fpcf.properties.AIDomainFactoryKey
+import org.opalj.br.analyses.Project
+import org.opalj.fpcf.properties.taint.ForwardFlowPath
+import org.opalj.tac.cg.RTACallGraphKey
+import org.opalj.tac.fpcf.analyses.ifds.taint.TaintNullFact
+
+import java.net.URL
+
+class JavaScriptAwareTaintProblemFixtureTest extends PropertiesTest {
+    override def fixtureProjectPackage: List[String] = List(
+        "org/opalj/fpcf/fixtures/js"
+    )
+
+    override def init(p: Project[URL]): Unit = {
+        p.updateProjectInformationKeyInitializationData(
+            AIDomainFactoryKey
+        )(
+            (_: Option[Set[Class[_ <: AnyRef]]]) =>
+                Set[Class[_ <: AnyRef]](
+                    classOf[l2.DefaultPerformInvocationsDomainWithCFGAndDefUse[URL]]
+                )
+        )
+        p.get(RTACallGraphKey)
+    }
+
+    describe("Test the ForwardFlowPath annotations") {
+        val testContext = executeAnalyses(IFDSAnalysisJSFixtureScheduler)
+        val project = testContext.project
+        val eas = methodsWithAnnotations(project).map {
+            case (method, entityString, annotations) =>
+                ((method, TaintNullFact), entityString, annotations)
+        }
+        testContext.propertyStore.shutdown()
+        validateProperties(testContext, eas, Set(ForwardFlowPath.PROPERTY_VALIDATOR_KEY))
+    }
+}

--- a/OPAL/ifds/src/main/scala/org/opalj/ifds/IFDSAnalysis.scala
+++ b/OPAL/ifds/src/main/scala/org/opalj/ifds/IFDSAnalysis.scala
@@ -158,6 +158,8 @@ class IFDSAnalysis[IFDSFact <: AbstractIFDSFact, C <: AnyRef, S <: Statement[_ <
     implicit var statistics = new Statistics
     val icfg = ifdsProblem.icfg
 
+    val DEBUG = false
+
     /**
      * Performs an IFDS analysis for a method-fact-pair.
      *
@@ -372,7 +374,15 @@ class IFDSAnalysis[IFDSFact <: AbstractIFDSFact, C <: AnyRef, S <: Statement[_ <
      */
     private def normalFlow(statement: S, in: IFDSFact, predecessor: Option[S]): Set[IFDSFact] = {
         statistics.normalFlow += 1
-        addNullFactIfConfigured(in, ifdsProblem.normalFlow(statement, in, predecessor))
+        val out = ifdsProblem.normalFlow(statement, in, predecessor)
+        if (DEBUG) {
+            printf("Normal: %s\n", statement.toString)
+            printf("In: %s\n", in.toString)
+            printf("Out: [")
+            out.foreach(f => printf("%s, ", f.toString))
+            printf("]\n\n")
+        }
+        addNullFactIfConfigured(in, out)
     }
 
     /**
@@ -384,7 +394,15 @@ class IFDSAnalysis[IFDSFact <: AbstractIFDSFact, C <: AnyRef, S <: Statement[_ <
      */
     private def callFlow(call: S, callee: C, in: IFDSFact): Set[IFDSFact] = {
         statistics.callFlow += 1
-        addNullFactIfConfigured(in, ifdsProblem.callFlow(call, callee, in))
+        val out = ifdsProblem.callFlow(call, callee, in)
+        if (DEBUG) {
+            printf("Call: %s\n", call.toString)
+            printf("In: %s\n", in.toString)
+            printf("Out: [")
+            out.foreach(f => printf("%s, ", f.toString))
+            printf("]\n\n")
+        }
+        addNullFactIfConfigured(in, out)
     }
 
     /**
@@ -397,7 +415,15 @@ class IFDSAnalysis[IFDSFact <: AbstractIFDSFact, C <: AnyRef, S <: Statement[_ <
      */
     private def returnFlow(exit: S, in: IFDSFact, call: S, callFact: IFDSFact, successor: S): Set[IFDSFact] = {
         statistics.returnFlow += 1
-        addNullFactIfConfigured(in, ifdsProblem.returnFlow(exit, in, call, callFact, successor))
+        val out = ifdsProblem.returnFlow(exit, in, call, callFact, successor)
+        if (DEBUG) {
+            printf("Return: %s\n", call.toString)
+            printf("In: %s\n", in.toString)
+            printf("Out: [")
+            out.foreach(f => printf("%s, ", f.toString))
+            printf("]\n\n")
+        }
+        addNullFactIfConfigured(in, out)
     }
 
     /**
@@ -408,7 +434,15 @@ class IFDSAnalysis[IFDSFact <: AbstractIFDSFact, C <: AnyRef, S <: Statement[_ <
      */
     private def callToReturnFlow(call: S, in: IFDSFact, successor: S): Set[IFDSFact] = {
         statistics.callToReturnFlow += 1
-        addNullFactIfConfigured(in, ifdsProblem.callToReturnFlow(call, in, successor))
+        val out = ifdsProblem.callToReturnFlow(call, in, successor)
+        if (DEBUG) {
+            printf("CallToReturn: %s\n", call.toString)
+            printf("In: %s\n", in.toString)
+            printf("Out: [")
+            out.foreach(f => printf("%s, ", f.toString))
+            printf("]\n\n")
+        }
+        addNullFactIfConfigured(in, out)
     }
 
     private def addNullFactIfConfigured(in: IFDSFact, out: Set[IFDSFact]): Set[IFDSFact] = {

--- a/OPAL/js/Readme.md
+++ b/OPAL/js/Readme.md
@@ -1,0 +1,146 @@
+# JavaScript module
+This module provides an IFDS taint analysis that is aware of calls to `ScriptEngine` objects that evaluate JavaScript and models them by internally invoking another IFDS taint analysis running on the JavaScript code, handing back the results to the Java IFDS taint analysis.
+
+We identified four challenges:
+1. Finding the JavaScript source code which is executed on a call to a `ScriptEngine`.
+2. Tracking the taints inside the `ScriptEngine` object.
+3. Handing over the taints between two taint analyses across different static analysis frameworks without rewriting an analysis.
+4. Scalability in presence unboxing of primitive type wrappers.
+
+## 1. Finding the source code
+`org.opal.js.LocalJSSourceFinder` implements a way to find the JavaScript source code. The class uses the Def-Use information provided by *TACAI* to find the source code.
+
+There are two ways in how JavaScript is invoked from Java. First, `eval()` can be used to evaluate code using a `ScriptEngine`:
+```java
+ScriptEngineManager sem = new ScriptEngineManager();
+ScriptEngine se = sem.getEngineByName("JavaScript");
+se.eval("*** insert JavaScript code here ***");
+```
+If the argument to `eval` is a constant string, the source code is already known. The argument could also be a `FileReader` or `File`. In that case, the `LocalJSSourceFinder` looks up to find the definition of the `FileReader`/`File` and tries to get the file name.
+
+The other way is to call `invokeFunction(functionName, ...args)` on the `ScriptEngine` object. That case is a bit more complicated, because the source code of the function was provided with an earlier call to `eval()`. So here `LocalJSSourceFinder` goes up to the definition of the `ScriptEngine` and then looks for `eval()` calls on the definition.
+
+### Limitations
+The `LocalJSSourceFinder` is only able to find the source code intraprocedural, inherited from using the def-use chains.
+
+## 2. Tracking tainted JavaScript variables in Java
+A `ScriptEngine` also holds an environment called `Binding` that maps variables names to values. With `put(varName, obj)` data can be handed to JavaScript and with `get(varName)` can be retrieved back from JavaScript. Every variable in the `Binding` is available as a global variable in the execution of the JavaScript script. Thus, to precisely model what's happening in JavaScript, we need to know the JavaScript variables that are tainted at a call to `eval` or `invokeFunction`.
+
+In essence, the environment is just a `Map<String, Object>` for Java. To track the tainted keys inside the map, we do manually model the behavior of the `get`, `put`, `remove` and `putAll` methods called on a `ScriptEngine` or `Binding` instance. At each call to first three, the first argument represents the variable name. Again, we use the def-use chains from *TACAI* to find a string constant. We introduce a new taint type called `BindingFact`, which holds a variable, either of type `ScriptEngine` or `Binding` and the tainted key.
+
+### Design Decisions
+#### In case of a non-constant argument
+```java
+String var = getUserInput();
+se.put(var, "some value");
+```
+Whenever the analysis does not know the constant string value of the first argument to `put`, it does derive a wildcard fact. The analysis considers a wildcard fact as if all variables inside the environment are tainted.
+
+#### Killing taints
+```java
+          String var;
+               |
+     se.put("v1", secret);
+               |
+           if (cond)
+           /       \
+  var = "v1";     var = "v2";
+           \       /
+         se.remove(var);
+```
+In the example above, `v1` is tainted inside the environment. Later on, `var` is removed from the environment but the constant string depends on the control-flow so `var` is either `"v1"` or `"v2"`. Herre two analysis could do two things:
+
+1. Kill the `BindingFact(_, "v1")`, because `"v1"` might have been removed.
+2. Leave `BindingFact(_, "v1")` alive, because `"v2"` might have been removed.
+
+The analysis implements the second way. Having to decide in this case is just a limitation of our analysis not being path-sensitive.
+
+## 3. Gluing two analyses together
+The semantics of `eval` and `invokeFunction` can be modelled by transforming the JavaScript source code. For this, we introduce two functions: `opal_source()` and `opal_last_stmt(...)`. The first one is marked as a source in the JavaScript analysis and used to taint all global variables that were handed over from Java. The latter is, as the name suggest, the last statement and records all taints that reach the end of the execution. We do provide dummy implementations for both functions to work around the fact that WALAs Call Graph generation does eliminate call sites without a callee.
+
+We do exploit that the entry and exit points of JavaScript script are easy to find out: The script is executed from top to bottom. Thus, we do perform the transformation on the source code directly.
+
+We do inject four symbols that may not be already in the script: `opal_source`, `opal_last_stmt`, `opal_fill_arg` and `opal_tainted_arg`. We assume that is the case, there is no check for this.
+
+* `opal_source` is a function that has no parameters and returns a value. This function shall be marked as a source in the JavaScript analysis.
+* `opal_last_stmt` is a function with n parameters where n is the number of variables visible in the top-level scope.
+* `opal_fill_arg` is an untainted variable used to generate valid function calls.
+* `opal_tainted_arg` is a tainted variable used to generate valid function calls.
+
+```javascript
+// Begin of OPAL generated code
+function opal_source() {
+    return "secret";
+}
+function opal_last_stmt(p0, p1) { }
+
+var secret = opal_source();
+// End of OPAL generated code
+
+var xxx = secret;
+
+// Begin of OPAL generated code
+opal_last_stmt(secret, xxx);
+// End of OPAL generated code
+```
+Above is the generated code for a simple example where `secret` is handed over from the environment inside a `ScriptEngine`. Before the actual script, `secret` is declared in the top-level scope and tainted. After the script, `opal_last_stmt` takes all variable names as arguments. For each tainted argument, WALA is queried for the variable name and converted back to a `BindingFact`.
+
+One might ask why we need to pass all variables in scope as arguments. Take a look at the following JavaScript snippet:
+```javascript
+var secret = opal_source();
+secret = 42;
+opal_last_stmt(secret);
+```
+and now in SSA form:
+```javascript
+_1 = opal_source();
+_2 = 42;
+opal_last_stmt(_2);
+```
+In the SSA form, `_1` is tainted at the end and if we'd query the name of `_1`, that would be `secret`. To find out for which SSA variables we should query the name, we pass them as arguments. That also makes the Java analysis less dependent on the JavaScript analysis. In theory, to switch the underlying JavaScript analysis, one would only need to implement a way such that the JavaScript analysis returns the original variable names for the tainted arguments of `opal_last_stmt`.
+
+```javascript
+// Begin of OPAL generated code
+function opal_source() {
+    return "secret";
+}
+function opal_last_stmt(p0) { }
+// End of OPAL generated code
+
+function check(str, unused) {
+    return str === "1337";
+}
+
+// Begin of OPAL generated code
+var opal_fill_arg = 42;
+var opal_tainted_arg = opal_source();
+var opal_tainted_return = check(opal_fill_arg, opal_tainted_arg);
+opal_last_stmt(opal_tainted_return);
+// End of OPAL generated code
+```
+Above is another example of a transformation, but this time for tainted arguments to `invokeFunction`. Here, we first generate the two variables, one tainted and one untainted. These are used to generate a valid call to the function that is invoked by `invokeFunction`. The return value is always named `opal_tainted_return` and also flows at the end into `opal_last_stmt`. Back in Java, when converting the variable names back to facts, the variable name `opal_tainted_return` indicates the special case that instead of a `BindingFact`, the return value should be tainted.
+
+### Limitations
+In theory, if there are too many variables in the top-level scope, the number of arguments in `opal_last_stmt` could reach the maximum number of arguments of the Rhino JavaScript engine, which WALA uses. The limit seems to be in the thousands, so that should never accidentally happen in practise. 
+
+Also, there is a bug in the WALA JavaScript IFDS analysis I did not fix. Look at the snippet below:
+```javascript
+var x;
+function setX(v) {
+    x = v;
+}
+```
+Assume a call to `setX` with a tainted argument. At the end of the execution, `x` should be tainted. But in the WALA IFDS analysis, this is not the case.
+
+## 4. Scalability
+When using `invokeFunction` to call JavaScript from Java, the variable parameters are passed as `Object` and the return value is an `Object` as well. In case of primitive arguments or returns, boxing and unboxing is needed. In that case, the analysis needs the JDK to precisely resolve boxings. But the IFDS solver in the current state is too inefficient such that the `JavaScriptAwareTaintProblem` gets slow.
+
+I have decided to implement a reader of the summaries from the *StubDroid* paper. Overriding the `useSummaries` field of `ForwardTaintProblem` enables the use of those summaries. With those, there is also no need to load the JDK, which further brings the analysis up to speed.
+> S. Arzt and E. Bodden, "StubDroid: Automatic Inference of Precise Data-Flow Summaries for the Android Framework," 2016 IEEE/ACM 38th International Conference on Software Engineering (ICSE), 2016, pp. 725-735, doi: 10.1145/2884781.2884816.
+
+
+## Things left open
+* While the `LocalJSSourceFinder` is able to find filenames, I did not implement a way to find these files in the filesystem. Thus, the `JavaScriptAnalysisCaller` ignores `JavaScriptFileSource`.
+* In various places, the analysis depends on finding a string constant. Plugging in a string analysis before running the JavaScript aware taint analysis might greatly improve the accuracy.
+* Pooling of JavaScript analysis calls. Currently, for each taint that gets handed over to the JavaScript, a new analysis run is started. We could save the overhead of constructing a JavaScript AST and exploded supergraph everytime by pooling all taints and only calling the JavaScript analysis when the worklist of the Java IFDS solver is empty.
+* Another optimization could be inside the IFDS solver: implementing unbalanced returns and only propagate zero-facts at sources.

--- a/OPAL/js/build.sbt
+++ b/OPAL/js/build.sbt
@@ -1,0 +1,1 @@
+// build settings reside in the opal root build.sbt file

--- a/OPAL/js/src/main/java/org/opalj/js/wala_ifds/JSDomain.java
+++ b/OPAL/js/src/main/java/org/opalj/js/wala_ifds/JSDomain.java
@@ -1,0 +1,19 @@
+package org.opalj.js.wala_ifds;
+
+import com.ibm.wala.dataflow.IFDS.PathEdge;
+import com.ibm.wala.dataflow.IFDS.TabulationDomain;
+import com.ibm.wala.ipa.cfg.BasicBlockInContext;
+import com.ibm.wala.ssa.analysis.IExplodedBasicBlock;
+import com.ibm.wala.util.collections.Pair;
+import com.ibm.wala.util.intset.MutableMapping;
+
+class JSDomain extends MutableMapping<Pair<Integer, BasicBlockInContext<IExplodedBasicBlock>>>
+        implements TabulationDomain<Pair<Integer,BasicBlockInContext<IExplodedBasicBlock>>, BasicBlockInContext<IExplodedBasicBlock>>
+{
+    private static final long serialVersionUID = -1897766113586243833L;
+
+    @Override
+    public boolean hasPriorityOver(PathEdge<BasicBlockInContext<IExplodedBasicBlock>> pathEdge, PathEdge<BasicBlockInContext<IExplodedBasicBlock>> pathEdge1) {
+        return false;
+    }
+}

--- a/OPAL/js/src/main/java/org/opalj/js/wala_ifds/JSFlowFunctions.java
+++ b/OPAL/js/src/main/java/org/opalj/js/wala_ifds/JSFlowFunctions.java
@@ -1,0 +1,123 @@
+package org.opalj.js.wala_ifds;
+
+import com.ibm.wala.dataflow.IFDS.*;
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.cfg.BasicBlockInContext;
+import com.ibm.wala.ssa.*;
+import com.ibm.wala.ssa.analysis.IExplodedBasicBlock;
+import com.ibm.wala.util.collections.Pair;
+import com.ibm.wala.util.intset.IntSet;
+import com.ibm.wala.util.intset.IntSetUtil;
+import com.ibm.wala.util.intset.MutableIntSet;
+
+class JSFlowFunctions implements IPartiallyBalancedFlowFunctions<BasicBlockInContext<IExplodedBasicBlock>> {
+    ISupergraph<BasicBlockInContext<IExplodedBasicBlock>, CGNode> supergraph;
+    JSDomain domain;
+
+    public JSFlowFunctions(JSDomain domain, ISupergraph<BasicBlockInContext<IExplodedBasicBlock>, CGNode> supergraph)
+    {
+        this.supergraph = supergraph;
+        this.domain = domain;
+    }
+
+    @Override
+    public IUnaryFlowFunction getNormalFlowFunction(BasicBlockInContext<IExplodedBasicBlock> src,
+                                                    BasicBlockInContext<IExplodedBasicBlock> dest) {
+        final IExplodedBasicBlock ebb = src.getDelegate();
+        final IExplodedBasicBlock dbb = dest.getDelegate();
+
+        return new IUnaryFlowFunction() {
+
+            private void propagate(SSAInstruction inst, Pair<Integer, BasicBlockInContext<IExplodedBasicBlock>> vn, MutableIntSet r) {
+                boolean propagates = inst instanceof SSAPhiInstruction || inst instanceof SSABinaryOpInstruction || inst instanceof SSAUnaryOpInstruction;
+
+                if (propagates) {
+                    for (int i = 0; i < inst.getNumberOfUses(); i++) {
+                        if (vn.fst == inst.getUse(i)) {
+                            Pair<Integer, BasicBlockInContext<IExplodedBasicBlock>> nvn = Pair.make(inst.getDef(), src);
+                            if (! domain.hasMappedIndex(nvn)) {
+                                domain.add(nvn);
+                            }
+                            r.add(domain.getMappedIndex(nvn));
+                        }
+                    }
+                }
+            }
+
+            @Override
+            public IntSet getTargets(int d1) {
+                Pair<Integer, BasicBlockInContext<IExplodedBasicBlock>> vn = domain.getMappedObject(d1);
+                MutableIntSet r = IntSetUtil.make(new int[] { domain.getMappedIndex(vn) });
+                dbb.iteratePhis().forEachRemaining((inst) -> propagate(inst, vn, r));
+                propagate(ebb.getInstruction(), vn, r);
+
+                return r;
+            }
+        };
+    }
+
+    // taint parameters from arguments
+    @Override
+    public IUnaryFlowFunction getCallFlowFunction(BasicBlockInContext<IExplodedBasicBlock> src,
+                                                  BasicBlockInContext<IExplodedBasicBlock> dest, BasicBlockInContext<IExplodedBasicBlock> ret) {
+        final IExplodedBasicBlock ebb = src.getDelegate();
+        SSAInstruction inst = ebb.getInstruction();
+        return (d1) -> {
+            MutableIntSet r = IntSetUtil.make();
+            Pair<Integer, BasicBlockInContext<IExplodedBasicBlock>> vn = domain.getMappedObject(d1);
+            for (int i = 0; i < inst.getNumberOfUses(); i++) {
+                if (vn.fst == inst.getUse(i)) {
+                    Pair<Integer, BasicBlockInContext<IExplodedBasicBlock>> key = Pair.make(i+1, src);
+                    if (! domain.hasMappedIndex(key)) {
+                        domain.add(key);
+                    }
+                    r.add(domain.getMappedIndex(key));
+                }
+            }
+            return r;
+        };
+    }
+
+    // pass tainted values back to caller
+    @Override
+    public IUnaryFlowFunction getReturnFlowFunction(BasicBlockInContext<IExplodedBasicBlock> call,
+                                                    BasicBlockInContext<IExplodedBasicBlock> src, BasicBlockInContext<IExplodedBasicBlock> dest) {
+        int retVal = call.getLastInstruction().getDef();
+        return (d1) -> {
+            Pair<Integer, BasicBlockInContext<IExplodedBasicBlock>> vn = domain.getMappedObject(d1);
+            MutableIntSet result = IntSetUtil.make();
+            supergraph.getPredNodes(src).forEachRemaining(pb -> {
+                SSAInstruction inst = pb.getDelegate().getInstruction();
+                if (inst instanceof SSAReturnInstruction && inst.getUse(0) == vn.fst) {
+                    Pair<Integer, BasicBlockInContext<IExplodedBasicBlock>> key = Pair.make(retVal, pb);
+                    if (! domain.hasMappedIndex(key)) {
+                        domain.add(key);
+                    }
+                    result.add(domain.getMappedIndex(key));
+                }
+            });
+            return result;
+        };
+    }
+
+    // local variables are not changed by calls.
+    @Override
+    public IUnaryFlowFunction getCallToReturnFlowFunction(BasicBlockInContext<IExplodedBasicBlock> src,
+                                                          BasicBlockInContext<IExplodedBasicBlock> dest) {
+        return IdentityFlowFunction.identity();
+    }
+
+    // missing a callee, so assume it does nothing and keep local information.
+    @Override
+    public IUnaryFlowFunction getCallNoneToReturnFlowFunction(BasicBlockInContext<IExplodedBasicBlock> src,
+                                                              BasicBlockInContext<IExplodedBasicBlock> dest) {
+        return IdentityFlowFunction.identity();
+    }
+
+    // data flow back from an unknown call site, so just keep what comes back.
+    @Override
+    public IFlowFunction getUnbalancedReturnFlowFunction(BasicBlockInContext<IExplodedBasicBlock> src,
+                                                         BasicBlockInContext<IExplodedBasicBlock> dest) {
+        return IdentityFlowFunction.identity();
+    }
+}

--- a/OPAL/js/src/main/java/org/opalj/js/wala_ifds/JSProblem.java
+++ b/OPAL/js/src/main/java/org/opalj/js/wala_ifds/JSProblem.java
@@ -1,0 +1,101 @@
+package org.opalj.js.wala_ifds;
+
+import com.ibm.wala.dataflow.IFDS.*;
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.cfg.BasicBlockInContext;
+import com.ibm.wala.ssa.SSAInstruction;
+import com.ibm.wala.ssa.analysis.IExplodedBasicBlock;
+import com.ibm.wala.util.collections.HashSetFactory;
+import com.ibm.wala.util.collections.Pair;
+
+import java.util.Collection;
+import java.util.function.Function;
+
+class JSProblem implements PartiallyBalancedTabulationProblem<BasicBlockInContext<IExplodedBasicBlock>, CGNode, Pair<Integer, BasicBlockInContext<IExplodedBasicBlock>>> {
+    private final ISupergraph<BasicBlockInContext<IExplodedBasicBlock>, CGNode> supergraph;
+    private final JSDomain domain;
+    private final Function<BasicBlockInContext<IExplodedBasicBlock>, Boolean> sources;
+    /** path edges corresponding to taint sources */
+    private final Collection<PathEdge<BasicBlockInContext<IExplodedBasicBlock>>> initialSeeds;
+
+    private final JSFlowFunctions flowFunctions;
+
+    public JSProblem(JSDomain domain, ISupergraph<BasicBlockInContext<IExplodedBasicBlock>, CGNode> supergraph, Function<BasicBlockInContext<IExplodedBasicBlock>, Boolean> sources)
+    {
+        this.supergraph = supergraph;
+        this.domain = domain;
+        this.sources = sources;
+        this.initialSeeds = collectInitialSeeds();
+        this.flowFunctions = new JSFlowFunctions(domain, supergraph);
+    }
+
+    /**
+     * we use the entry block of the CGNode as the fake entry when propagating from
+     * callee to caller with unbalanced parens
+     */
+    @Override
+    public BasicBlockInContext<IExplodedBasicBlock> getFakeEntry(BasicBlockInContext<IExplodedBasicBlock> node) {
+        final CGNode cgNode = node.getNode();
+        return getFakeEntry(cgNode);
+    }
+
+    /**
+     * we use the entry block of the CGNode as the "fake" entry when propagating
+     * from callee to caller with unbalanced parens
+     */
+    private BasicBlockInContext<IExplodedBasicBlock> getFakeEntry(final CGNode cgNode) {
+        BasicBlockInContext<IExplodedBasicBlock>[] entriesForProcedure = supergraph.getEntriesForProcedure(cgNode);
+        assert entriesForProcedure.length == 1;
+        return entriesForProcedure[0];
+    }
+
+    /**
+     * collect sources of taint
+     */
+    private Collection<PathEdge<BasicBlockInContext<IExplodedBasicBlock>>> collectInitialSeeds() {
+        Collection<PathEdge<BasicBlockInContext<IExplodedBasicBlock>>> result = HashSetFactory.make();
+        for (BasicBlockInContext<IExplodedBasicBlock> bb : supergraph) {
+            IExplodedBasicBlock ebb = bb.getDelegate();
+            SSAInstruction instruction = ebb.getInstruction();
+
+            if (sources.apply(bb)) {
+                Pair<Integer, BasicBlockInContext<IExplodedBasicBlock>> fact = Pair.make(instruction.getDef(), bb);
+                final CGNode cgNode = bb.getNode();
+                int factNum = domain.add(fact);
+                BasicBlockInContext<IExplodedBasicBlock> fakeEntry = getFakeEntry(cgNode);
+                // note that the fact number used for the source of this path edge doesn't
+                // really matter
+                result.add(PathEdge.createPathEdge(fakeEntry, factNum, bb, factNum));
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public IPartiallyBalancedFlowFunctions<BasicBlockInContext<IExplodedBasicBlock>> getFunctionMap() {
+        return flowFunctions;
+    }
+
+    @Override
+    public JSDomain getDomain() {
+        return domain;
+    }
+
+    /**
+     * we don't need a merge function; the default unioning of tabulation works fine
+     */
+    @Override
+    public IMergeFunction getMergeFunction() {
+        return null;
+    }
+
+    @Override
+    public ISupergraph<BasicBlockInContext<IExplodedBasicBlock>, CGNode> getSupergraph() {
+        return supergraph;
+    }
+
+    @Override
+    public Collection<PathEdge<BasicBlockInContext<IExplodedBasicBlock>>> initialSeeds() {
+        return initialSeeds;
+    }
+}

--- a/OPAL/js/src/main/java/org/opalj/js/wala_ifds/WalaJavaScriptIFDSTaintAnalysis.java
+++ b/OPAL/js/src/main/java/org/opalj/js/wala_ifds/WalaJavaScriptIFDSTaintAnalysis.java
@@ -1,0 +1,60 @@
+package org.opalj.js.wala_ifds;
+
+import com.ibm.wala.dataflow.IFDS.ICFGSupergraph;
+import com.ibm.wala.dataflow.IFDS.PartiallyBalancedTabulationSolver;
+import com.ibm.wala.dataflow.IFDS.TabulationDomain;
+import com.ibm.wala.dataflow.IFDS.TabulationResult;
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.CallGraph;
+import com.ibm.wala.ipa.cfg.BasicBlockInContext;
+import com.ibm.wala.ssa.analysis.IExplodedBasicBlock;
+import com.ibm.wala.util.CancelException;
+import com.ibm.wala.util.collections.Pair;
+import com.ibm.wala.util.intset.IntSet;
+import scala.Function3;
+
+import java.util.function.Function;
+
+public class WalaJavaScriptIFDSTaintAnalysis {
+
+    private final ICFGSupergraph supergraph;
+
+    private final JSDomain domain;
+
+    private final Function<BasicBlockInContext<IExplodedBasicBlock>, Boolean> sources;
+
+    public WalaJavaScriptIFDSTaintAnalysis(CallGraph cg, Function<BasicBlockInContext<IExplodedBasicBlock>, Boolean> sources)
+    {
+        supergraph = ICFGSupergraph.make(cg);
+        this.sources = sources;
+        this.domain = new JSDomain();
+    }
+
+    public TabulationResult<BasicBlockInContext<IExplodedBasicBlock>, CGNode, Pair<Integer,BasicBlockInContext<IExplodedBasicBlock>>> analyze() {
+        PartiallyBalancedTabulationSolver<BasicBlockInContext<IExplodedBasicBlock>, CGNode, Pair<Integer, BasicBlockInContext<IExplodedBasicBlock>>> solver = PartiallyBalancedTabulationSolver
+                .createPartiallyBalancedTabulationSolver(new JSProblem(domain, supergraph, sources), null);
+        TabulationResult<BasicBlockInContext<IExplodedBasicBlock>, CGNode, Pair<Integer, BasicBlockInContext<IExplodedBasicBlock>>> result = null;
+        try {
+            result = solver.solve();
+        } catch (CancelException e) {
+            // this shouldn't happen
+            assert false;
+        }
+        return result;
+    }
+
+    public static void startJSAnalysis(CallGraph CG, Function<BasicBlockInContext<IExplodedBasicBlock>, Boolean> sources,
+                                        Function3<BasicBlockInContext<IExplodedBasicBlock>,
+                                                  IntSet,
+                                                  TabulationDomain<Pair<Integer,
+                                                                        BasicBlockInContext<IExplodedBasicBlock>>,
+                                                                   BasicBlockInContext<IExplodedBasicBlock>>,
+                                                  Void> sinks) {
+        WalaJavaScriptIFDSTaintAnalysis A = new WalaJavaScriptIFDSTaintAnalysis(CG, sources);
+
+        TabulationResult<BasicBlockInContext<IExplodedBasicBlock>,
+                         CGNode, Pair<Integer, BasicBlockInContext<IExplodedBasicBlock>>> R = A.analyze();
+
+        R.getSupergraphNodesReached().forEach((sbb) -> sinks.apply(sbb, R.getResult(sbb), A.domain));
+    }
+}

--- a/OPAL/js/src/main/scala/org/opalj/js/JSFact.scala
+++ b/OPAL/js/src/main/scala/org/opalj/js/JSFact.scala
@@ -1,0 +1,22 @@
+/* BSD 2-Clause License - see OPAL/LICENSE for details. */
+package org.opalj.js
+
+import org.opalj.tac.fpcf.analyses.ifds.taint.TaintFact
+
+/* Common trait for facts for ScriptEngines. */
+trait JSFact extends TaintFact
+
+/**
+ * A tainted value inside a Key-Value-Map.
+ *
+ * @param index variable of a map type
+ * @param keyName name of the key. Empty string if unknown.
+ */
+case class BindingFact(index: Int, keyName: String) extends JSFact with TaintFact
+
+/**
+ * A tainted value inside a Key-Value-Map where the value is not statically known.
+ *
+ * @param index variable of a map type
+ */
+case class WildcardBindingFact(index: Int) extends JSFact with TaintFact

--- a/OPAL/js/src/main/scala/org/opalj/js/JavaScriptAnalysisCaller.scala
+++ b/OPAL/js/src/main/scala/org/opalj/js/JavaScriptAnalysisCaller.scala
@@ -39,6 +39,8 @@ class JavaScriptAnalysisCaller(p: SomeProject) {
      * @return set of taints
      */
     def analyze(stmt: JavaStatement, in: JSFact): Set[TaintFact] = {
+        // TODO: pool queries
+
         val sourceFiles = sourceFinder(stmt)
         in match {
             case b: BindingFact         => sourceFiles.flatMap(s => analyzeScript(s, b))
@@ -56,6 +58,8 @@ class JavaScriptAnalysisCaller(p: SomeProject) {
      * @return set of taints
      */
     def analyze(stmt: JavaStatement, in: ArrayElement, fName: String): Set[TaintFact] = {
+        // TODO: pool queries
+
         val sourceFiles = sourceFinder(stmt)
         sourceFiles.flatMap(s => analyzeFunction(s, in, fName, stmt.index)) + in
     }

--- a/OPAL/js/src/main/scala/org/opalj/js/JavaScriptAnalysisCaller.scala
+++ b/OPAL/js/src/main/scala/org/opalj/js/JavaScriptAnalysisCaller.scala
@@ -1,0 +1,294 @@
+/* BSD 2-Clause License - see OPAL/LICENSE for details. */
+package org.opalj.js
+
+import com.ibm.wala.cast.js.ipa.callgraph.{JSCFABuilder, JSCallGraphUtil}
+import com.ibm.wala.cast.js.translator.CAstRhinoTranslatorFactory
+import com.ibm.wala.cast.js.util.JSCallGraphBuilderUtil
+import com.ibm.wala.dataflow.IFDS.TabulationDomain
+import com.ibm.wala.ipa.callgraph.CallGraph
+import com.ibm.wala.ipa.cfg.BasicBlockInContext
+import com.ibm.wala.ssa.SSAAbstractInvokeInstruction
+import com.ibm.wala.ssa.analysis.IExplodedBasicBlock
+import com.ibm.wala.util.collections.Pair
+import com.ibm.wala.util.intset.{IntIterator, IntSet, IntSetUtil, MutableIntSet}
+import org.opalj.br.analyses.SomeProject
+import org.opalj.js.wala_ifds.WalaJavaScriptIFDSTaintAnalysis
+import org.opalj.tac.fpcf.analyses.ifds.JavaStatement
+import org.opalj.tac.fpcf.analyses.ifds.taint.{ArrayElement, TaintFact, Variable}
+import org.mozilla.javascript.{Parser, Token}
+import org.mozilla.javascript.ast.{AstNode, AstRoot, FunctionNode, NodeVisitor, Symbol}
+
+import java.io.File
+
+/**
+ * Class which does convert a call from Java to JavaScript into something that a JavaScript IFDS analysis
+ * can consume and converts the results back into facts for the Java taint analysis.
+ *
+ * @param p Project
+ */
+class JavaScriptAnalysisCaller(p: SomeProject) {
+    type Domain = TabulationDomain[Pair[Integer, BasicBlockInContext[IExplodedBasicBlock]], BasicBlockInContext[IExplodedBasicBlock]]
+
+    val sourceFinder = new LocalJSSourceFinder(p)
+
+    /**
+     * Analyze an evaluation of a JavaScript script.
+     *
+     * @param stmt Java Statement
+     * @param in incoming BindingFact
+     * @return set of taints
+     */
+    def analyze(stmt: JavaStatement, in: JSFact): Set[TaintFact] = {
+        val sourceFiles = sourceFinder(stmt)
+        in match {
+            case b: BindingFact         => sourceFiles.flatMap(s => analyzeScript(s, b))
+            /* If we don't know what variable is tainted, we have to give up. */
+            case b: WildcardBindingFact => Set(b)
+        }
+    }
+
+    /**
+     * Analyze a call to a JavaScript function.
+     *
+     * @param stmt Java Statement
+     * @param in Variable-length parameter array
+     * @param fName function name
+     * @return set of taints
+     */
+    def analyze(stmt: JavaStatement, in: ArrayElement, fName: String): Set[TaintFact] = {
+        val sourceFiles = sourceFinder(stmt)
+        sourceFiles.flatMap(s => analyzeFunction(s, in, fName, stmt.index)) + in
+    }
+
+    /**
+     * Return all variable names that are in the top level scope.
+     *
+     * @param root root AST node of the script
+     * @return set of variable names
+     */
+    private def getTopLevelVariableNames(root: AstRoot): Set[String] = {
+        var nameSet: Set[String] = Set()
+        root.getSymbols.forEach(symbol => {
+            if ((symbol.getDeclType == Token.VAR
+                || symbol.getDeclType == Token.LET
+                || symbol.getDeclType == Token.CONST)
+                && symbol.getContainingTable == root)
+                nameSet += symbol.getName
+        })
+        nameSet
+    }
+
+    /**
+     * Return the corresponding function node for the function symbol.
+     *
+     * @param func function symbol
+     * @return function node
+     */
+    private def getFunctionNode(func: Symbol): Option[FunctionNode] = {
+        /**
+         * Visitor to find the node of the function in the AST.
+         */
+        class FunctionFinder extends NodeVisitor {
+            var fnResult: Option[FunctionNode] = None
+
+            override def visit(node: AstNode): Boolean = {
+                if (fnResult.isEmpty)
+                    node match {
+                        case fn: FunctionNode =>
+                            fnResult = Some(fn)
+                            false
+                        case _ => true
+                    }
+                else
+                    false
+            }
+        }
+
+        val fnFinder = new FunctionFinder()
+        func.getContainingTable.visit(fnFinder)
+        fnFinder.fnResult
+    }
+
+    /**
+     * Map a list of variable names to a list of BindingFacts
+     *
+     * @param vars    variable names
+     * @param defSite definition site of the incoming BindingFact
+     * @return list of BindingFacts
+     */
+    private def varNamesToFacts(vars: List[String], defSite: Integer): Set[TaintFact] =
+        vars.map(v => if (v == "opal_tainted_return") Variable(defSite) else BindingFact(defSite, v)).toSet
+
+    /**
+     * Generate a argument list of length n with one tainted argument.
+     *
+     * @param n number of arguments
+     * @param taintedIdx index which should be tainted
+     * @return argument list as string
+     */
+    private def generateFunctionArgs(n: Int, taintedIdx: Int): String = {
+        (0 until n).map(i =>
+            if (i == taintedIdx) {
+                s"opal_tainted_arg"
+            } else {
+                s"opal_fill_arg"
+            }).mkString(", ")
+    }
+
+    /**
+     * Prepare and analyze a JavaScript function call.
+     *
+     * @param sourceFile JavaScript source
+     * @param in incoming fact from a variable-length parameter list
+     * @param fName function name
+     * @param stmtIndex statement index
+     * @return set of facts
+     */
+    private def analyzeFunction(sourceFile: JavaScriptSource, in: ArrayElement,
+                                fName: String, stmtIndex: Int): Set[TaintFact] = {
+        val parser: Parser = new Parser()
+
+        val root: AstRoot = parser.parse(sourceFile.asString, "fileName", 1)
+        val sTable = root.getSymbolTable
+        if (!sTable.containsKey(fName))
+            return Set()
+        val fSymbol = sTable.get(fName)
+        if (fSymbol.getDeclType != Token.FUNCTION)
+            return Set()
+        val fNode = getFunctionNode(fSymbol)
+        if (fNode.isEmpty)
+            return Set()
+
+        val nameSet: Set[String] = getTopLevelVariableNames(root)+"opal_tainted_return"
+        val beforeCode =
+            s"""function opal_source() {
+               |    return \"secret\";
+               |}
+               |function opal_last_stmt(${generateParams(nameSet.size)}) { }
+               |\n""".stripMargin
+        val funcCall = s"var opal_tainted_return = $fName(${generateFunctionArgs(fNode.get.getParamCount, in.element)});"
+        val afterCode = s"""
+                 |var opal_fill_arg = 42;
+                 |var opal_tainted_arg = opal_source();
+                 |$funcCall
+                 |opal_last_stmt(${nameSet.mkString(", ")});\n""".stripMargin
+
+        val f: File = sourceFile.asFile(beforeCode, afterCode)
+        analyzeCommon(f, stmtIndex)
+    }
+
+    /**
+     * Generate a n-length parameter list.
+     *
+     * @param n number of parameters
+     * @return parameter list as string
+     */
+    private def generateParams(n: Int): String = {
+        (0 until n).map(i => s"p$i").mkString(", ")
+    }
+
+    /**
+     * Prepare and analyze a script evaluation.
+     *
+     * @param sourceFile JavaScript source
+     * @param in incoming BindingFact
+     * @return set of facts
+     */
+    private def analyzeScript(sourceFile: JavaScriptSource, in: BindingFact): Set[TaintFact] = {
+        val parser: Parser = new Parser()
+        val taintedVar = s"var ${in.keyName} = opal_source();\n"
+        val root: AstRoot = parser.parse(taintedVar + sourceFile.asString, "fileName", 1)
+        val nameSet: Set[String] = getTopLevelVariableNames(root)
+
+        val beforeCode =
+            s"""function opal_source() {
+               |    return \"secret\";
+               |}
+               |function opal_last_stmt(${generateParams(nameSet.size)}) { }
+               |\n
+               |$taintedVar""".stripMargin
+        val afterCode = s"\nopal_last_stmt(${nameSet.mkString(", ")});\n"
+        val f: File = sourceFile.asFile(beforeCode, afterCode)
+        analyzeCommon(f, in.index)
+    }
+
+    /**
+     * Invoke the WALA IFDS taint analysis
+     *
+     * @param f JavaScript file
+     * @param idx Index used in the out facts
+     * @return set of facts
+     */
+    private def analyzeCommon(f: File, idx: Int): Set[TaintFact] = {
+        JSCallGraphUtil.setTranslatorFactory(new CAstRhinoTranslatorFactory)
+        val B: JSCFABuilder = JSCallGraphBuilderUtil.makeScriptCGBuilder(f.getParent, f.getName)
+        val CG: CallGraph = B.makeCallGraph(B.getOptions)
+
+        /**
+         * Check basic block for source.
+         *
+         * @param ebb exploded basic block
+         * @return true if ebb contains a source
+         */
+        def sources(ebb: BasicBlockInContext[IExplodedBasicBlock]): Boolean = {
+            val inst = ebb.getDelegate.getInstruction
+            inst match {
+                case i: SSAAbstractInvokeInstruction =>
+                    CG.getPossibleTargets(ebb.getNode, i.getCallSite).forEach(target => {
+                        if (target.getMethod.getDeclaringClass.getName.toString.endsWith("opal_source"))
+                            return true
+                    })
+                case _ =>
+            }
+            false
+        }
+
+        var varsAliveAfterJS: List[String] = List()
+
+        /**
+         * Add all tainted variable names to varsAliveAfterJS after the analysis ran.
+         *
+         * @param bb basic block
+         * @param r result set
+         * @param d domain
+         */
+        def sinks(bb: BasicBlockInContext[IExplodedBasicBlock], r: IntSet, d: Domain): Void = {
+            val inst = bb.getDelegate.getInstruction
+            inst match {
+                case invInst: SSAAbstractInvokeInstruction =>
+                    CG.getPossibleTargets(bb.getNode, invInst.getCallSite).forEach(target => {
+                        if (target.getMethod.getDeclaringClass.getName.toString.endsWith("opal_last_stmt")) {
+                            /* Collect all parameters.  */
+                            val paramIdx: MutableIntSet = IntSetUtil.make()
+                            for (i <- 1 until invInst.getNumberOfPositionalParameters) {
+                                paramIdx.add(inst.getUse(i))
+                            }
+
+                            /* Collect all tainted variables reaching the end of the JS script. */
+                            val it: IntIterator = r.intIterator()
+                            val taints: MutableIntSet = IntSetUtil.make()
+                            while (it.hasNext) {
+                                val vn = d.getMappedObject(it.next())
+                                taints.add(vn.fst)
+                            }
+
+                            /* Intersect all tainted variables with the parameters of the last statement.
+                               This is a workaround to only reconstruct the variable names for the "last" SSA name. */
+                            val taintedParams: IntSet = taints.intersection(paramIdx)
+                            val taintedIt: IntIterator = taintedParams.intIterator()
+                            while (taintedIt.hasNext) {
+                                val idx = taintedIt.next()
+                                varsAliveAfterJS ++= bb.getNode.getIR.getLocalNames(1, idx).toList
+                            }
+                        }
+                    })
+                case _ =>
+            }
+            null
+        }
+
+        WalaJavaScriptIFDSTaintAnalysis.startJSAnalysis(CG, sources, sinks)
+        f.delete()
+        varNamesToFacts(varsAliveAfterJS, idx)
+    }
+}

--- a/OPAL/js/src/main/scala/org/opalj/js/JavaScriptAwareTaintProblem.scala
+++ b/OPAL/js/src/main/scala/org/opalj/js/JavaScriptAwareTaintProblem.scala
@@ -1,0 +1,291 @@
+/* BSD 2-Clause License - see OPAL/LICENSE for details. */
+package org.opalj.js
+
+import org.opalj.br.{Method, ObjectType}
+import org.opalj.br.analyses.SomeProject
+import org.opalj.collection.immutable.IntTrieSet
+import org.opalj.ifds.Dependees.Getter
+import org.opalj.tac.fpcf.analyses.ifds.JavaIFDSProblem.{NO_MATCH, V}
+import org.opalj.tac.{AITACode, Assignment, Call, ComputeTACAIKey, Expr, ReturnValue, Stmt, TACMethodParameter, TACode}
+import org.opalj.tac.fpcf.analyses.ifds.{JavaIFDSProblem, JavaMethod, JavaStatement}
+import org.opalj.tac.fpcf.analyses.ifds.taint.{ArrayElement, FlowFact, ForwardTaintProblem, TaintFact, TaintNullFact, Variable}
+import org.opalj.value.ValueInformation
+
+import scala.annotation.nowarn
+
+/**
+ * Java IFDS analysis that is able to resolve calls to JavaScript.
+ *
+ * @param p project
+ */
+class JavaScriptAwareTaintProblem(p: SomeProject) extends ForwardTaintProblem(p) {
+    final type TACAICode = TACode[TACMethodParameter, JavaIFDSProblem.V]
+    val tacaiKey: Method => AITACode[TACMethodParameter, ValueInformation] = p.get(ComputeTACAIKey)
+
+    /**
+     * Called, when the exit to return facts are computed for some `callee` with the null fact and
+     * the callee's return value is assigned to a variable.
+     * Creates a taint, if necessary.
+     *
+     * @param callee The called method.
+     * @param call   The call.
+     * @return Some variable fact, if necessary. Otherwise none.
+     */
+    override protected def createTaints(callee: Method, call: JavaStatement): Set[TaintFact] =
+        if (callee.name == "source") Set(Variable(call.index))
+        else Set.empty
+
+    /**
+     * Called, when the call to return facts are computed for some `callee`.
+     * Creates a FlowFact, if necessary.
+     *
+     * @param callee The method, which was called.
+     * @param call   The call.
+     * @return Some FlowFact, if necessary. Otherwise None.
+     */
+    override protected def createFlowFact(
+        callee: Method,
+        call:   JavaStatement,
+        in:     TaintFact
+    ): Option[FlowFact] =
+        if (callee.name == "sink" && in == Variable(-2))
+            Some(FlowFact(Seq(JavaMethod(call.method), JavaMethod(callee))))
+        else None
+
+    /**
+     * The entry points of this analysis.
+     */
+    override def entryPoints: Seq[(Method, TaintFact)] =
+        for {
+            m <- p.allMethodsWithBody
+            if m.name == "main"
+        } yield m -> TaintNullFact
+
+    /**
+     * Checks, if some `callee` is a sanitizer, which sanitizes its return value.
+     * In this case, no return flow facts will be created.
+     *
+     * @param callee The method, which was called.
+     * @return True, if the method is a sanitizer.
+     */
+    override protected def sanitizesReturnValue(callee: Method): Boolean = callee.name == "sanitize"
+
+    /**
+     * Called in callToReturnFlow. This method can return whether the input fact
+     * will be removed after `callee` was called. I.e. the method could sanitize parameters.
+     *
+     * @param call The call statement.
+     * @param in   The fact which holds before the call.
+     * @return Whether in will be removed after the call.
+     */
+    override protected def sanitizesParameter(call: JavaStatement, in: TaintFact): Boolean = false
+
+    override def callFlow(call: JavaStatement, callee: Method, in: TaintFact): Set[TaintFact] = {
+        val callObject = JavaIFDSProblem.asCall(call.stmt)
+        val allParams = callObject.allParams
+
+        val allParamsWithIndices = allParams.zipWithIndex
+        in match {
+            case BindingFact(index, keyName) => allParamsWithIndices.flatMap {
+                case (param, paramIndex) if param.asVar.definedBy.contains(index) =>
+                    Some(BindingFact(JavaIFDSProblem.switchParamAndVariableIndex(
+                        paramIndex,
+                        callee.isStatic
+                    ), keyName))
+                case _ => None // Nothing to do
+            }.toSet
+            case _ => super.callFlow(call, callee, in)
+        }
+    }
+
+    override def returnFlow(exit: JavaStatement, in: TaintFact, call: JavaStatement,
+                            callFact: TaintFact, successor: JavaStatement): Set[TaintFact] = {
+        if (!isPossibleReturnFlow(exit, successor)) return Set.empty
+        val callee = exit.callable
+        if (sanitizesReturnValue(callee)) return Set.empty
+        val callStatement = JavaIFDSProblem.asCall(call.stmt)
+        val allParams = callStatement.allParams
+
+        in match {
+            case BindingFact(index, keyName) =>
+                var flows: Set[TaintFact] = Set.empty
+                if (index < 0 && index > -100) {
+                    val param = allParams(
+                        JavaIFDSProblem.switchParamAndVariableIndex(index, callee.isStatic)
+                    )
+                    flows ++= param.asVar.definedBy.map(i => BindingFact(i, keyName))
+                }
+                if (exit.stmt.astID == ReturnValue.ASTID && call.stmt.astID == Assignment.ASTID) {
+                    val returnValueDefinedBy = exit.stmt.asReturnValue.expr.asVar.definedBy
+                    if (returnValueDefinedBy.contains(index))
+                        flows += BindingFact(call.index, keyName)
+                }
+                flows
+            case _ => super.returnFlow(exit, in, call, callFact, successor)
+        }
+    }
+
+    /**
+     * Kills the flow.
+     *
+     * @return empty set
+     */
+    def killFlow(
+        @nowarn call:            JavaStatement,
+        @nowarn successor:       JavaStatement,
+        @nowarn in:              TaintFact,
+        @nowarn dependeesGetter: Getter
+    ): Set[TaintFact] = Set.empty
+
+    val scriptEngineMethods: Map[ObjectType, List[String]] = Map(
+        ObjectType("javax/script/Invocable") -> List("invokeFunction"),
+        ObjectType("javax/script/ScriptEngine") -> List("put", "get", "eval"),
+        ObjectType("javax/script/Bindings") -> List("put", "get", "putAll", "remove"),
+    )
+
+    /**
+     * Checks whether we handle the method.
+     *
+     * @param objType type of the base object
+     * @param methodName method name of the call
+     * @return true if we have a rule for the method call
+     */
+    def invokesScriptFunction(objType: ObjectType, methodName: String): Boolean =
+        scriptEngineMethods.exists(kv => objType.isSubtypeOf(kv._1)(p.classHierarchy) && kv._2.contains(methodName))
+
+    def invokesScriptFunction(callStmt: Call[JavaIFDSProblem.V]): Boolean =
+        invokesScriptFunction(callStmt.declaringClass.mostPreciseObjectType, callStmt.name)
+
+    def invokesScriptFunction(method: Method): Boolean =
+        invokesScriptFunction(method.classFile.thisType, method.name)
+
+    /**
+     * Kill the flow if we handle the call outside.
+     */
+    override def outsideAnalysisContext(callee: Method): Option[OutsideAnalysisContextHandler] = {
+        if (invokesScriptFunction(callee)) {
+            Some(killFlow _)
+        } else {
+            super.outsideAnalysisContext(callee)
+        }
+    }
+
+    /**
+     * Finds all definition/use sites inside the method.
+     *
+     * @param method method to be searched in
+     * @param sites  definition or use sites
+     * @return sites as JavaStatement
+     */
+    def searchStmts(method: Method, sites: IntTrieSet): Set[Stmt[JavaIFDSProblem.V]] = {
+        val taCode = tacaiKey(method)
+        sites.map(site => taCode.stmts.apply(site))
+    }
+
+    /**
+     * Returns all possible constant strings. Contains the empty string if at least one was non-constant.
+     *
+     * @param method method
+     * @param defSites def sites of the queried variable
+     * @return
+     */
+    private def getPossibleStrings(method: Method, defSites: IntTrieSet): Set[String] = {
+        val taCode = tacaiKey(method)
+
+        defSites.map(site => taCode.stmts.apply(site)).map {
+            case a: Assignment[JavaIFDSProblem.V] if a.expr.isStringConst =>
+                a.expr.asStringConst.value
+            case _ => ""
+        }
+    }
+
+    val jsAnalysis = new JavaScriptAnalysisCaller(p)
+
+    override def callToReturnFlow(call: JavaStatement, in: TaintFact, successor: JavaStatement): Set[TaintFact] = {
+        val callStmt = JavaIFDSProblem.asCall(call.stmt)
+        val allParams = callStmt.allParams
+        val allParamsWithIndex = callStmt.allParams.zipWithIndex
+
+        if (!invokesScriptFunction(callStmt)) {
+            in match {
+                case BindingFact(index, _) =>
+                    if (JavaIFDSProblem.getParameterIndex(allParamsWithIndex, index) == NO_MATCH)
+                        Set(in)
+                    else
+                        Set()
+                case _ => super.callToReturnFlow(call, in, successor)
+            }
+        } else {
+            in match {
+                /* Call to invokeFunction. The variable length parameter list is an array in TACAI. */
+                case arrIn: ArrayElement if callStmt.name == "invokeFunction"
+                    && JavaIFDSProblem.getParameterIndex(allParamsWithIndex, arrIn.index) == -3 =>
+                    val fNames = getPossibleStrings(call.method, allParams(1).asVar.definedBy)
+                    fNames.map(fName =>
+                        if (fName == "")
+                            /* Function name is unknown. We don't know what to call */
+                            None
+                        else
+                            Some(jsAnalysis.analyze(call, arrIn, fName))).filter(_.isDefined).flatMap(_.get) ++ Set(in)
+                /* Call to eval. */
+                case f: BindingFact if callStmt.name == "eval"
+                    && (JavaIFDSProblem.getParameterIndex(allParamsWithIndex, f.index) == -1
+                        || JavaIFDSProblem.getParameterIndex(allParamsWithIndex, f.index) == -3) =>
+                    jsAnalysis.analyze(call, f)
+                case f: WildcardBindingFact if callStmt.name == "eval"
+                    && (JavaIFDSProblem.getParameterIndex(allParamsWithIndex, f.index) == -1
+                        || JavaIFDSProblem.getParameterIndex(allParamsWithIndex, f.index) == -3) =>
+                    jsAnalysis.analyze(call, f)
+                /* Put obj in Binding */
+                case Variable(index) if callStmt.name == "put" && JavaIFDSProblem.getParameterIndex(allParamsWithIndex, index) == -3 =>
+                    val keyNames = getPossibleStrings(call.method, allParams(1).asVar.definedBy)
+                    val defSites = callStmt.receiverOption.get.asVar.definedBy
+                    keyNames.flatMap(keyName => defSites.map(i => if (keyName == "") WildcardBindingFact(i) else BindingFact(i, keyName))) ++ Set(in)
+                /* putAll BindingFact to other BindingFact */
+                case BindingFact(index, keyName) if callStmt.name == "putAll" && JavaIFDSProblem.getParameterIndex(allParamsWithIndex, index) == -2 =>
+                    callStmt.receiverOption.get.asVar.definedBy.map(i => if (keyName == "") WildcardBindingFact(i) else BindingFact(i, keyName)) ++ Set(in)
+                case WildcardBindingFact(index) if callStmt.name == "putAll" && JavaIFDSProblem.getParameterIndex(allParamsWithIndex, index) == -2 =>
+                    callStmt.receiverOption.get.asVar.definedBy.map(i => WildcardBindingFact(i)) ++ Set(in)
+                /* Overwrite BindingFact */
+                case BindingFact(index, keyName) if callStmt.name == "put" && JavaIFDSProblem.getParameterIndex(allParamsWithIndex, index) == -1 =>
+                    val possibleFields = getPossibleStrings(call.method, allParams(1).asVar.definedBy)
+                    if (possibleFields.size == 1 && possibleFields.contains(keyName))
+                        /* Key is definitely overwritten */
+                        Set()
+                    else
+                        Set(in)
+                case WildcardBindingFact(index) if callStmt.name == "put" && JavaIFDSProblem.getParameterIndex(allParamsWithIndex, index) == -1 =>
+                    /* We never overwrite here as we don't know the key */
+                    Set(in)
+                /* Remove BindingFact */
+                case BindingFact(index, keyName) if callStmt.name == "remove" && JavaIFDSProblem.getParameterIndex(allParamsWithIndex, index) == -1 =>
+                    val possibleFields = getPossibleStrings(call.method, allParams(1).asVar.definedBy)
+                    if (possibleFields.size == 1 && possibleFields.contains(keyName))
+                        Set()
+                    else
+                        Set(in)
+                case WildcardBindingFact(index) if callStmt.name == "remove" && JavaIFDSProblem.getParameterIndex(allParamsWithIndex, index) == -1 =>
+                    /* We never kill here as we don't know the key */
+                    Set(in)
+                /* get from BindingFact */
+                case BindingFact(index, keyName) if callStmt.name == "get" && JavaIFDSProblem.getParameterIndex(allParamsWithIndex, index) == -1 =>
+                    val possibleFields = getPossibleStrings(call.method, allParams(1).asVar.definedBy)
+                    if (possibleFields.size == 1 && possibleFields.contains(keyName))
+                        Set(Variable(call.index), in)
+                    else
+                        Set(in)
+                case WildcardBindingFact(index) if callStmt.name == "get" && JavaIFDSProblem.getParameterIndex(allParamsWithIndex, index) == -1 =>
+                    Set(Variable(call.index), in)
+                case _ => Set(in)
+            }
+        }
+    }
+
+    override def isTainted(expression: Expr[V], in: TaintFact): Boolean = {
+        val definedBy = expression.asVar.definedBy
+        expression.isVar && (in match {
+            case BindingFact(index, _) => definedBy.contains(index)
+            case _                     => super.isTainted(expression, in)
+        })
+    }
+}

--- a/OPAL/js/src/main/scala/org/opalj/js/JavaScriptAwareTaintProblem.scala
+++ b/OPAL/js/src/main/scala/org/opalj/js/JavaScriptAwareTaintProblem.scala
@@ -6,7 +6,7 @@ import org.opalj.br.analyses.SomeProject
 import org.opalj.collection.immutable.IntTrieSet
 import org.opalj.ifds.Dependees.Getter
 import org.opalj.tac.fpcf.analyses.ifds.JavaIFDSProblem.{NO_MATCH, V}
-import org.opalj.tac.{AITACode, Assignment, Call, ComputeTACAIKey, Expr, ReturnValue, Stmt, TACMethodParameter, TACode}
+import org.opalj.tac.{AITACode, Assignment, Call, ComputeTACAIKey, Expr, ReturnValue, TACMethodParameter, TACode}
 import org.opalj.tac.fpcf.analyses.ifds.{JavaIFDSProblem, JavaMethod, JavaStatement}
 import org.opalj.tac.fpcf.analyses.ifds.taint.{ArrayElement, FlowFact, ForwardTaintProblem, TaintFact, TaintNullFact, Variable}
 import org.opalj.value.ValueInformation
@@ -171,18 +171,6 @@ class JavaScriptAwareTaintProblem(p: SomeProject) extends ForwardTaintProblem(p)
     }
 
     /**
-     * Finds all definition/use sites inside the method.
-     *
-     * @param method method to be searched in
-     * @param sites  definition or use sites
-     * @return sites as JavaStatement
-     */
-    def searchStmts(method: Method, sites: IntTrieSet): Set[Stmt[JavaIFDSProblem.V]] = {
-        val taCode = tacaiKey(method)
-        sites.map(site => taCode.stmts.apply(site))
-    }
-
-    /**
      * Returns all possible constant strings. Contains the empty string if at least one was non-constant.
      *
      * @param method method
@@ -192,6 +180,7 @@ class JavaScriptAwareTaintProblem(p: SomeProject) extends ForwardTaintProblem(p)
     private def getPossibleStrings(method: Method, defSites: IntTrieSet): Set[String] = {
         val taCode = tacaiKey(method)
 
+        // TODO: use string analysis here
         defSites.map(site => taCode.stmts.apply(site)).map {
             case a: Assignment[JavaIFDSProblem.V] if a.expr.isStringConst =>
                 a.expr.asStringConst.value

--- a/OPAL/js/src/main/scala/org/opalj/js/JavaScriptSource.scala
+++ b/OPAL/js/src/main/scala/org/opalj/js/JavaScriptSource.scala
@@ -1,0 +1,44 @@
+/* BSD 2-Clause License - see OPAL/LICENSE for details. */
+package org.opalj.js
+
+import java.io.{File, FileOutputStream}
+import java.nio.file.Files
+
+/**
+ * Common trait for representing JavaScript sources embedded in Java source code.
+ */
+sealed trait JavaScriptSource {
+    /**
+     * Return the JavaScript source code as a string.
+     * @return JavaScript source
+     */
+    def asString: String
+
+    /**
+     *
+     * @param codeBefore Code to be added in front of the script.
+     * @param codeAfter Code to be added at the end of the script.
+     * @return file handler
+     */
+    def asFile(codeBefore: String, codeAfter: String): File
+}
+
+case class JavaScriptStringSource(source: String) extends JavaScriptSource {
+    lazy val tmpFile: File = Files.createTempFile("opal", ".js").toFile
+
+    override def asString: String = source
+
+    override def asFile(codeBefore: String, codeAfter: String): File = {
+        val code = codeBefore + source + codeAfter
+        val fos = new FileOutputStream(tmpFile)
+        fos.write(code.getBytes())
+        fos.close()
+        tmpFile
+    }
+}
+
+case class JavaScriptFileSource(path: String) extends JavaScriptSource {
+    override def asString: String = throw new RuntimeException("Not implemented!")
+
+    override def asFile(codeBefore: String, codeAfter: String): File = throw new RuntimeException("Not implemented!")
+}

--- a/OPAL/js/src/main/scala/org/opalj/js/JavaScriptSource.scala
+++ b/OPAL/js/src/main/scala/org/opalj/js/JavaScriptSource.scala
@@ -37,6 +37,7 @@ case class JavaScriptStringSource(source: String) extends JavaScriptSource {
     }
 }
 
+// TODO: Implement a way to read source files from disk and uncomment lines in LocalJSSourceFinder
 case class JavaScriptFileSource(path: String) extends JavaScriptSource {
     override def asString: String = throw new RuntimeException("Not implemented!")
 

--- a/OPAL/js/src/main/scala/org/opalj/js/LocalJSSourceFinder.scala
+++ b/OPAL/js/src/main/scala/org/opalj/js/LocalJSSourceFinder.scala
@@ -127,6 +127,8 @@ class LocalJSSourceFinder(val p: SomeProject) extends (JavaStatement => Set[Java
     private def varToJavaScriptSource(method: Method, variable: JavaIFDSProblem.V): Set[JavaScriptSource] = {
         val resultSet: mutable.Set[JavaScriptSource] = mutable.Set()
 
+        // TODO: use a string analysis instead of 'Assignment with a.expr.isStringConst' here
+
         def findFileArg(sites: IntTrieSet): Unit = {
             val calls = findCallOnObject(method, sites, "<init>")
             calls.foreach(init => {

--- a/OPAL/js/src/main/scala/org/opalj/js/LocalJSSourceFinder.scala
+++ b/OPAL/js/src/main/scala/org/opalj/js/LocalJSSourceFinder.scala
@@ -1,0 +1,184 @@
+/* BSD 2-Clause License - see OPAL/LICENSE for details. */
+package org.opalj.js
+
+import org.opalj.br.{Method, ObjectType}
+import org.opalj.br.analyses.SomeProject
+import org.opalj.collection.immutable.IntTrieSet
+import org.opalj.tac.{AITACode, ASTNode, Assignment, Call, ComputeTACAIKey, Expr, ExprStmt, MethodCall, Stmt, TACMethodParameter, TACode}
+import org.opalj.tac.fpcf.analyses.ifds.JavaIFDSProblem.V
+import org.opalj.tac.fpcf.analyses.ifds.{JavaIFDSProblem, JavaStatement}
+import org.opalj.value.ValueInformation
+
+import scala.collection.mutable
+
+/**
+ * Uses the def-use information of TACAI to find the javascript sources passed
+ * to an ScriptEngine within method boundaries.
+ *
+ * @param p Project
+ */
+class LocalJSSourceFinder(val p: SomeProject) extends (JavaStatement => Set[JavaScriptSource]) {
+    final type TACAICode = TACode[TACMethodParameter, JavaIFDSProblem.V]
+    val tacaiKey: Method => AITACode[TACMethodParameter, ValueInformation] = p.get(ComputeTACAIKey)
+
+    /* Maps a statement defining a JavaScript source to the instance.  */
+    val statementToJavaScriptSource: mutable.Map[Stmt[V], JavaScriptSource] = mutable.Map()
+    /* Maps the statement to search from to the resulting set of JavaScriptSources.  */
+    val jsSourceCache: mutable.Map[(JavaStatement, Expr[V]), Set[JavaScriptSource]] = mutable.Map()
+
+    /**
+     * @see [[LocalJSSourceFinder.findJSSourceOnInvokeFunction()]]
+     */
+    override def apply(stmt: JavaStatement): Set[JavaScriptSource] = findJSSourceOnInvokeFunction(stmt, JavaIFDSProblem.asCall(stmt.stmt).allParams.head.asVar)
+
+    /**
+     * In case of a snippet like this:
+     * 1 ScriptEngine se = ...;
+     * 2 se.eval("JS Code");
+     * 3 ((Invocable) se).invokeFunction("myFunction", args...);
+     * This functions finds "JS Code" given "se" at se.invokeFunction().
+     *
+     * @param javaStmt statement to start with
+     * @param arg    ScriptEngine variable
+     * @return javascript source code
+     */
+    private def findJSSourceOnInvokeFunction(javaStmt: JavaStatement, arg: Expr[V]): Set[JavaScriptSource] = {
+        val decls = findCallOnObject(javaStmt.method, arg.asVar.definedBy, "getEngineByName")
+
+        val maybeCached = jsSourceCache.get((javaStmt, arg))
+        if (maybeCached.isDefined)
+            maybeCached.get
+        else
+            decls.flatMap(decl => {
+                val evals = findCallOnObject(
+                    javaStmt.method,
+                    decl.asAssignment.targetVar.usedBy,
+                    "eval"
+                )
+                val jsSources = evals.flatMap(eval => {
+                    val evalCall = JavaIFDSProblem.asCall(eval)
+                    varToJavaScriptSource(javaStmt.method, evalCall.params.head.asVar)
+                })
+                jsSourceCache += (javaStmt, arg) -> jsSources
+                jsSources
+            })
+    }
+
+    /**
+     * Finds all definiton/use sites inside the method.
+     *
+     * @param method method to be searched in
+     * @param sites  definition or use sites
+     * @return sites as JavaStatement
+     */
+    private def searchStmts(method: Method, sites: IntTrieSet): Set[Stmt[JavaIFDSProblem.V]] = {
+        val taCode = tacaiKey(method)
+        sites.map(site => taCode.stmts.apply(site))
+    }
+
+    /**
+     * If stmt is a call, return it as a FunctionCall
+     *
+     * @param stmt Statement
+     * @return maybe a function call
+     */
+    private def maybeCall(stmt: Stmt[JavaIFDSProblem.V]): Option[Call[JavaIFDSProblem.V]] = {
+        def isCall(node: ASTNode[JavaIFDSProblem.V]) = node match {
+            case expr: Expr[JavaIFDSProblem.V] => expr.isVirtualFunctionCall || expr.isStaticFunctionCall
+            case stmt: Stmt[JavaIFDSProblem.V] => (stmt.isNonVirtualMethodCall
+                || stmt.isVirtualMethodCall
+                || stmt.isStaticMethodCall)
+        }
+
+        stmt match {
+            case exprStmt: ExprStmt[JavaIFDSProblem.V] if isCall(exprStmt.expr) =>
+                Some(exprStmt.expr.asFunctionCall)
+            case assignStmt: Assignment[JavaIFDSProblem.V] if isCall(assignStmt.expr) =>
+                Some(assignStmt.expr.asFunctionCall)
+            case call: MethodCall[JavaIFDSProblem.V] if isCall(stmt) =>
+                Some(call)
+            case _ => None
+        }
+    }
+
+    /**
+     * Finds instance method calls.
+     *
+     * @param method Method to search in.
+     * @param sites def/use sites
+     * @param methodName searched method name as string
+     * @return
+     */
+    private def findCallOnObject(method: Method, sites: IntTrieSet, methodName: String): Set[Stmt[V]] = {
+        val stmts = searchStmts(method, sites)
+        stmts.map(stmt => maybeCall(stmt) match {
+            case Some(call) if call.name.equals(methodName) => Some(stmt)
+            case _                                          => None
+        }).filter(_.isDefined).map(_.get)
+    }
+
+    /**
+     * Tries to resolve a variable either to a string constant or a file path containing the variable's value
+     *
+     * @param method   method to be searched in
+     * @param variable variable of interest
+     * @return JavaScriptSource
+     */
+    private def varToJavaScriptSource(method: Method, variable: JavaIFDSProblem.V): Set[JavaScriptSource] = {
+        val resultSet: mutable.Set[JavaScriptSource] = mutable.Set()
+
+        def findFileArg(sites: IntTrieSet): Unit = {
+            val calls = findCallOnObject(method, sites, "<init>")
+            calls.foreach(init => {
+                val defSitesOfFileSrc = init.asInstanceMethodCall.params.head.asVar.definedBy
+                val defs = searchStmts(method, defSitesOfFileSrc)
+                defs.foreach {
+                    /* new File("path/to/src"); */
+                    case a: Assignment[JavaIFDSProblem.V] if a.expr.isStringConst =>
+                    //                        resultSet.add(statementToJavaScriptSource.getOrElseUpdate(a,
+                    //                            JavaScriptFileSource(a.expr.asStringConst.value)))
+                    /* File constructor argument is no string constant */
+                    case _ =>
+                }
+            })
+        }
+
+        def findFileReaderArg(sites: IntTrieSet): Unit = {
+            val calls = findCallOnObject(method, sites, "<init>")
+            calls.foreach(init => {
+                val defSitesOfFileReaderSrc = init.asInstanceMethodCall.params.head.asVar.definedBy
+                val defs = searchStmts(method, defSitesOfFileReaderSrc)
+                defs.foreach {
+                    /* FileReader fr = new FileReader(new File("path/to/src")); */
+                    case a: Assignment[JavaIFDSProblem.V] if a.expr.isStringConst =>
+                    //                        resultSet.add(statementToJavaScriptSource.getOrElseUpdate(a,
+                    //                            JavaScriptFileSource(a.expr.asStringConst.value)))
+                    /* new FileReader(new File(...)); */
+                    case a: Assignment[JavaIFDSProblem.V] if a.expr.isNew =>
+                        if (a.expr.asNew.tpe.isSubtypeOf(ObjectType("java/io/File"))(p.classHierarchy))
+                            findFileArg(a.targetVar.usedBy)
+                    // Unknown argument
+                    case _ =>
+                }
+            })
+        }
+
+        val nextJStmts = searchStmts(method, variable.definedBy)
+        nextJStmts.foreach {
+            /* se.eval("function() ..."); */
+            case a: Assignment[JavaIFDSProblem.V] if a.expr.isStringConst =>
+                resultSet.add(statementToJavaScriptSource.getOrElseUpdate(a, JavaScriptStringSource(a.expr.asStringConst.value)))
+            case a: Assignment[JavaIFDSProblem.V] if a.expr.isNew =>
+                val tpe: ObjectType = a.expr.asNew.tpe
+                /* se.eval(new FileReader(...)); */
+                if (tpe.isSubtypeOf(ObjectType("java/io/FileReader"))(p.classHierarchy))
+                    findFileReaderArg(a.targetVar.usedBy)
+                /* se.eval(new File(...)); */
+                else if (tpe.isSubtypeOf(ObjectType("java/io/File"))(p.classHierarchy))
+                    findFileArg(a.targetVar.usedBy)
+            case _ =>
+        }
+
+        resultSet.toSet
+    }
+}

--- a/OPAL/js/src/test/scala/org/opal/js/JavaScriptAwareTaintAnalysisFixture.scala
+++ b/OPAL/js/src/test/scala/org/opal/js/JavaScriptAwareTaintAnalysisFixture.scala
@@ -1,0 +1,70 @@
+/* BSD 2-Clause License - see OPAL/LICENSE for details. */
+package org.opal.js
+
+import org.opalj.br.Method
+import org.opalj.br.analyses.{DeclaredMethodsKey, ProjectInformationKeys, SomeProject}
+import org.opalj.br.fpcf.PropertyStoreKey
+import org.opalj.fpcf.{PropertyBounds, PropertyStore}
+import org.opalj.ifds.{IFDSAnalysis, IFDSAnalysisScheduler, IFDSPropertyMetaInformation}
+import org.opalj.js.JavaScriptAwareTaintProblem
+import org.opalj.tac.cg.TypeProviderKey
+import org.opalj.tac.fpcf.analyses.ifds.taint.{TaintFact, FlowFact, TaintNullFact, Variable}
+import org.opalj.tac.fpcf.analyses.ifds.{JavaMethod, JavaStatement}
+import org.opalj.tac.fpcf.properties.Taint
+
+/**
+ * An analysis that checks, if the return value of the method `source` can flow to the parameter of
+ * the method `sink`.
+ *
+ * @author Mario Trageser
+ */
+class JavaScriptAwareTaintAnalysisFixture(project: SomeProject)
+    extends IFDSAnalysis()(project, new JavaScriptAwareTaintProblemProblemFixture(project), Taint)
+
+class JavaScriptAwareTaintProblemProblemFixture(p: SomeProject) extends JavaScriptAwareTaintProblem(p) {
+    /* Without, the tests are unbearably slow. */
+    override def useSummaries = true
+
+    /**
+     * The analysis starts with all public methods in TaintAnalysisTestClass.
+     */
+    override val entryPoints: Seq[(Method, TaintFact)] = p.allProjectClassFiles.filter(classFile =>
+        classFile.thisType.fqn == "org/opalj/fpcf/fixtures/js/Java2JsTestClass")
+        .flatMap(classFile => classFile.methods)
+        .filter(method => method.isPublic && outsideAnalysisContext(method).isEmpty)
+        .map(method => method -> TaintNullFact)
+
+    /**
+     * The sanitize method is a sanitizer.
+     */
+    override protected def sanitizesReturnValue(callee: Method): Boolean = callee.name == "sanitize"
+
+    /**
+     * We do not sanitize paramters.
+     */
+    override protected def sanitizesParameter(call: JavaStatement, in: TaintFact): Boolean = false
+
+    /**
+     * Creates a new variable fact for the callee, if the source was called.
+     */
+    override protected def createTaints(callee: Method, call: JavaStatement): Set[TaintFact] =
+        if (callee.name == "source") Set(Variable(call.index))
+        else Set.empty
+
+    /**
+     * Create a FlowFact, if sink is called with a tainted variable.
+     * Note, that sink does not accept array parameters. No need to handle them.
+     */
+    override protected def createFlowFact(callee: Method, call: JavaStatement,
+                                          in: TaintFact): Option[FlowFact] =
+        if (callee.name == "sink" && in == Variable(-2))
+            Some(FlowFact(Seq(JavaMethod(call.method))))
+        else None
+}
+
+object IFDSAnalysisJSFixtureScheduler extends IFDSAnalysisScheduler[TaintFact, Method, JavaStatement] {
+    override def init(p: SomeProject, ps: PropertyStore) = new JavaScriptAwareTaintAnalysisFixture(p)
+    override def property: IFDSPropertyMetaInformation[JavaStatement, TaintFact] = Taint
+    override val uses: Set[PropertyBounds] = Set(PropertyBounds.ub(Taint))
+    override def requiredProjectInformation: ProjectInformationKeys = Seq(TypeProviderKey, DeclaredMethodsKey, PropertyStoreKey)
+}

--- a/OPAL/tac/src/main/resources/summaries/java.io.BufferedInputStream.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.io.BufferedInputStream.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<methods>
+		<method id="void &lt;init&gt;(java.io.InputStream)">
+			<flows>
+				<flow isAlias="true">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.BufferedInputStream: java.io.InputStream innerStream]"
+						AccessPathTypes="[java.io.InputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.io.InputStream,int)">
+			<flows>
+				<flow isAlias="true">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.BufferedInputStream: java.io.InputStream innerStream]"
+						AccessPathTypes="[java.io.InputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int read()">
+			<flows>
+				<flow isAlias="false" cutSubfields="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int read(byte[])">
+			<flows>
+				<flow isAlias="false" cutSubfields="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Parameter" ParameterIndex="0" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int read(byte[],int,int)">
+			<flows>
+				<flow isAlias="false" cutSubfields="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Parameter" ParameterIndex="0" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.io.BufferedOutputStream.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.io.BufferedOutputStream.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<methods>
+		<method id="void &lt;init&gt;(java.io.OutputStream)">
+			<flows>
+				<flow isAlias="true">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.BufferedOutputStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.io.OutputStream,int)">
+			<flows>
+				<flow isAlias="true">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.BufferedOutputStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void write(byte[],int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.BufferedOutputStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void write(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.BufferedOutputStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void write(byte[])">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.BufferedOutputStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.io.BufferedReader.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.io.BufferedReader.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<methods>
+		<method id="void &lt;init&gt;(java.io.Reader)">
+			<flows>
+				<flow isAlias="true">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.BufferedReader: java.io.Reader innerReader]"
+						AccessPathTypes="[java.io.Reader]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.io.Reader,int)">
+			<flows>
+				<flow isAlias="true">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.BufferedReader: java.io.Reader innerReader]"
+						AccessPathTypes="[java.io.Reader]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int read()">
+			<flows>
+				<flow isAlias="false" cutSubfields="true" typeChecking="false">
+					<from sourceSinkType="Field"  />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int read(char[])">
+			<flows>
+				<flow isAlias="false" cutSubfields="true" typeChecking="false">
+					<from sourceSinkType="Field"  />
+					<to sourceSinkType="Parameter" ParameterIndex="0" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int read(char[],int,int)">
+			<flows>
+				<flow isAlias="false" cutSubfields="true" typeChecking="false">
+					<from sourceSinkType="Field"  />
+					<to sourceSinkType="Parameter" ParameterIndex="0" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int read(java.nio.CharBuffer)">
+			<flows>
+				<flow isAlias="false" cutSubfields="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.nio.CharBuffer: char[] buffer]"
+						AccessPathTypes="[char[]]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String readLine()">
+			<flows>
+				<flow isAlias="false" cutSubfields="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.io.BufferedWriter.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.io.BufferedWriter.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<methods>
+		<method id="void &lt;init&gt;(java.io.Writer)">
+			<flows>
+				<flow isAlias="true">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.BufferedWriter: java.io.Writer innerWriter]"
+						AccessPathTypes="[java.io.Writer]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.io.Writer,int)">
+			<flows>
+				<flow isAlias="true">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.BufferedWriter: java.io.Writer innerWriter]"
+						AccessPathTypes="[java.io.Writer]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.io.Writer append(char)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.BufferedWriter: java.io.Writer innerWriter]"
+						AccessPathTypes="[java.io.Writer]" />
+				</flow>
+				<flow isAlias="true">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.io.Writer append(java.lang.CharSequence)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.BufferedWriter: java.io.Writer innerWriter]"
+						AccessPathTypes="[java.io.Writer]" />
+				</flow>
+				<flow isAlias="true">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.io.Writer append(java.lang.CharSequence,int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.BufferedWriter: java.io.Writer innerWriter]"
+						AccessPathTypes="[java.io.Writer]" />
+				</flow>
+				<flow isAlias="true">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void write(char[],int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.BufferedWriter: java.io.Writer innerWriter]"
+						AccessPathTypes="[java.io.Writer]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void write(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.BufferedWriter: java.io.Writer innerWriter]"
+						AccessPathTypes="[java.io.Writer]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void write(char[])">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.BufferedWriter: java.io.Writer innerWriter]"
+						AccessPathTypes="[java.io.Writer]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void write(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.BufferedWriter: java.io.Writer innerWriter]"
+						AccessPathTypes="[java.io.Writer]" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.io.ByteArrayInputStream.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.io.ByteArrayInputStream.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+  <methods>
+    <method id="void &lt;init&gt;(byte[])">
+      <flows>
+        <flow isAlias="true">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+          <to sourceSinkType="Field"
+            AccessPath="[java.io.InputStream: byte[] innerArray]"
+            AccessPathTypes="[byte[]]" />
+        </flow>
+      </flows>
+    </method>
+    <method id="void &lt;init&gt;(byte[],int,int)">
+      <flows>
+        <flow isAlias="true">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+          <to sourceSinkType="Field"
+            AccessPath="[java.io.InputStream: byte[] innerArray]"
+            AccessPathTypes="[byte[]]" />
+        </flow>
+      </flows>
+    </method>
+    <method id="int read()">
+      <flows>
+        <flow isAlias="false" cutSubfields="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="int read(byte[])">
+      <flows>
+        <flow isAlias="false" cutSubfields="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Parameter" ParameterIndex="0" />
+        </flow>
+      </flows>
+    </method>
+    <method id="int read(byte[],int,int)">
+      <flows>
+        <flow isAlias="false" cutSubfields="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Parameter" ParameterIndex="0" />
+        </flow>
+      </flows>
+    </method>
+  </methods>
+ </summary>

--- a/OPAL/tac/src/main/resources/summaries/java.io.ByteArrayOutputStream.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.io.ByteArrayOutputStream.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+  <methods>
+    <method id="void write(byte[])">
+      <flows>
+        <flow isAlias="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+          <to sourceSinkType="Field"
+            AccessPath="[java.io.OutputStream: byte[] innerArray]"
+            AccessPathTypes="[byte[]]" />
+        </flow>
+      </flows>
+    </method>
+    <method id="void write(byte[],int,int)">
+      <flows>
+        <flow isAlias="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+          <to sourceSinkType="Field"
+            AccessPath="[java.io.OutputStream: byte[] innerArray]"
+            AccessPathTypes="[byte[]]" />
+        </flow>
+      </flows>
+    </method>
+    <method id="void write(int)">
+      <flows>
+        <flow isAlias="false" cutSubfields="true" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+          <to sourceSinkType="Field"
+            AccessPath="[java.io.OutputStream: byte[] innerArray]"
+            AccessPathTypes="[byte[]]" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.lang.String toString()">
+      <flows>
+        <flow isAlias="false" cutSubfields="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.lang.String toString(java.lang.String)">
+      <flows>
+        <flow isAlias="false" cutSubfields="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.lang.String toString(int)">
+      <flows>
+        <flow isAlias="false" cutSubfields="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="byte[] toByteArray()">
+      <flows>
+        <flow isAlias="false" cutSubfields="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="void writeTo(java.io.OutputStream)">
+      <flows>
+        <flow isAlias="false" cutSubfields="true" typeChecking="false">
+          <from sourceSinkType="Field"  />
+          <to sourceSinkType="Parameter" ParameterIndex="0"
+            AccessPath="[java.io.OutputStream: byte[] innerArray]"
+            AccessPathTypes="[byte[]]" />
+        </flow>
+      </flows>
+    </method>
+  </methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.io.CharArrayReader.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.io.CharArrayReader.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<methods>
+		<method id="void &lt;init&gt;(char[])">
+			<flows>
+				<flow isAlias="true">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.CharArrayReader: char[] array]"
+						AccessPathTypes="[char[]]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(char[],int,int)">
+			<flows>
+				<flow isAlias="true">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.CharArrayReader: char[] array]"
+						AccessPathTypes="[char[]]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int read()">
+			<flows>
+				<flow isAlias="false" cutSubfields="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int read(char[])">
+			<flows>
+				<flow isAlias="false" cutSubfields="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Parameter" ParameterIndex="0" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int read(char[],int,int)" >
+			<flows>
+				<flow isAlias="false" cutSubfields="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Parameter" ParameterIndex="0" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int read(java.nio.CharBuffer)">
+			<flows>
+				<flow isAlias="false" cutSubfields="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.nio.CharBuffer: char[] buffer]"
+						AccessPathTypes="[char[]]" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.io.CharArrayWriter.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.io.CharArrayWriter.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<methods>
+		<method id="java.io.CharArrayWriter append(char)">
+			<flows>
+				<flow isAlias="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.CharArrayWriter: char[] array]"
+						AccessPathTypes="[char[]]" />
+				</flow>
+				<flow isAlias="true">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.io.CharArrayWriter append(java.lang.CharSequence)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.CharArrayWriter: char[] array]"
+						AccessPathTypes="[char[]]" />
+				</flow>
+				<flow isAlias="true">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.io.CharArrayWriter append(java.lang.CharSequence,int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.CharArrayWriter: char[] array]"
+						AccessPathTypes="[char[]]" />
+				</flow>
+				<flow isAlias="true">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="char[] toCharArray()">
+			<flows>
+				<flow isAlias="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.io.CharArrayWriter: char[] array]"
+						AccessPathTypes="[char[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toString()">
+			<flows>
+				<flow isAlias="false" cutSubfields="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void write(char[],int,int)">
+			<flows>
+				<flow isAlias="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.CharArrayWriter: char[] array]"
+						AccessPathTypes="[char[]]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void write(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.CharArrayWriter: char[] array]"
+						AccessPathTypes="[char[]]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void write(char[])">
+			<flows>
+				<flow isAlias="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.CharArrayWriter: char[] array]"
+						AccessPathTypes="[char[]]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void write(char[],int,int)">
+			<flows>
+				<flow isAlias="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.CharArrayWriter: char[] array]"
+						AccessPathTypes="[char[]]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void write(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.CharArrayWriter: char[] array]"
+						AccessPathTypes="[char[]]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void write(java.lang.String,int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.CharArrayWriter: char[] array]"
+						AccessPathTypes="[char[]]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void write(java.io.Writer)">
+			<flows>
+				<flow isAlias="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.io.DataInputStream.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.io.DataInputStream.xml
@@ -1,0 +1,159 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+  <methods>
+    <method id="void &lt;init&gt;(java.io.InputStream)">
+      <flows>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+          <to sourceSinkType="Field"
+              AccessPath="[java.io.DataInputStream: java.io.InputStream innerStream]"
+          	  AccessPathTypes="[java.io.InputStream]" />
+        </flow>
+      </flows>
+    </method>
+    <method id="int read()">
+      <flows>
+        <flow isAlias="false" cutSubfields="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="int read(byte[])">
+      <flows>
+        <flow isAlias="false" cutSubfields="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Parameter" ParameterIndex="0" />
+        </flow>
+      </flows>
+    </method>
+    <method id="int read(byte[],int,int)">
+      <flows>
+        <flow isAlias="false" cutSubfields="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Parameter" ParameterIndex="0" />
+        </flow>
+      </flows>
+    </method>
+    <method id="boolean readBoolean()">
+      <flows>
+        <flow isAlias="false" cutSubfields="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="byte readByte()">
+      <flows>
+        <flow isAlias="false" cutSubfields="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="char readChar()">
+      <flows>
+        <flow isAlias="false" cutSubfields="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="double readDouble">
+      <flows>
+        <flow isAlias="false" cutSubfields="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="float readFloat()">
+      <flows>
+        <flow isAlias="false" cutSubfields="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="int readFully(byte[])">
+      <flows>
+        <flow isAlias="false" cutSubfields="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Parameter" ParameterIndex="0" />
+        </flow>
+      </flows>
+    </method>
+    <method id="int readFully(byte[],int,int)">
+      <flows>
+        <flow isAlias="false" cutSubfields="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Parameter" ParameterIndex="0" />
+        </flow>
+      </flows>
+    </method>
+    <method id="int readInt()">
+      <flows>
+        <flow isAlias="false" cutSubfields="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.lang.String readLine()">
+      <flows>
+        <flow isAlias="false" cutSubfields="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="long readLong()">
+      <flows>
+        <flow isAlias="false" cutSubfields="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="short readShort()">
+      <flows>
+        <flow isAlias="false" cutSubfields="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="int readUnsignedByte()">
+      <flows>
+        <flow isAlias="false" cutSubfields="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="int readUnsignedShort()">
+      <flows>
+        <flow isAlias="false" cutSubfields="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.lang.String readUTF()">
+      <flows>
+        <flow isAlias="false" cutSubfields="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.lang.String readUTF(java.io.DataInput)">
+      <flows>
+        <flow isAlias="false" cutSubfields="true" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+  </methods>
+ </summary>

--- a/OPAL/tac/src/main/resources/summaries/java.io.DataOutputStream.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.io.DataOutputStream.xml
@@ -1,0 +1,155 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<methods>
+		<method id="void &lt;init&gt;(java.io.OutputStream)">
+			<flows>
+				<flow isAlias="true">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.DataOutputStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void write(byte[],int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.DataOutputStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void write(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.DataOutputStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void write(byte[])">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.DataOutputStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void writeBoolean(boolean)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.DataOutputStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void writeByte(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.DataOutputStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void writeBytes(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.DataOutputStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void writeChar(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.DataOutputStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void writeChars(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.DataOutputStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void writeDouble(double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.DataOutputStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void writeFloat(float)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.DataOutputStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void writeInt(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.DataOutputStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void writeLong(long)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.DataOutputStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void writeShort(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.DataOutputStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void writeUTF(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.DataOutputStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.io.File.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.io.File.xml
@@ -1,0 +1,181 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<methods>
+		<method id="void &lt;init&gt;(java.io.File,java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.io.File: java.lang.String fileName]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.File: java.lang.String fileName]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.File: java.lang.String fileName]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.File: java.lang.String fileName]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.lang.String,java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.File: java.lang.String fileName]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.File: java.lang.String fileName]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.net.URI)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.net.URI: java.lang.String path]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.File: java.lang.String fileName]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.io.File getAbsoluteFile()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String getAbsolutePath()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.io.File: java.lang.String fileName]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.io.File getCanonicalFile()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String getCanonicalPath()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.io.File: java.lang.String fileName]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String getName()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.io.File: java.lang.String fileName]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String getParent()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.io.File: java.lang.String fileName]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.io.File getParentFile()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String getPath()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.io.File: java.lang.String fileName]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.nio.file.Path toPath()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.io.File: java.lang.String fileName]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.nio.file.Path: java.lang.String fileName]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toString()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.io.File: java.lang.String fileName]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.net.URI toURI()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.io.File: java.lang.String fileName]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.net.URI: java.lang.String path]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.net.URL toURL()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.io.File: java.lang.String fileName]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.net.URL: java.lang.String file]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.io.FileInputStream.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.io.FileInputStream.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<hierarchy superClass="java.io.InputStream" />
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.io.FileOutputStream.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.io.FileOutputStream.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<hierarchy superClass="java.io.OutputStream" />
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.io.FilterInputStream.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.io.FilterInputStream.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<hierarchy superClass="java.io.InputStream">
+	</hierarchy>
+	<methods>
+		<method id="void &lt;init&gt;(java.io.InputStream)">
+			<flows>
+				<flow isAlias="true">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.InputStream: java.io.InputStream innerStream]"
+						AccessPathTypes="[java.io.InputStream]" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.io.InputStream.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.io.InputStream.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<hierarchy superClass="java.lang.Object">
+		<interface name="java.io.Closeable" />
+		<interface name="java.lang.AutoCloseable" />
+	</hierarchy>
+	<methods>
+		<method id="int read()">
+			<flows>
+				<flow isAlias="false" typeChecking="false" cutSubfields="true">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int read(byte[])">
+			<flows>
+				<flow isAlias="false" typeChecking="false" cutSubfields="true">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Parameter" ParameterIndex="0" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int read(byte[],int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false" cutSubfields="true">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Parameter" ParameterIndex="0" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.io.InputStreamReader.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.io.InputStreamReader.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<hierarchy superClass="java.io.Reader">
+		<interface name="java.io.Closeable" />
+		<interface name="java.io.Flushable" />
+		<interface name="java.lang.AutoCloseable" />
+	</hierarchy>
+	<methods>
+		<method id="void &lt;init&gt;(java.io.InputStream)">
+			<flows>
+				<flow isAlias="true">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.InputStreamReader: java.io.InputStream innerStream]"
+						AccessPathTypes="[java.io.InputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.io.InputStream,java.nio.charset.Charset)">
+			<flows>
+				<flow isAlias="true">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.InputStreamReader: java.io.InputStream innerStream]"
+						AccessPathTypes="[java.io.InputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.io.InputStream,java.nio.charset.CharsetDecoder)">
+			<flows>
+				<flow isAlias="true">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.InputStreamReader: java.io.InputStream innerStream]"
+						AccessPathTypes="[java.io.InputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.io.InputStream,java.lang.String)">
+			<flows>
+				<flow isAlias="true">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.InputStreamReader: java.io.InputStream innerStream]"
+						AccessPathTypes="[java.io.InputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int read()">
+			<flows>
+				<flow isAlias="false" typeChecking="false" cutSubfields="true">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int read(char[])">
+			<flows>
+				<flow isAlias="false" typeChecking="false" cutSubfields="true">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Parameter" ParameterIndex="0" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int read(char[],int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false" cutSubfields="true">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Parameter" ParameterIndex="0" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int read(java.nio.CharBuffer)">
+			<flows>
+				<flow isAlias="false" typeChecking="false" cutSubfields="true">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.nio.CharBuffer: char[] buffer]"
+						AccessPathTypes="[char[]]" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.io.LineNumberReader.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.io.LineNumberReader.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<methods>
+		<method id="void &lt;init&gt;(java.io.Reader)">
+			<flows>
+				<flow isAlias="true">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.LineNumberReader: java.io.Reader innerReader]"
+						AccessPathTypes="[java.io.Reader]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.io.Reader,int)">
+			<flows>
+				<flow isAlias="true">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.LineNumberReader: java.io.Reader innerReader]"
+						AccessPathTypes="[java.io.Reader]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int read()">
+			<flows>
+				<flow isAlias="false" typeChecking="false" cutSubfields="true">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int read(char[])">
+			<flows>
+				<flow isAlias="false" typeChecking="false" cutSubfields="true">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Parameter" ParameterIndex="0" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int read(char[],int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false" cutSubfields="true">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Parameter" ParameterIndex="0" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int read(java.nio.CharBuffer)">
+			<flows>
+				<flow isAlias="false" typeChecking="false" cutSubfields="true">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.nio.CharBuffer: char[] buffer]"
+						AccessPathTypes="[char[]]" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.io.ObjectInputStream.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.io.ObjectInputStream.xml
@@ -1,0 +1,177 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<methods>
+		<method id="void &lt;init&gt;(java.io.InputStream)">
+			<flows>
+				<flow isAlias="true">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.InputStream: java.io.InputStream innerStream]"
+						AccessPathTypes="[java.io.InputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int read()">
+			<flows>
+				<flow isAlias="false" typeChecking="false" cutSubfields="true">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int read(byte[])" typeChecking="false" cutSubfields="true">
+			<flows>
+				<flow isAlias="false" cutSubfields="true">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Parameter" ParameterIndex="0" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void read(byte[],int,int)" typeChecking="false" cutSubfields="true">
+			<flows>
+				<flow isAlias="false" cutSubfields="true">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Parameter" ParameterIndex="0" />
+				</flow>
+			</flows>
+		</method>
+		<method id="byte readByte()" typeChecking="false" cutSubfields="true">
+			<flows>
+				<flow isAlias="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="char readChar()" typeChecking="false" cutSubfields="true">
+			<flows>
+				<flow isAlias="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="double readDouble()" typeChecking="false" cutSubfields="true">
+			<flows>
+				<flow isAlias="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="float readFloat()" typeChecking="false" cutSubfields="true">
+			<flows>
+				<flow isAlias="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void readFully(byte[])">
+			<flows>
+				<flow isAlias="false" typeChecking="false" cutSubfields="true">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Parameter" ParameterIndex="0" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void readFully(byte[],int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false" cutSubfields="true">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Parameter" ParameterIndex="0" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int readInt()">
+			<flows>
+				<flow isAlias="false" typeChecking="false" cutSubfields="true">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String readLine()">
+			<flows>
+				<flow isAlias="false" typeChecking="false" cutSubfields="true">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="long readLong()" typeChecking="false" cutSubfields="true">
+			<flows>
+				<flow isAlias="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Object readObject()">
+			<flows>
+				<flow isAlias="false" typeChecking="false" cutSubfields="true">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Object readObjectOverride()">
+			<flows>
+				<flow isAlias="false" typeChecking="false" cutSubfields="true">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="short readShort()">
+			<flows>
+				<flow isAlias="false" typeChecking="false" cutSubfields="true">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Object readUnshared()">
+			<flows>
+				<flow isAlias="false" typeChecking="false" cutSubfields="true">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int readUnsignedByte()">
+			<flows>
+				<flow isAlias="false" typeChecking="false" cutSubfields="true">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int readUnsignedShort()">
+			<flows>
+				<flow isAlias="false" typeChecking="false" cutSubfields="true">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String readUTF()">
+			<flows>
+				<flow isAlias="false" typeChecking="false" cutSubfields="true">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.io.ObjectInputStream$GetField readFields()">
+			<flows>
+				<flow isAlias="false" typeChecking="false" cutSubfields="true">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.io.ObjectInputStream$GetField: java.io.InputStream innerStream]"
+						AccessPathTypes="[java.io.InputStream]" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.io.ObjectOutputStream.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.io.ObjectOutputStream.xml
@@ -1,0 +1,225 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<methods>
+		<method id="void &lt;init&gt;(java.io.OutputStream)">
+			<flows>
+				<flow isAlias="true">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+            AccessPath="[java.io.OutputStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+					<to sourceSinkType="Field"
+            AccessPath="[java.io.OutputStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+				<flow isAlias="true" typeChecking="true">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.io.OutputStream: byte[] innerArray]"
+						AccessPathTypes="[byte[]]" />
+					<to sourceSinkType="Field"
+            AccessPath="[java.io.OutputStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+    <method id="void write(byte[])">
+      <flows>
+        <flow isAlias="false" typeChecking="false">>
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+            AccessPath="[java.io.OutputStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+        </flow>
+      </flows>
+    </method>
+    <method id="void write(byte[],int,int)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+            AccessPath="[java.io.OutputStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+        </flow>
+      </flows>
+    </method>
+    <method id="void write(int)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+            AccessPath="[java.io.OutputStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+        </flow>
+      </flows>
+    </method>
+    <method id="void writeBoolean(boolean)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+            AccessPath="[java.io.OutputStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+        </flow>
+      </flows>
+    </method>
+    <method id="void writeByte(int)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+            AccessPath="[java.io.OutputStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+        </flow>
+      </flows>
+    </method>
+    <method id="void writeBytes(java.lang.String)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+            AccessPath="[java.io.OutputStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+        </flow>
+      </flows>
+    </method>
+    <method id="void writeChar(int)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+            AccessPath="[java.io.OutputStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+        </flow>
+      </flows>
+    </method>
+    <method id="void writeChars(java.lang.String)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+            AccessPath="[java.io.OutputStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+        </flow>
+      </flows>
+    </method>
+    <method id="void writeClassDescription(java.io.ObjectStreamClass)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+            AccessPath="[java.io.OutputStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+        </flow>
+      </flows>
+    </method>
+    <method id="void writeDouble(double)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+            AccessPath="[java.io.OutputStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+        </flow>
+      </flows>
+    </method>
+    <method id="void writeFloat(float)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+            AccessPath="[java.io.OutputStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+        </flow>
+      </flows>
+    </method>
+    <method id="void writeInt(int)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+            AccessPath="[java.io.OutputStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+        </flow>
+      </flows>
+    </method>
+    <method id="void writeLong(long)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+            AccessPath="[java.io.OutputStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+        </flow>
+      </flows>
+    </method>
+    <method id="void writeObject(java.lang.Object)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+            AccessPath="[java.io.OutputStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+        </flow>
+      </flows>
+    </method>
+    <method id="void writeObjectOverride(java.lang.Object)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+            AccessPath="[java.io.OutputStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+        </flow>
+      </flows>
+    </method>
+    <method id="void writeShort(int)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+            AccessPath="[java.io.OutputStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+        </flow>
+      </flows>
+    </method>
+    <method id="void writeUnshared(java.lang.Object)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+            AccessPath="[java.io.OutputStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+        </flow>
+      </flows>
+    </method>
+    <method id="void writeUTF(java.lang.String)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+            AccessPath="[java.io.OutputStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+        </flow>
+      </flows>
+    </method>
+		<method id="java.io.ObjectOutputStream$PutField putFields()">
+			<flows>
+				<flow isAlias="true">
+					<from sourceSinkType="Field" AccessPath="[java.io.ObjectOutputStream: java.io.OutputStream bufferedStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+					<to sourceSinkType="Return" AccessPath="[java.io.ObjectOutputStream$PutField: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void writeFields()">
+			<flows>
+				<flow isAlias="false">
+					<from sourceSinkType="Field" AccessPath="[java.io.ObjectOutputStream: java.io.OutputStream bufferedStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+					<to sourceSinkType="Field" AccessPath="[java.io.OutputStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.io.OutputStream.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.io.OutputStream.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<hierarchy superClass="java.lang.Object">
+		<interface name="java.io.Closeable" />
+		<interface name="java.io.Flushable" />
+		<interface name="java.lang.AutoCloseable" />
+	</hierarchy>
+	<methods>
+		<method id="void write(byte[])">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.OutputStream: byte[] innerArray]"
+						AccessPathTypes="[byte[]]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void write(byte[],int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.OutputStream: byte[] innerArray]"
+						AccessPathTypes="[byte[]]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void write(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.OutputStream: byte[] innerArray]"
+						AccessPathTypes="[byte[]]" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.io.OutputStreamWriter.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.io.OutputStreamWriter.xml
@@ -1,0 +1,143 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<hierarchy superClass="java.io.Writer">
+		<interface name="java.io.Closeable" />
+		<interface name="java.io.Flushable" />
+		<interface name="java.lang.Appendable" />
+		<interface name="java.lang.AutoCloseable" />
+	</hierarchy>
+	<methods>
+		<method id="void &lt;init&gt;(java.io.OutputStream)">
+			<flows>
+				<flow isAlias="true">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+            			AccessPath="[java.io.OutputStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.OutputStreamWriter: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.io.OutputStream: byte[] innerArray]"
+						AccessPathTypes="[byte[]]" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.OutputStreamWriter: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.io.OutputStream,java.nio.charset.Charset)">
+			<flows>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.OutputStreamWriter: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.io.OutputStream,java.nio.charset.CharsetEncoder)">
+			<flows>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.OutputStreamWriter: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.io.OutputStream,java.lang.String)">
+			<flows>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.OutputStreamWriter: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.io.Writer append(char)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.OutputStreamWriter: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+				<flow isAlias="true">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.io.Writer append(java.lang.CharSequence)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.OutputStreamWriter: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+				<flow isAlias="true">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.io.Writer append(java.lang.CharSequence,int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.OutputStreamWriter: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+				<flow isAlias="true">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void write(char[],int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.OutputStreamWriter: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void write(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.OutputStreamWriter: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void write(char[])">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.OutputStreamWriter: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void write(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.OutputStreamWriter: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.io.PrintStream.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.io.PrintStream.xml
@@ -1,0 +1,351 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<methods>
+		<method id="void &lt;init&gt;(java.io.OutputStream)">
+			<flows>
+				<flow isAlias="true">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.PrintStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.io.OutputStream, boolean)">
+			<flows>
+				<flow isAlias="true">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.PrintStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.io.OutputStream, boolean, java.lang.String)">
+			<flows>
+				<flow isAlias="true">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.PrintStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void write(byte[])">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.PrintStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void write(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.PrintStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void write(byte[],int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.PrintStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.io.PrintStream append(char)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.PrintStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+				<flow isAlias="true">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.io.PrintStream append(java.lang.CharSequence)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.PrintStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+				<flow isAlias="true">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.io.PrintStream append(java.lang.CharSequence,int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.PrintStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+				<flow isAlias="true">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.io.PrintStream format(java.lang.String,java.lang.Object[])">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.PrintStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+				<flow isAlias="true">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.io.PrintStream format(java.util.Locale,java.lang.String,java.lang.Object[])">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="2" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.PrintStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+				<flow isAlias="true">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void print(boolean)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.PrintStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void print(char)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.PrintStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void print(char[])">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.PrintStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void print(double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.PrintStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void print(float)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.PrintStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void print(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.PrintStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void print(long)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.PrintStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void print(java.lang.Object)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.PrintStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void print(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.PrintStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.io.PrintStream printf(java.util.Locale,java.lang.String,java.lang.Object[])">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="2" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.PrintStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+				<flow isAlias="true">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.io.PrintStream printf(java.lang.String,java.lang.Object[])">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.PrintStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+				<flow isAlias="true">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void println(boolean)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.PrintStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void println(char)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.PrintStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void println(char[])">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.PrintStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void println(double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.PrintStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void println(float)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.PrintStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void println(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.PrintStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void println(long)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.PrintStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void println(java.lang.Object)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.PrintStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void println(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.PrintStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toString()">
+			<flows>
+				<flow isAlias="false" cutSubfields="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+  </methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.io.PrintWriter.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.io.PrintWriter.xml
@@ -1,0 +1,372 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<hierarchy superClass="java.io.Writer">
+		<interface name="java.io.Closeable" />
+		<interface name="java.io.Flushable" />
+		<interface name="java.lang.Appendable" />
+		<interface name="java.lang.AutoCloseable" />
+	</hierarchy>
+	<methods>
+		<method id="void &lt;init&gt;(java.io.OutputStream)">
+			<flows>
+				<flow isAlias="true">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.Writer: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.io.OutputStream,boolean)">
+			<flows>
+				<flow isAlias="true">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.Writer: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void write(byte[])">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.Writer: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void write(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.Writer: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void write(byte[],int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.Writer: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void write(java.lang.String,int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.Writer: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void write(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.Writer: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.io.PrintWriter append(char)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.Writer: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+				<flow isAlias="true">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.io.PrintWriter append(java.lang.CharSequence)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.Writer: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+				<flow isAlias="true">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method
+			id="java.io.PrintWriter append(java.lang.CharSequence,int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.Writer: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+				<flow isAlias="true">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method
+			id="java.io.PrintWriter format(java.lang.String,java.lang.Object[])">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.Writer: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+				<flow isAlias="true">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method
+			id="java.io.PrintWriter format(java.util.Locale,java.lang.String,java.lang.Object[])">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="2" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.Writer: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+				<flow isAlias="true">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void print(boolean)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.Writer: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void print(char)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.Writer: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void print(char[])">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.Writer: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void print(double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.Writer: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void print(float)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.Writer: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void print(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.Writer: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void print(long)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.Writer: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void print(java.lang.Object)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.Writer: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void print(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.Writer: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method
+			id="java.io.PrintWriter printf(java.util.Locale,java.lang.String,java.lang.Object[])">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="2" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.Writer: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+				<flow isAlias="true">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method
+			id="java.io.PrintWriter printf(java.lang.String,java.lang.Object[])">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.Writer: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+				<flow isAlias="true">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void println(boolean)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.Writer: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void println(char)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.Writer: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void println(char[])">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.Writer: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void println(double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.Writer: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void println(float)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.Writer: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void println(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.Writer: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void println(long)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.Writer: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void println(java.lang.Object)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.Writer: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void println(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.Writer: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toString()">
+			<flows>
+				<flow isAlias="false"  cutSubfields="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.io.StringReader.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.io.StringReader.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<hierarchy superClass="java.io.Reader">
+		<interface name="java.io.Closeable" />
+		<interface name="java.io.Flushable" />
+		<interface name="java.lang.AutoCloseable" />
+	</hierarchy>
+  <methods>
+    <method id="void &lt;init&gt;(java.lang.String)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+          <to sourceSinkType="Field"
+            AccessPath="[java.io.StringReader: java.lang.String string]"
+          	AccessPathTypes="[java.lang.String]" />
+        </flow>
+      </flows>
+    </method>
+    <method id="int read()">
+      <flows>
+        <flow isAlias="false" cutSubfields="true" typeChecking="false">
+          <from sourceSinkType="Field"  />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="int read(char[])">
+      <flows>
+        <flow isAlias="false" cutSubfields="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Parameter" ParameterIndex="0" />
+        </flow>
+      </flows>
+    </method>
+    <method id="int read(java.nio.CharBuffer)">
+      <flows>
+        <flow isAlias="false" cutSubfields="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Parameter" ParameterIndex="0" />
+        </flow>
+      </flows>
+    </method>
+    <method id="int read(char[],int,int)">
+      <flows>
+        <flow isAlias="false" cutSubfields="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Parameter" ParameterIndex="0" />
+        </flow>
+      </flows>
+    </method>
+  </methods>
+ </summary>

--- a/OPAL/tac/src/main/resources/summaries/java.io.StringWriter.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.io.StringWriter.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<hierarchy superClass="java.io.Writer">
+		<interface name="java.io.Closeable" />
+		<interface name="java.io.Flushable" />
+		<interface name="java.lang.Appendable" />
+		<interface name="java.lang.AutoCloseable" />
+	</hierarchy>
+	<methods>
+		<method id="java.io.StringWriter append(char)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.StringWriter: java.lang.String string]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="true">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.io.StringWriter append(java.lang.CharSequence)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.StringWriter: java.lang.String string]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="true">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.io.StringWriter append(java.lang.CharSequence,int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.StringWriter: java.lang.String string]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="true">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void write(char[],int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.StringWriter: java.lang.String string]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void write(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.StringWriter: java.lang.String string]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void write(char[])">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.StringWriter: java.lang.String string]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void write(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.StringWriter: java.lang.String string]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void write(java.lang.String,int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.io.StringWriter: java.lang.String string]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuffer getBuffer()">
+			<flows>
+				<flow isAlias="false" cutSubfields="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toString()">
+			<flows>
+				<flow isAlias="false" cutSubfields="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.lang.Appendable.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.lang.Appendable.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<methods>
+		<method id="java.lang.Appendable append(char)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" 
+						 />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuffer append(java.lang.CharSequence)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" 
+						 />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuffer append(java.lang.CharSequence,int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" 
+						 />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.lang.Boolean.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.lang.Boolean.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<methods>
+		<method id="void &lt;init&gt;(boolean)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" AccessPath="[java.lang.Boolean: boolean value]"
+						AccessPathTypes="[boolean]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" AccessPath="[java.lang.Boolean: boolean value]"
+						AccessPathTypes="[boolean]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="boolean booleanValue()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.lang.Boolean: boolean value]"
+						AccessPathTypes="[boolean]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="boolean parseBoolean(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" AccessPath="[java.lang.Boolean: boolean value]"
+						AccessPathTypes="[boolean]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toString()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.lang.Boolean: boolean value]"
+						AccessPathTypes="[boolean]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toString(boolean)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Boolean valueOf(boolean)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" AccessPath="[java.lang.Boolean: java.lang.Boolean value]"
+						AccessPathTypes="[java.lang.Boolean]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Boolean valueOf(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" AccessPath="[java.lang.Boolean: java.lang.Boolean value]"
+						AccessPathTypes="[java.lang.Boolean]" />
+				</flow>
+			</flows>
+		</method>
+  </methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.lang.Byte.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.lang.Byte.xml
@@ -1,0 +1,148 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<methods>
+		<method id="void &lt;init&gt;(byte)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" AccessPath="[java.lang.Byte: byte value]"
+						AccessPathTypes="[byte]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" AccessPath="[java.lang.Byte: byte value]"
+						AccessPathTypes="[byte]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="byte byteValue()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.lang.Byte: byte value]"
+						AccessPathTypes="[byte]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Byte decode(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" AccessPath="[java.lang.Byte: byte value]"
+						AccessPathTypes="[byte]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="double doubleValue()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.lang.Byte: byte value]"
+						AccessPathTypes="[byte]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="float floatValue()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.lang.Byte: byte value]"
+						AccessPathTypes="[byte]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int intValue()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.lang.Byte: byte value]"
+						AccessPathTypes="[byte]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="long longValue()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.lang.Byte: byte value]"
+						AccessPathTypes="[byte]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="byte parseByte(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" AccessPath="[java.lang.Byte: byte value]"
+						AccessPathTypes="[byte]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="byte parseByte(java.lang.String,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" AccessPath="[java.lang.Byte: byte value]"
+						AccessPathTypes="[byte]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="short shortValue()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.lang.Byte: byte value]"
+						AccessPathTypes="[byte]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toString()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.lang.Byte: byte value]"
+						AccessPathTypes="[byte]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toString(byte)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Byte valueOf(byte)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" AccessPath="[java.lang.Byte: java.lang.Byte value]"
+						AccessPathTypes="[java.lang.Byte]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Byte valueOf(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" AccessPath="[java.lang.Byte: java.lang.Byte value]"
+						AccessPathTypes="[java.lang.Byte]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Byte valueOf(java.lang.String,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" AccessPath="[java.lang.Byte: java.lang.Byte value]"
+						AccessPathTypes="[java.lang.Byte]" />
+				</flow>
+			</flows>
+		</method>
+  </methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.lang.CharSequence.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.lang.CharSequence.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<methods>
+		<method id="char charAt(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.CharSequence subSequence(int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toString()">
+			<flows>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.lang.Character.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.lang.Character.xml
@@ -1,0 +1,229 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<methods>
+		<method id="void &lt;init&gt;(char)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" AccessPath="[java.lang.Character: char value]"
+						AccessPathTypes="[char]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="char charValue()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.lang.Character: char value]"
+						AccessPathTypes="[char]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int codePointAt(char[],int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return"/>
+				</flow>
+			</flows>
+		</method>
+		<method id="int codePointAt(char[],int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return"/>
+				</flow>
+			</flows>
+		</method>
+		<method id="int codePointAt(java.lang.CharSequence,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return"/>
+				</flow>
+			</flows>
+		</method>
+		<method id="int codePointBefore(char[],int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return"/>
+				</flow>
+			</flows>
+		</method>
+		<method id="int codePointBefore(char[],int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return"/>
+				</flow>
+			</flows>
+		</method>
+		<method id="int codePointBefore(java.lang.CharSequence,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return"/>
+				</flow>
+			</flows>
+		</method>
+		<method id="int digit(char,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return"/>
+				</flow>
+			</flows>
+		</method>
+		<method id="int digit(int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return"/>
+				</flow>
+			</flows>
+		</method>
+		<method id="char forDigit(int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return"/>
+				</flow>
+			</flows>
+		</method>
+		<method id="byte getDirectionality(char)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return"/>
+				</flow>
+			</flows>
+		</method>
+		<method id="byte getDirectionality(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return"/>
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String getName(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return"/>
+				</flow>
+			</flows>
+		</method>
+		<method id="char reverseBytes(char)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return"/>
+				</flow>
+			</flows>
+		</method>
+		<method id="char[] toChars(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return"/>
+				</flow>
+			</flows>
+		</method>
+		<method id="int toChars(int,char[],int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Parameter" ParameterIndex="1" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int toCodePoint(char,char)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return"/>
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Return"/>
+				</flow>
+			</flows>
+		</method>
+		<method id="char toLowerCase(char)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int toLowerCase(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toString()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.lang.Character: char value]"
+						AccessPathTypes="[char]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toString(char)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="char toTitleCase(char)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int toTitleCase(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="char toUpperCase(char)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int toUpperCase(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Character valueOf(char)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" AccessPath="[java.lang.Character: char value]"
+						AccessPathTypes="[char]" />
+				</flow>
+			</flows>
+		</method>
+  </methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.lang.Class.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.lang.Class.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<methods>
+		<method id="java.lang.Class forName(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" AccessPath="[java.lang.Class: java.lang.String className]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Class forName(java.lang.String,boolean,java.lang.ClassLoader)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" AccessPath="[java.lang.Class: java.lang.String className]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String getCanonicalName()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.lang.Class: java.lang.String className]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String getName()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.lang.Class: java.lang.String className]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String getSimpleName()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.lang.Class: java.lang.String className]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toString()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.lang.Class: java.lang.String className]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.lang.Double.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.lang.Double.xml
@@ -1,0 +1,154 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<methods>
+		<method id="void &lt;init&gt;(double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" AccessPath="[java.lang.Double: double value]"
+						AccessPathTypes="[double]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" AccessPath="[java.lang.Double: double value]"
+						AccessPathTypes="[double]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="byte byteValue()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.lang.Double: double value]"
+						AccessPathTypes="[double]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="long doubleToLongBits(double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="long doubleToRawLongBits(double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="double doubleValue()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.lang.Double: double value]"
+						AccessPathTypes="[double]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="float floatValue()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.lang.Double: double value]"
+						AccessPathTypes="[double]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int intValue()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.lang.Double: double value]"
+						AccessPathTypes="[double]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="double longBitsToDouble(long)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="long longValue()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.lang.Double: double value]"
+						AccessPathTypes="[double]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="double parseDouble(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" AccessPath="[java.lang.Double: double value]"
+						AccessPathTypes="[double]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="short shortValue()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.lang.Double: double value]"
+						AccessPathTypes="[double]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toHexString()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.lang.Double: double value]"
+						AccessPathTypes="[double]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toString()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.lang.Double: double value]"
+						AccessPathTypes="[double]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toString(double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Double valueOf(double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" AccessPath="[java.lang.Double: java.lang.Double value]"
+						AccessPathTypes="[java.lang.Double]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Double valueOf(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" AccessPath="[java.lang.Double: java.lang.Double value]"
+						AccessPathTypes="[java.lang.Double]" />
+				</flow>
+			</flows>
+		</method>
+  </methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.lang.Exception.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.lang.Exception.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<hierarchy superClass="java.lang.Throwable" />
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.lang.Float.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.lang.Float.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<methods>
+		<method id="void &lt;init&gt;(double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" AccessPath="[java.lang.Float: float value]"
+						AccessPathTypes="[float]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(float)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" AccessPath="[java.lang.Float: float value]"
+						AccessPathTypes="[float]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" AccessPath="[java.lang.Float: float value]"
+						AccessPathTypes="[float]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="byte byteValue()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.lang.Float: float value]"
+						AccessPathTypes="[float]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="double doubleValue()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.lang.Float: float value]"
+						AccessPathTypes="[float]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int floatToIntBits(float)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int floatToRawIntBits(float)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="float floatValue()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.lang.Float: float value]"
+						AccessPathTypes="[float]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="float intBitsToFloat(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int intValue()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.lang.Float: float value]"
+						AccessPathTypes="[float]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="long longValue()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.lang.Float: float value]"
+						AccessPathTypes="[float]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="short shortValue()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.lang.Float: float value]"
+						AccessPathTypes="[float]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toHexString()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.lang.Float: float value]"
+						AccessPathTypes="[float]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toString()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.lang.Float: float value]"
+						AccessPathTypes="[float]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toString(float)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Float valueOf(float)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" AccessPath="[java.lang.Float: float value]"
+						AccessPathTypes="[float]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Float valueOf(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" AccessPath="[java.lang.Float: float value]"
+						AccessPathTypes="[float]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="float parseFloat(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" AccessPath="[java.lang.Float: float value]"
+						AccessPathTypes="[float]" />
+				</flow>
+			</flows>
+		</method>
+  </methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.lang.Integer.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.lang.Integer.xml
@@ -1,0 +1,212 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<methods>
+		<method id="void &lt;init&gt;(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" AccessPath="[java.lang.Integer: int value]"
+						AccessPathTypes="[int]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" AccessPath="[java.lang.Integer: int value]"
+						AccessPathTypes="[int]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="byte byteValue()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.lang.Integer: int value]"
+						AccessPathTypes="[int]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Integer decode(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" AccessPath="[java.lang.Integer: int value]"
+						AccessPathTypes="[int]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="double doubleValue()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.lang.Integer: int value]"
+						AccessPathTypes="[int]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="float floatValue()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.lang.Integer: int value]"
+						AccessPathTypes="[int]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int intValue()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.lang.Integer: int value]"
+						AccessPathTypes="[int]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="long longValue()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.lang.Integer: int value]"
+						AccessPathTypes="[int]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int parseInt(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" AccessPath="[java.lang.Integer: int value]"
+						AccessPathTypes="[int]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int parseInt(java.lang.String,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" AccessPath="[java.lang.Integer: int value]"
+						AccessPathTypes="[int]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int reverse(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int reverseBytes(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int rotateLeft(int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int rotateRight(int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="short shortValue()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.lang.Integer: int value]"
+						AccessPathTypes="[int]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toBinaryString(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toHexString(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toOctalString(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toString()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.lang.Integer: int value]"
+						AccessPathTypes="[int]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toString(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toString(int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Integer valueOf(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" AccessPath="[java.lang.Integer: java.lang.Integer value]"
+						AccessPathTypes="[java.lang.Integer]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Integer valueOf(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" AccessPath="[java.lang.Integer: java.lang.Integer value]"
+						AccessPathTypes="[java.lang.Integer]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Integer valueOf(java.lang.String,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" AccessPath="[java.lang.Integer: java.lang.Integer value]"
+						AccessPathTypes="[java.lang.Integer]" />
+				</flow>
+			</flows>
+		</method>
+  </methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.lang.Long.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.lang.Long.xml
@@ -1,0 +1,215 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<methods>
+		<method id="void &lt;init&gt;(long)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" AccessPath="[java.lang.Long: long value]"
+						AccessPathTypes="[long]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" AccessPath="[java.lang.Long: long value]"
+						AccessPathTypes="[long]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="byte byteValue()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.lang.Long: long value]"
+						AccessPathTypes="[long]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Long decode(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" AccessPath="[java.lang.Long: long value]"
+						AccessPathTypes="[long]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="double doubleValue()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.lang.Long: long value]"
+						AccessPathTypes="[long]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="float floatValue()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.lang.Long: long value]"
+						AccessPathTypes="[long]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int intValue()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.lang.Long: long value]"
+						AccessPathTypes="[long]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="long longValue()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.lang.Long: long value]"
+						AccessPathTypes="[long]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="long parseLong(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" AccessPath="[java.lang.Long: long value]"
+						AccessPathTypes="[long]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="long parseLong(java.lang.String,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" AccessPath="[java.lang.Long: long value]"
+						AccessPathTypes="[long]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="long reverse(long)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="long reverseBytes(long)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="long rotateLeft(long,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="long rotateRight(long,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="short shortValue()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.lang.Long: long value]"
+						AccessPathTypes="[long]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toBinaryString()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.lang.Long: long value]"
+						AccessPathTypes="[long]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toHexString()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.lang.Long: long value]"
+						AccessPathTypes="[long]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toOctalString()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.lang.Long: long value]"
+						AccessPathTypes="[long]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toString()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.lang.Long: long value]"
+						AccessPathTypes="[long]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toString(long)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toString(long,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Long valueOf(long)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" AccessPath="[java.lang.Long: java.lang.Long value]"
+						AccessPathTypes="[java.lang.Long]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Long valueOf(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" AccessPath="[java.lang.Long: java.lang.Long value]"
+						AccessPathTypes="[java.lang.Long]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Long valueOf(java.lang.String,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" AccessPath="[java.lang.Long: java.lang.Long value]"
+						AccessPathTypes="[java.lang.Long]" />
+				</flow>
+			</flows>
+		</method>
+  </methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.lang.Math.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.lang.Math.xml
@@ -1,0 +1,681 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<summary fileFormatVersion="101">
+	<methods>
+		<method id="double abs(double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="float abs(float)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int abs(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="long abs(long)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="double acos(double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int addExact(int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="long addExact(long,long)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="double asin(double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="double atan(double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="double atan2(double,double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="double cbrt(double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="double ceil(double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="double copySign(double,double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="float copySign(float,float)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="double cos(double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="double cosh(double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int decrementExact(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="long decrementExact(long)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="double exp(double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="double expm1(double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="double floor(double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int floorDiv(int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="long floorDiv(long,long)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="long floorMod(long,long)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int getExponent(double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int getExponent(float)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="double hypot(double,double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="double IEEEremainder(double,double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int incrementExact(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="long incrementExact(long)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="double log(double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="double log10(double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="double log1p(double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="double max(double,double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="float max(float,float)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int max(int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="long max(long,long)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="double min(double,double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="float min(float,float)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int min(int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="long min(long,long)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int multiplyExact(int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="long multiplyExact(long,long)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int negateExact(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="long negateExact(long)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="double nextAfter(double,double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="float nextAfter(float,double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="double nextDown(double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="float nextDown(float)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="double nextUp(double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="float nextUp(float)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="double pow(double,double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="double rint(double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="long round(double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int round(float)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="double scalb(double,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="float scalb(float,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="double signum(double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="float signum(float)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="double sin(double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="double sinh(double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="double sqrt(double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int subExact(int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="long subExact(long,long)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="double tan(double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="double tanh(double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="double toDegress(double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int toIntExact(long)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="double toRadians(double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="double ulp(double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="float ulp(float)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.lang.NullPointerException.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.lang.NullPointerException.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<hierarchy superClass="java.lang.RuntimeException" />
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.lang.Object.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.lang.Object.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<summary fileFormatVersion="101">
+	<methods>
+		<method id="java.lang.String toString()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.lang.ProcessBuilder.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.lang.ProcessBuilder.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<methods>
+		<method id="void &lt;init&gt;(java.util.List)">
+			<flows>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.lang.ProcessBuilder: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.lang.String[])">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.lang.ProcessBuilder: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.util.List command()">
+			<flows>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.lang.ProcessBuilder: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.ProcessBuilder command(java.lang.String[])">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" AccessPath="[java.lang.ProcessBuilder: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.ProcessBuilder command(java.util.List)">
+			<flows>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.lang.ProcessBuilder: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+                <flow isAlias="true" typeChecking="false">
+                    <from sourceSinkType="Field" />
+                    <to sourceSinkType="Return" />
+                </flow>
+			</flows>
+		</method>
+  </methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.lang.RuntimeException.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.lang.RuntimeException.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<hierarchy superClass="java.lang.Exception" />
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.lang.Short.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.lang.Short.xml
@@ -1,0 +1,156 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<methods>
+		<method id="void &lt;init&gt;(short)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" AccessPath="[java.lang.Short: short value]"
+						AccessPathTypes="[short]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" AccessPath="[java.lang.Short: short value]"
+						AccessPathTypes="[short]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="byte byteValue()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.lang.Short: short value]"
+						AccessPathTypes="[short]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Short decode(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" AccessPath="[java.lang.Short: short value]"
+						AccessPathTypes="[short]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="double doubleValue()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.lang.Short: short value]"
+						AccessPathTypes="[short]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="float floatValue()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.lang.Short: short value]"
+						AccessPathTypes="[short]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int intValue()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.lang.Short: short value]"
+						AccessPathTypes="[short]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="long longValue()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.lang.Short: short value]"
+						AccessPathTypes="[short]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="short parseShort(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" AccessPath="[java.lang.Short: short value]"
+						AccessPathTypes="[short]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="short parseShort(java.lang.String,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" AccessPath="[java.lang.Short: short value]"
+						AccessPathTypes="[short]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="short reverseBytes(short)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="short shortValue()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.lang.Short: short value]"
+						AccessPathTypes="[short]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toString()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.lang.Short: short value]"
+						AccessPathTypes="[short]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toString(short)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Short valueOf(short)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" AccessPath="[java.lang.Short: java.lang.Short value]"
+						AccessPathTypes="[java.lang.Short]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Short valueOf(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" AccessPath="[java.lang.Short: java.lang.Short value]"
+						AccessPathTypes="[java.lang.Short]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Short valueOf(java.lang.String,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" AccessPath="[java.lang.Short: java.lang.Short value]"
+						AccessPathTypes="[java.lang.Short]" />
+				</flow>
+			</flows>
+		</method>
+  </methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.lang.String.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.lang.String.xml
@@ -1,0 +1,458 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<methods>
+		<method id="void &lt;init&gt;(byte[])">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(byte[],java.nio.charset.Charset)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(byte[],int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(byte[],int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(byte[],int,int,java.nio.charset.Charset)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(byte[],int,int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(byte[],int,int,java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(byte[],java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(char[])">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(char[],int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(int[],int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.lang.StringBuffer)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.lang.StringBuilder)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" />
+				</flow>
+			</flows>
+		</method>
+		<method id="char charAt(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int codePointAt(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int codePointBefore(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String concat(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"/>
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String copyValueOf(char[])">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String copyValueOf(char[],int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return"/>
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String format(java.util.Locale,java.lang.String,java.lang.Object[])">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="2" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String format(java.lang.String,java.lang.Object[])">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="byte[] getBytes()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="byte[] getBytes(java.nio.charset.Charset)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void getBytes(int,int,byte[],int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Parameter" ParameterIndex="2" />
+				</flow>
+			</flows>
+		</method>
+		<method id="byte[] getBytes(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void getChars(int,int,char[],int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Parameter" ParameterIndex="2" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String intern()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String replace(char,char)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String replace(java.lang.CharSequence,java.lang.CharSequence)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String replaceAll(java.lang.String,java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String replaceFirst(java.lang.String,java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String[] split(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String[] split(java.lang.String,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.CharSequence subSequence(int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String substring(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String substring(int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="char[] toCharArray()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toLowerCase()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toLowerCase(java.util.Locale)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toString()">
+			<flows>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toUpperCase()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toUpperCase(java.util.Locale)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String trim()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String valueOf(boolean)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String valueOf(char)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String valueOf(char[])">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String valueOf(char[],int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String valueOf(double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String valueOf(float)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String valueOf(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String valueOf(long)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String valueOf(java.lang.Object)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="boolean equals(java.lang.Object)" isExcluded="true" />
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.lang.StringBuffer.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.lang.StringBuffer.xml
@@ -1,0 +1,468 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<methods>
+		<method id="void &lt;init&gt;(java.lang.CharSequence)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" 
+						 />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" 
+						 />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuffer append(boolean)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" 
+						 />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuffer append(char)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" 
+						 />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuffer append(char[])">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" 
+						 />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuffer append(char[],int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" 
+						 />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuffer append(double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" 
+						 />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuffer append(float)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" 
+						 />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuffer append(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" 
+						 />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuffer append(java.lang.AbstractStringBuffer)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" 
+						 />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuffer append(java.lang.CharSequence)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" 
+						 />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuffer append(java.lang.CharSequence,int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" 
+						 />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuffer append(java.lang.Object)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" 
+						 />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuffer append(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" 
+						 />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuffer append(java.lang.StringBuffer)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" 
+						 />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuffer append(long)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" 
+						 />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuffer appendCodePoint(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" 
+						 />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuffer insert(int,boolean)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field" 
+						 />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuffer insert(int,char)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field" 
+						 />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuffer insert(int,char[])">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field" 
+						 />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuffer insert(int,char[],int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field" 
+						 />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuffer insert(int,double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field" 
+						 />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuffer insert(int,float)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field" 
+						 />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuffer insert(int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field" 
+						 />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuffer insert(int,java.lang.CharSequence)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field" 
+						 />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuffer insert(int,java.lang.CharSequence,int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field" 
+						 />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuffer insert(int,java.lang.Object)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field" 
+						 />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuffer insert(int,java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field" 
+						 />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuffer insert(int,long)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field" 
+						 />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuffer replace(int,int,java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="2" />
+					<to sourceSinkType="Field" 
+						 />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toString()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" 
+						 />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="char charAt(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" 
+						 />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int codePointAt(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" 
+						 />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int codePointBefore(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" 
+						 />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void getChars(int,int,char[],int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" 
+						 />
+					<to sourceSinkType="Parameter" ParameterIndex="2" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void setCharAt(int,char)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field" 
+						 />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.CharSequence subSequence(int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" 
+						 />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String substring(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" 
+						 />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String substring(int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" 
+						 />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.lang.StringBuilder.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.lang.StringBuilder.xml
@@ -1,0 +1,438 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<methods>
+		<method id="void &lt;init&gt;(java.lang.CharSequence)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuilder append(boolean)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuilder append(char)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuilder append(char[])">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuilder append(char[],int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuilder append(double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"  />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuilder append(float)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuilder append(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuilder append(java.lang.CharSequence)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuilder append(java.lang.CharSequence,int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuilder append(java.lang.Object)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuilder append(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuilder append(java.lang.StringBuffer)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuilder append(long)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuilder appendCodePoint(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuilder insert(int,boolean)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field"  />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuilder insert(int,char)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field"
+						/>
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuilder insert(int,char[])">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field"
+						/>
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuilder insert(int,char[],int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field"
+						/>
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuilder insert(int,double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field"
+						/>
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuilder insert(int,float)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field"
+						/>
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuilder insert(int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field"
+						/>
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuilder insert(int,java.lang.CharSequence)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field"
+						/>
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuilder insert(int,java.lang.CharSequence,int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field"
+						/>
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuilder insert(int,java.lang.Object)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field"
+						/>
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuilder insert(int,java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field"
+						/>
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuilder insert(int,long)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field"
+						/>
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StringBuilder replace(int,int,java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="2" />
+					<to sourceSinkType="Field"
+						/>
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toString()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						/>
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="char charAt(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						/>
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int codePointAt(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						/>
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int codePointBefore(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						/>
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void getChars(int,int,char[],int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						/>
+					<to sourceSinkType="Parameter" ParameterIndex="2" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void setCharAt(int,char)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field"
+						/>
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.CharSequence subSequence(int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						/>
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String substring(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						/>
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String substring(int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						/>
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.lang.System.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.lang.System.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<methods>
+		<method id="void arraycopy(java.lang.Object,int,java.lang.Object,int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Parameter" ParameterIndex="2" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String getProperty(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String getProperty(java.lang.String,java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.lang.Thread.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.lang.Thread.xml
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<summary fileFormatVersion="101">
+	<methods>
+		<method id="void &lt;init&gt;(java.lang.Runnable)">
+			<flows>
+				<flow isAlias="true">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" BaseType="java.lang.Thread"
+						AccessPath="[java.lang.Thread: java.lang.Runnable runnable]"
+						AccessPathTypes="[java.lang.Runnable]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.lang.Runnable,java.lang.String)">
+			<flows>
+				<flow isAlias="true">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" BaseType="java.lang.Thread"
+						AccessPath="[java.lang.Thread: java.lang.Runnable runnable]"
+						AccessPathTypes="[java.lang.Runnable]" />
+				</flow>
+				<flow isAlias="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field" BaseType="java.lang.Thread"
+						AccessPath="[java.lang.Thread: java.lang.String name]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.lang.String)">
+			<flows>
+				<flow isAlias="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" BaseType="java.lang.Thread"
+						AccessPath="[java.lang.Thread: java.lang.String name]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.lang.ThreadGroup,java.lang.Runnable)">
+			<flows>
+				<flow isAlias="true">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" BaseType="java.lang.Thread"
+						AccessPath="[java.lang.Thread: java.lang.ThreadGroup threadGroup]"
+						AccessPathTypes="[java.lang.ThreadGroup]" />
+				</flow>
+				<flow isAlias="true">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field" BaseType="java.lang.Thread"
+						AccessPath="[java.lang.Thread: java.lang.Runnable runnable]"
+						AccessPathTypes="[java.lang.Runnable]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.lang.ThreadGroup,java.lang.Runnable,java.lang.String)">
+			<flows>
+				<flow isAlias="true">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" BaseType="java.lang.Thread"
+						AccessPath="[java.lang.Thread: java.lang.ThreadGroup threadGroup]"
+						AccessPathTypes="[java.lang.ThreadGroup]" />
+				</flow>
+				<flow isAlias="true">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field" BaseType="java.lang.Thread"
+						AccessPath="[java.lang.Thread: java.lang.Runnable runnable]"
+						AccessPathTypes="[java.lang.Runnable]" />
+				</flow>
+				<flow isAlias="false">
+					<from sourceSinkType="Parameter" ParameterIndex="2" />
+					<to sourceSinkType="Field" BaseType="java.lang.Thread"
+						AccessPath="[java.lang.Thread: java.lang.String name]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.lang.ThreadGroup,java.lang.Runnable,java.lang.String,long)">
+			<flows>
+				<flow isAlias="true">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" BaseType="java.lang.Thread"
+						AccessPath="[java.lang.Thread: java.lang.ThreadGroup threadGroup]"
+						AccessPathTypes="[java.lang.ThreadGroup]" />
+				</flow>
+				<flow isAlias="true">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field" BaseType="java.lang.Thread"
+						AccessPath="[java.lang.Thread: java.lang.Runnable runnable]"
+						AccessPathTypes="[java.lang.Runnable]" />
+				</flow>
+				<flow isAlias="false">
+					<from sourceSinkType="Parameter" ParameterIndex="2" />
+					<to sourceSinkType="Field" BaseType="java.lang.Thread"
+						AccessPath="[java.lang.Thread: java.lang.String name]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false">
+					<from sourceSinkType="Parameter" ParameterIndex="2" />
+					<to sourceSinkType="Field" BaseType="java.lang.Thread"
+						AccessPath="[java.lang.Thread: int stackSize]"
+						AccessPathTypes="[int]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String getName()">
+			<flows>
+				<flow isAlias="false">
+					<from sourceSinkType="Field" BaseType="java.lang.Thread"
+						AccessPath="[java.lang.Thread: java.lang.String name]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return"/>
+				</flow>
+			</flows>
+		</method>
+		<method id="int getPriority()">
+			<flows>
+				<flow isAlias="false">
+					<from sourceSinkType="Field" BaseType="java.lang.Thread"
+						AccessPath="[java.lang.Thread: int priority]"
+						AccessPathTypes="[int]" />
+					<to sourceSinkType="Return"/>
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.ThreadGroup getThreadGroup()">
+			<flows>
+				<flow isAlias="false">
+					<from sourceSinkType="Field" BaseType="java.lang.Thread"
+						AccessPath="[java.lang.Thread: java.lang.ThreadGroup threadGroup]"
+						AccessPathTypes="[java.lang.ThreadGroup]" />
+					<to sourceSinkType="Return"/>
+				</flow>
+			</flows>
+		</method>
+		<method id="void setName(java.lang.String)">
+			<flows>
+				<flow isAlias="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" BaseType="java.lang.Thread"
+						AccessPath="[java.lang.Thread: java.lang.String name]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void setPriority(int)">
+			<flows>
+				<flow isAlias="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" BaseType="java.lang.Thread"
+						AccessPath="[java.lang.Thread: int priority]"
+						AccessPathTypes="[int]" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.lang.ThreadLocal.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.lang.ThreadLocal.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<summary fileFormatVersion="101">
+	<methods>
+		<method id="java.lang.Object get()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.lang.ThreadLocal"
+						AccessPath="[java.lang.ThreadLocal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Object initialValue()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.lang.ThreadLocal"
+						AccessPath="[java.lang.ThreadLocal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void remove()">
+			<clears>
+				<clear sourceSinkType="Field"
+					AccessPath="[java.lang.ThreadLocal: java.lang.Object value]"
+					AccessPathTypes="[java.lang.Object]" />
+			</clears>
+		</method>
+		<method id="void set(java.lang.Object)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" BaseType="java.lang.ThreadLocal"
+						AccessPath="[java.lang.ThreadLocal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.lang.Throwable.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.lang.Throwable.xml
@@ -1,0 +1,167 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<summary fileFormatVersion="101">
+	<methods>
+		<method id="void &lt;init&gt;(java.lang.String)">
+			<flows>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.lang.Throwable: java.lang.String message]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.lang.String,java.lang.Throwable)">
+			<flows>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.lang.Throwable: java.lang.String message]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.lang.Throwable: java.lang.Throwable cause]"
+						AccessPathTypes="[java.lang.Throwable]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.lang.String,java.lang.Throwable,boolean,boolean)">
+			<flows>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.lang.Throwable: java.lang.String message]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.lang.Throwable: java.lang.Throwable cause]"
+						AccessPathTypes="[java.lang.Throwable]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.lang.Throwable)">
+			<flows>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.lang.Throwable: java.lang.Throwable cause]"
+						AccessPathTypes="[java.lang.Throwable]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Throwable getCause()">
+			<flows>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.lang.Throwable: java.lang.Throwable cause]"
+						AccessPathTypes="[java.lang.Throwable]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String getLocalizedMessage()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.lang.Throwable: java.lang.String localizedMessage]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.lang.Throwable: java.lang.String message]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String getMessage()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.lang.Throwable: java.lang.String message]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.StackTraceElement[] getStackTrace()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.lang.Throwable: java.lang.StackTraceElement[] stackTrace]"
+						AccessPathTypes="[java.lang.StackTraceElement[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Throwable initCause(java.lang.Throwable)">
+			<flows>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.lang.Throwable: java.lang.Throwable cause]"
+						AccessPathTypes="[java.lang.Throwable]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void printStackTrace(java.io.PrintStream)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.lang.Throwable: java.lang.StackTraceElement[] stackTrace]"
+						AccessPathTypes="[java.lang.StackTraceElement[]]" />
+					<to sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.io.PrintStream: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void printStackTrace(java.io.PrintWriter)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.lang.Throwable: java.lang.StackTraceElement[] stackTrace]"
+						AccessPathTypes="[java.lang.StackTraceElement[]]" />
+					<to sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.io.Writer: java.io.OutputStream innerStream]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void setStackTrace(java.lang.StackTraceElement[])">
+			<flows>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.lang.Throwable: java.lang.StackTraceElement[] stackTrace]"
+						AccessPathTypes="[java.lang.StackTraceElement[]]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toString()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.lang.Throwable: java.lang.String localizedMessage]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.lang.Throwable: java.lang.String message]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.math.BigDecimal.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.math.BigDecimal.xml
@@ -1,0 +1,881 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<methods>
+		<method id="java.math.BigDecimal valueOf(long)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigDecimal valueOf(long,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigDecimal valueOf(double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.lang.BigInteger)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.lang.BigInteger,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.lang.BigInteger,int,java.math.MathContext)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.lang.BigInteger,java.math.MathContext)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(char[])">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(char[],int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(char[],int,int,java.math.MathContext)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(char[],java.math.MathContext)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(double,java.math.MathContext)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(int,java.math.MathContext)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(long)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(long,java.math.MathContext)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.lang.String,java.math.MathContext)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigDecimal abs()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigDecimal abs(java.math.MathContext)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return"  />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigDecimal add(java.math.BigDecimal)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigDecimal add(java.math.BigDecimal,java.math.MathContext)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigDecimal divide(java.math.BigDecimal)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigDecimal divide(java.math.BigDecimal,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigDecimal divide(java.math.BigDecimal,int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigDecimal divide(java.math.BigDecimal,int,java.math.RoundingMode)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigDecimal divide(java.math.BigDecimal,java.math.MathContext)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigDecimal divide(java.math.BigDecimal,java.math.RoundingMode)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigDecimal[] divideAndRemainder(java.math.BigDecimal)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigDecimal[] divideAndRemainder(java.math.BigDecimal,java.math.MathContext)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigDecimal[] divideToIntegralValue(java.math.BigDecimal)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigDecimal[] divideToIntegralValue(java.math.BigDecimal,java.math.MathContext)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="double doubleValue()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="float floatValue()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int intValue()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int intValueExact()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="long longValue()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="long longValueExact()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigDecimal max(java.math.BigDecimal)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigDecimal min(java.math.BigDecimal)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigDecimal movePointLeft(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigDecimal movePointRight(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigDecimal multiply(java.math.BigDecimal)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigDecimal multiply(java.math.BigDecimal,java.math.MathContext)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigDecimal negate()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigDecimal plus()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigDecimal plus(java.math.MathContext)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigDecimal pow(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigDecimal pow(int,java.math.MathContext)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigDecimal remainder(java.math.BigDecimal)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigDecimal remainder(java.math.BigDecimal,java.math.MathContext)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigDecimal round(java.math.MathContext)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigDecimal scaleByPowerOfTen(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigDecimal setScale(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigDecimal setScale(int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigDecimal setScale(int,java.math.RoundingMode)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>		
+		<method id="short shortValueExact()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+					AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigDecimal stripTrailingZeros()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigDecimal subtract(java.math.BigDecimal)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigDecimal subtract(java.math.BigDecimal,java.math.MathContext)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigInteger toBigInteger">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigInteger toBigIntegerExact">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toEngineeringString()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toPlainString()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toString()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.math.BigDecimal: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigDecimal ulp()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigDecimal unscaledValue()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.math.BigInteger.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.math.BigInteger.xml
@@ -1,0 +1,506 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<methods>
+		<method id="java.math.BigInteger valueOf(long)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(byte[])">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(int,byte[])">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.lang.String,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigInteger abs()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigInteger add(java.math.BigInteger)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigInteger add(long)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigInteger and(java.math.BigInteger)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigInteger andNot(java.math.BigInteger)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigInteger divide(java.math.BigInteger)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigInteger[] divideAndRemainder(java.math.BigInteger)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="double doubleValue()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigInteger flipBit(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="float floatValue()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigInteger gcd(java.math.BigInteger)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int intValue()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int intValueExact()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigInteger max(java.math.BigInteger)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigInteger min(java.math.BigInteger)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigInteger mod(java.math.BigInteger)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigInteger modInverse(java.math.BigInteger)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigInteger modPow(java.math.BigInteger,java.math.BigInteger)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1"
+						AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigInteger multiply(java.math.BigInteger)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigInteger negate()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigInteger not()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigInteger or(java.math.BigInteger)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigInteger pow(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigInteger remainder(java.math.BigInteger)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigInteger setBit(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigInteger shiftLeft(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigInteger shiftRight(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="short shortValueExact()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigInteger subtract(java.math.BigInteger)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="byte[] toByteArray()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toString()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toString(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigInteger xor(java.math.BigInteger)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" AccessPath="[java.math.BigInteger: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.net.Proxy.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.net.Proxy.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<summary fileFormatVersion="101">
+	<methods>
+		<method id="void &lt;init&gt;(java.net.Proxy$Type,java.net.SocketAddress)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" BaseType="java.net.Proxy"
+						AccessPath="[java.net.Proxy: java.net.Proxy$Type type]"
+						AccessPathTypes="[java.net.Proxy$Type]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field" BaseType="java.net.Proxy"
+						AccessPath="[java.net.Proxy: java.net.SocketAddress address]"
+						AccessPathTypes="[java.net.SocketAddress]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.net.SocketAddress address()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.Proxy"
+						AccessPath="[java.net.Proxy: java.net.SocketAddress address]"
+						AccessPathTypes="[java.net.SocketAddress]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toString()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.Proxy"
+						AccessPath="[java.net.Proxy: java.net.Proxy$Type type]"
+						AccessPathTypes="[java.net.Proxy$Type]" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.Proxy"
+						AccessPath="[java.net.Proxy: java.net.SocketAddress address]"
+						AccessPathTypes="[java.net.SocketAddress]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.net.Proxy$Type type()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.Proxy"
+						AccessPath="[java.net.Proxy: java.net.Proxy$Type type]"
+						AccessPathTypes="[java.net.Proxy$Type]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.net.URI.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.net.URI.xml
@@ -1,0 +1,537 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<summary fileFormatVersion="101">
+	<methods>
+		<method id="void &lt;init&gt;(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String host]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String path]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String query]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String fragment]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.lang.String,java.lang.String,java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String scheme]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String host]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String path]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String query]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="2" />
+					<to sourceSinkType="Field" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String fragment]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.lang.String,java.lang.String,java.lang.String,int,java.lang.String,java.lang.String,java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String scheme]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String userInfo]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="2" />
+					<to sourceSinkType="Field" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String host]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="3" />
+					<to sourceSinkType="Field" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: int port]"
+						AccessPathTypes="[int]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="4" />
+					<to sourceSinkType="Field" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String path]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="5" />
+					<to sourceSinkType="Field" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String query]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="6" />
+					<to sourceSinkType="Field" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String fragment]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.lang.String,java.lang.String,java.lang.String,java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String scheme]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String host]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="2" />
+					<to sourceSinkType="Field" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String path]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="3" />
+					<to sourceSinkType="Field" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String fragment]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.lang.String,java.lang.String,java.lang.String,java.lang.String,java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String scheme]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String host]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="2" />
+					<to sourceSinkType="Field" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String path]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="3" />
+					<to sourceSinkType="Field" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String query]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="4" />
+					<to sourceSinkType="Field" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String fragment]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.net.URI create(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String host]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String path]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String query]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String fragment]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String getFragment()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String fragment]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String getHost()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String host]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String getPath()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String path]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String getQuery()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String query]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String getRawFragment()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String fragment]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String getRawPath()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String path]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String getRawQuery()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String query]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String getRawUserInfo()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String userInfo]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String getScheme()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String scheme]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String getUserInfo()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String userInfo]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.net.URI normalize()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.net.URI parseServerAuthority()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.net.URI relativize(java.net.URI)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.net.URI resolve(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String host]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String path]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String query]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String fragment]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.net.URI resolve(java.net.URI)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toASCIIString()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String scheme]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String host]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: int port]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String path]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String query]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String fragment]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String userInfo]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toString()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String scheme]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String host]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: int port]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String path]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String query]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String fragment]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String userInfo]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.net.URL toURL()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String scheme]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String protocol]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String host]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String host]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: int port]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: int port]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String path]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String file]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String query]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String query]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String fragment]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String ref]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String userInfo]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String userInfo]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.net.URL.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.net.URL.xml
@@ -1,0 +1,567 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<summary fileFormatVersion="101">
+	<methods>
+		<method id="void &lt;init&gt;(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String host]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String file]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String query]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String ref]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.lang.String,java.lang.String,int,java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String protocol]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String host]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="2" />
+					<to sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: int port]"
+						AccessPathTypes="[int]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="3" />
+					<to sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String file]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.lang.String,java.lang.String,int,java.lang.String,java.net.URLStreamHandler)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String protocol]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String host]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="2" />
+					<to sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: int port]"
+						AccessPathTypes="[int]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="3" />
+					<to sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String file]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.lang.String,java.lang.String,java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String protocol]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String host]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="2" />
+					<to sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String file]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.net.URL,java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String protocol]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String protocol]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String host]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String host]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						BaseType="java.net.URL"
+						AccessPath="[java.net.URL: int port]"
+						AccessPathTypes="[int]" />
+					<to sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: int port]"
+						AccessPathTypes="[int]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String file]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String file]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String host]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String file]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String query]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String ref]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.net.URL,java.lang.String,java.net.URLStreamHandler)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String protocol]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String protocol]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String host]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String host]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						BaseType="java.net.URL"
+						AccessPath="[java.net.URL: int port]"
+						AccessPathTypes="[int]" />
+					<to sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: int port]"
+						AccessPathTypes="[int]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String file]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String file]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String host]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String file]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String query]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String ref]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int getDefaultPort()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String protocol]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String getFile()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String file]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String getHost()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String host]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int getPort()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						BaseType="java.net.URL"
+						AccessPath="[java.net.URL: int port]"
+						AccessPathTypes="[int]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String getProtocol()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String protocol]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String getQuery()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String query]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String getRef()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String ref]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String getUserInfo()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String userInfo]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void set(java.lang.String,java.lang.String,int,java.lang.String,java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String protocol]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String host]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="2" />
+					<to sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: int port]"
+						AccessPathTypes="[int]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="3" />
+					<to sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String file]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="4" />
+					<to sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String ref]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void set(java.lang.String,java.lang.String,int,java.lang.String,java.lang.String,java.lang.String,java.lang.String,java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String protocol]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String host]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="2" />
+					<to sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: int port]"
+						AccessPathTypes="[int]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="4" />
+					<to sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String userInfo]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="5" />
+					<to sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String file]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="6" />
+					<to sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String query]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="7" />
+					<to sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String ref]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toExternalForm()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String protocol]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String host]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: int port]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String file]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String query]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String ref]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toString()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String protocol]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String host]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: int port]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String file]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String query]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String ref]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.net.URI toURI()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String protocol]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String scheme]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String host]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String host]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: int port]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: int port]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String file]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String path]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String query]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String query]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String ref]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String fragment]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URL"
+						AccessPath="[java.net.URL: java.lang.String userInfo]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" BaseType="java.net.URI"
+						AccessPath="[java.net.URI: java.lang.String userInfo]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.io.InputStream openStream()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return"  BaseType="java.io.InputStream"
+						AccessPath="[java.io.InputStream: java.net.URL url]"
+						AccessPathTypes="[java.net.URL]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.net.URLConnection openConnection()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return"  BaseType="java.net.URLConnection"
+						AccessPath="[java.net.URLConnection: java.net.URL url]"
+						AccessPathTypes="[java.net.URL]" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.net.URLConnection.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.net.URLConnection.xml
@@ -1,0 +1,392 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<summary fileFormatVersion="101">
+	<methods>
+		<method id="void &lt;init&gt;(java.net.URL)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" BaseType="java.net.URLConnection"
+						AccessPath="[java.net.URLConnection: java.net.URL url]"
+						AccessPathTypes="[java.net.URL]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void addRequestProperty(java.lang.String,java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" BaseType="java.net.URLConnection"
+						AccessPath="[java.net.URLConnection: java.lang.String[] requestKeys]"
+						AccessPathTypes="[java.lang.String[]]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field" BaseType="java.net.URLConnection"
+						AccessPath="[java.net.URLConnection: java.lang.String[] requestValues]"
+						AccessPathTypes="[java.lang.String[]]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="boolean getAllowUserInteraction()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URLConnection"
+						AccessPath="[java.net.URLConnection: boolean allowUserInteraction]"
+						AccessPathTypes="[boolean]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int getConnectTimeout()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URLConnection"
+						AccessPath="[java.net.URLConnection: int connectTimeout]"
+						AccessPathTypes="[int]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="boolean getDefaultUseCaches()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URLConnection"
+						AccessPath="[java.net.URLConnection: boolean defaultUseCaches]"
+						AccessPathTypes="[boolean]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="boolean getDoInput()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URLConnection"
+						AccessPath="[java.net.URLConnection: boolean doInput]"
+						AccessPathTypes="[boolean]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="boolean getDoOutput()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URLConnection"
+						AccessPath="[java.net.URLConnection: boolean doOutput]"
+						AccessPathTypes="[boolean]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String getHeaderField(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URLConnection"
+						AccessPath="[java.net.URLConnection: java.lang.String[] headerValues]"
+						AccessPathTypes="[java.lang.String[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String getHeaderField(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URLConnection"
+						AccessPath="[java.net.URLConnection: java.lang.String[] headerValues]"
+						AccessPathTypes="[java.lang.String[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="long getHeaderFieldDate(java.lang.String,long)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URLConnection"
+						AccessPath="[java.net.URLConnection: java.lang.String[] headerValues]"
+						AccessPathTypes="[java.lang.String[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int getHeaderFieldInt(java.lang.String,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URLConnection"
+						AccessPath="[java.net.URLConnection: java.lang.String[] headerValues]"
+						AccessPathTypes="[java.lang.String[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int getHeaderFieldKey(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URLConnection"
+						AccessPath="[java.net.URLConnection: java.lang.String[] headerKeys]"
+						AccessPathTypes="[java.lang.String[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="long getHeaderFieldLong(java.lang.String,long)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URLConnection"
+						AccessPath="[java.net.URLConnection: java.lang.String[] headerValues]"
+						AccessPathTypes="[java.lang.String[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.util.Map getHeaderFields()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URLConnection"
+						AccessPath="[java.net.URLConnection: java.lang.String[] headerKeys]"
+						AccessPathTypes="[java.lang.String[]]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.util.Map: java.lang.Object[] keys]"
+						AccessPathTypes="[java.lang.Object[]]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URLConnection"
+						AccessPath="[java.net.URLConnection: java.lang.String[] headerValues]"
+						AccessPathTypes="[java.lang.String[]]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.util.Map: java.lang.Object[] values]"
+						AccessPathTypes="[java.lang.Object[]]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="long getIfModifiedSince()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URLConnection"
+						AccessPath="[java.net.URLConnection: long ifModifiedSince]"
+						AccessPathTypes="[long]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.io.InputStream getInputStream()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URLConnection"
+						AccessPath="[java.net.URLConnection: java.net.URL url]"
+						AccessPathTypes="[java.net.URL]" />
+					<to sourceSinkType="Return" BaseType="java.io.InputStream"
+						AccessPath="[java.io.InputStream: java.net.URL url]"
+						AccessPathTypes="[java.net.URL]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.io.OutputStream getOutputStream()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URLConnection"
+						AccessPath="[java.net.URLConnection: java.net.URL url]"
+						AccessPathTypes="[java.net.URL]" />
+					<to sourceSinkType="Return" BaseType="java.io.OutputStream"
+						AccessPath="[java.io.OutputStream: java.net.URL url]"
+						AccessPathTypes="[java.net.URL]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int getReadTimeout()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URLConnection"
+						AccessPath="[java.net.URLConnection: int readTimeout]"
+						AccessPathTypes="[int]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.util.Map getRequestProperties()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URLConnection"
+						AccessPath="[java.net.URLConnection: java.lang.String[] requestKeys]"
+						AccessPathTypes="[java.lang.String[]]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.util.Map: java.lang.Object[] keys]"
+						AccessPathTypes="[java.lang.Object[]]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URLConnection"
+						AccessPath="[java.net.URLConnection: java.lang.String[] requestValues]"
+						AccessPathTypes="[java.lang.String[]]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.util.Map: java.lang.Object[] values]"
+						AccessPathTypes="[java.lang.Object[]]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String getRequestProperty(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URLConnection"
+						AccessPath="[java.net.URLConnection: java.lang.String[] requestValues]"
+						AccessPathTypes="[java.lang.String[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.net.URL getURL()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URLConnection"
+						AccessPath="[java.net.URLConnection: java.net.URL url]"
+						AccessPathTypes="[java.net.URL]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="boolean getUseCaches()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URLConnection"
+						AccessPath="[java.net.URLConnection: boolean useCaches]"
+						AccessPathTypes="[boolean]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String guessContentTypeFromName(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String guessContentTypeFromStream(java.io.InputStream)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						BaseType="java.io.InputStream"
+						AccessPath="[java.io.InputStream: byte[] data]"
+						AccessPathTypes="[byte[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void setAllowUserInteraction(boolean)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" BaseType="java.net.URLConnection"
+						AccessPath="[java.net.URLConnection: boolean allowUserInteraction]"
+						AccessPathTypes="[boolean]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void setConnectTimeout(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" BaseType="java.net.URLConnection"
+						AccessPath="[java.net.URLConnection: int connectTimeout]"
+						AccessPathTypes="[int]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void setDefaultUseCaches(boolean)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" BaseType="java.net.URLConnection"
+						AccessPath="[java.net.URLConnection: boolean defaultUseCaches]"
+						AccessPathTypes="[boolean]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void setDoInput(boolean)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" BaseType="java.net.URLConnection"
+						AccessPath="[java.net.URLConnection: boolean doInput]"
+						AccessPathTypes="[boolean]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void setDoOutput(boolean)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" BaseType="java.net.URLConnection"
+						AccessPath="[java.net.URLConnection: boolean doOutput]"
+						AccessPathTypes="[boolean]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void setIfModifiedSince(long)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" BaseType="java.net.URLConnection"
+						AccessPath="[java.net.URLConnection: long ifModifiedSince]"
+						AccessPathTypes="[long]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void setReadTimeout(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" BaseType="java.net.URLConnection"
+						AccessPath="[java.net.URLConnection: int readTimeout]"
+						AccessPathTypes="[int]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void setRequestProperty(java.lang.String,java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" BaseType="java.net.URLConnection"
+						AccessPath="[java.net.URLConnection: java.lang.String[] requestKeys]"
+						AccessPathTypes="[java.lang.String[]]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field" BaseType="java.net.URLConnection"
+						AccessPath="[java.net.URLConnection: java.lang.String[] requestValues]"
+						AccessPathTypes="[java.lang.String[]]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void setUseCaches(boolean)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" BaseType="java.net.URLConnection"
+						AccessPath="[java.net.URLConnection: boolean useCaches]"
+						AccessPathTypes="[boolean]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toString()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.net.URLConnection"
+						AccessPath="[java.net.URLConnection: java.net.URL url]"
+						AccessPathTypes="[java.net.URL]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.net.URLDecoder.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.net.URLDecoder.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<methods>
+		<method id="java.lang.String decode(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String decode(java.lang.String,java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.net.URLEncoder.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.net.URLEncoder.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<methods>
+		<method id="java.lang.String encode(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String encode(java.lang.String,java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.nio.ByteBuffer.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.nio.ByteBuffer.xml
@@ -1,0 +1,453 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<hierarchy superClass="java.nio.Buffer" />
+	<methods>
+		<method id="java.nio.ByteBuffer get(byte[])">
+			<flows>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.nio.ByteBuffer: byte[] innerArray]"
+						AccessPathTypes="[java.io.OutputStream]" />
+					<to sourceSinkType="Parameter" ParameterIndex="0" AccessPath="[java.nio.ByteBuffer: byte[] innerArray]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.nio.ByteBuffer get(byte[],int,int)">
+			<flows>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.nio.ByteBuffer: byte[] innerArray]"
+						AccessPathTypes="[java.io.OutputStream]" />
+					<to sourceSinkType="Parameter" ParameterIndex="0" AccessPath="[java.nio.ByteBuffer: byte[] innerArray]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="char getChar()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.nio.ByteBuffer: byte[] innerArray]"
+						AccessPathTypes="[java.io.OutputStream]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="char getChar(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.nio.ByteBuffer: byte[] innerArray]"
+						AccessPathTypes="[java.io.OutputStream]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="double getDouble()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.nio.ByteBuffer: byte[] innerArray]"
+						AccessPathTypes="[java.io.OutputStream]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="double getDouble(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.nio.ByteBuffer: byte[] innerArray]"
+						AccessPathTypes="[java.io.OutputStream]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="float getFloat()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.nio.ByteBuffer: byte[] innerArray]"
+						AccessPathTypes="[java.io.OutputStream]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="float getFloat(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.nio.ByteBuffer: byte[] innerArray]"
+						AccessPathTypes="[java.io.OutputStream]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int getInt()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.nio.ByteBuffer: byte[] innerArray]"
+						AccessPathTypes="[java.io.OutputStream]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int getInt(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.nio.ByteBuffer: byte[] innerArray]"
+						AccessPathTypes="[java.io.OutputStream]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="long getLong()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.nio.ByteBuffer: byte[] innerArray]"
+						AccessPathTypes="[java.io.OutputStream]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="long getLong(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.nio.ByteBuffer: byte[] innerArray]"
+						AccessPathTypes="[java.io.OutputStream]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="short getShort()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.nio.ByteBuffer: byte[] innerArray]"
+						AccessPathTypes="[java.io.OutputStream]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="short getShort(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.nio.ByteBuffer: byte[] innerArray]"
+						AccessPathTypes="[java.io.OutputStream]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.nio.ByteBuffer put(byte)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" AccessPath="[java.nio.ByteBuffer: byte[] innerArray]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.nio.ByteBuffer put(byte,int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" AccessPath="[java.nio.ByteBuffer: byte[] innerArray]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.nio.ByteBuffer put(byte[])">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" AccessPath="[java.nio.ByteBuffer: byte[] innerArray]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.nio.ByteBuffer put(byte[],int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" AccessPath="[java.nio.ByteBuffer: byte[] innerArray]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.nio.ByteBuffer put(java.nio.ByteBuffer)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" AccessPath="[java.nio.ByteBuffer: byte[] innerArray]"
+						AccessPathTypes="[java.io.OutputStream]" />
+					<to sourceSinkType="Field" AccessPath="[java.nio.ByteBuffer: byte[] innerArray]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.nio.ByteBuffer put(int,byte)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field" AccessPath="[java.nio.ByteBuffer: byte[] innerArray]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.nio.ByteBuffer putChar(char)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" AccessPath="[java.nio.ByteBuffer: byte[] innerArray]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.nio.ByteBuffer putChar(int,char)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field" AccessPath="[java.nio.ByteBuffer: byte[] innerArray]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.nio.ByteBuffer putDouble(double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" AccessPath="[java.nio.ByteBuffer: byte[] innerArray]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.nio.ByteBuffer putDouble(int,double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field" AccessPath="[java.nio.ByteBuffer: byte[] innerArray]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.nio.ByteBuffer putFloat(float)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" AccessPath="[java.nio.ByteBuffer: byte[] innerArray]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.nio.ByteBuffer putFloat(int,float)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field" AccessPath="[java.nio.ByteBuffer: byte[] innerArray]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+
+		<method id="java.nio.ByteBuffer putInt(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" AccessPath="[java.nio.ByteBuffer: byte[] innerArray]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.nio.ByteBuffer putInt(int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field" AccessPath="[java.nio.ByteBuffer: byte[] innerArray]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+
+		<method id="java.nio.ByteBuffer putLong(long)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" AccessPath="[java.nio.ByteBuffer: byte[] innerArray]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.nio.ByteBuffer putLong(int,long)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field" AccessPath="[java.nio.ByteBuffer: byte[] innerArray]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+
+		<method id="java.nio.ByteBuffer putShort(short)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" AccessPath="[java.nio.ByteBuffer: byte[] innerArray]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.nio.ByteBuffer putShort(int,short)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field" AccessPath="[java.nio.ByteBuffer: byte[] innerArray]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.nio.ByteBuffer slice()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.nio.ByteBuffer: byte[] innerArray]"
+						AccessPathTypes="[java.io.OutputStream]" />
+					<to sourceSinkType="Return" AccessPath="[java.nio.ByteBuffer: byte[] innerArray]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="byte[] array()">
+			<flows>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.nio.ByteBuffer: byte[] innerArray]"
+						AccessPathTypes="[java.io.OutputStream]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.nio.ByteBuffer compact()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.nio.ByteBuffer: byte[] innerArray]"
+						AccessPathTypes="[java.io.OutputStream]" />
+					<to sourceSinkType="Return" AccessPath="[java.nio.ByteBuffer: byte[] innerArray]"
+						AccessPathTypes="[java.io.OutputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.nio.ByteBuffer wrap(byte[])">
+			<flows>
+		        <flow isAlias="true" typeChecking="false">
+		          <from sourceSinkType="Parameter" ParameterIndex="0" />
+		          <to sourceSinkType="Return" AccessPath="[java.nio.ByteBuffer: byte[] innerArray]"
+		            AccessPathTypes="[byte[]]" />
+		        </flow>
+			</flows>
+		</method>
+		<method id="java.nio.ByteBuffer wrap(byte[],int,int)">
+			<flows>
+		        <flow isAlias="true" typeChecking="false">
+		          <from sourceSinkType="Parameter" ParameterIndex="0" />
+		          <to sourceSinkType="Return" AccessPath="[java.nio.ByteBuffer: byte[] innerArray]"
+		            AccessPathTypes="[byte[]]" />
+		        </flow>
+			</flows>
+		</method>
+	    <method id="java.nio.ByteBuffer asReadOnlyBuffer()">
+	      <flows>
+	        <flow isAlias="true" typeChecking="false">
+	          <from sourceSinkType="Field" />
+	          <to sourceSinkType="Return" />
+	        </flow>
+	      </flows>
+	    </method>
+	    <method id="java.nio.ByteBuffer compact()">
+	      <flows>
+	        <flow isAlias="true" typeChecking="false">
+	          <from sourceSinkType="Field" />
+	          <to sourceSinkType="Return" />
+	        </flow>
+	      </flows>
+	    </method>
+		<method id="java.nio.ByteBuffer duplicate()">
+			<flows>
+		        <flow isAlias="true" typeChecking="false">
+				  <from sourceSinkType="Field" AccessPath="[java.nio.ByteBuffer: byte[] innerArray]"
+						AccessPathTypes="[java.io.OutputStream]" />
+		          <to sourceSinkType="Return" AccessPath="[java.nio.ByteBuffer: byte[] innerArray]"
+		            AccessPathTypes="[byte[]]" />
+		        </flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.nio.CharBuffer.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.nio.CharBuffer.xml
@@ -1,0 +1,294 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<hierarchy superClass="java.nio.Buffer" />
+  <methods>
+    <method id="java.nio.CharBuffer append(char)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+          <to sourceSinkType="Field" AccessPath="[java.nio.CharBuffer: char[] buffer]"
+          	AccessPathTypes="[char[]]" />
+        </flow>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.CharBuffer append(java.lang.CharSequence)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+          <to sourceSinkType="Field" AccessPath="[java.nio.CharBuffer: char[] buffer]"
+          	AccessPathTypes="[char[]]" />
+        </flow>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.CharBuffer append(java.lang.CharSequence,int,int)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+          <to sourceSinkType="Field" AccessPath="[java.nio.CharBuffer: char[] buffer]"
+          	AccessPathTypes="[char[]]" />
+        </flow>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="char[] array()">
+      <flows>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" AccessPath="[java.nio.CharBuffer: char[] buffer]"
+          	AccessPathTypes="[char[]]" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="char charAt(int)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Field" AccessPath="[java.nio.CharBuffer: char[] buffer]"
+          	AccessPathTypes="[char[]]" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.CharBuffer asReadOnlyBuffer()">
+      <flows>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.CharBuffer compact()">
+      <flows>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.CharBuffer duplicate()">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return"  />
+        </flow>
+      </flows>
+    </method>
+    <method id="char get()">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Field" AccessPath="[java.nio.CharBuffer: char[] buffer]"
+          	AccessPathTypes="[char[]]" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.CharBuffer get(char[])">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Field" AccessPath="[java.nio.CharBuffer: char[] buffer]"
+          	AccessPathTypes="[char[]]" />
+          <to sourceSinkType="Parameter" ParameterIndex="0" />
+        </flow>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.CharBuffer get(char[],int,int)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Field" AccessPath="[java.nio.CharBuffer: char[] buffer]"
+          	AccessPathTypes="[char[]]" />
+          <to sourceSinkType="Parameter" ParameterIndex="0" />
+        </flow>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="char get(int)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Field" AccessPath="[java.nio.CharBuffer: char[] buffer]"
+          	AccessPathTypes="[char[]]" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.CharBuffer put(char)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+          <to sourceSinkType="Field" AccessPath="[java.nio.CharBuffer: char[] buffer]"
+          	AccessPathTypes="[char[]]" />
+        </flow>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.CharBuffer put(char[])">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+          <to sourceSinkType="Field" AccessPath="[java.nio.CharBuffer: char[] buffer]"
+          	AccessPathTypes="[char[]]" />
+        </flow>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.CharBuffer put(char[],int,int)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+          <to sourceSinkType="Field" AccessPath="[java.nio.CharBuffer: char[] buffer]"
+          	AccessPathTypes="[char[]]" />
+        </flow>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.CharBuffer put(java.nio.CharBuffer)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" AccessPath="[java.nio.CharBuffer: char[] buffer]"
+          	AccessPathTypes="[char[]]" />
+          <to sourceSinkType="Field" AccessPath="[java.nio.CharBuffer: char[] buffer]"
+          	AccessPathTypes="[char[]]" />
+        </flow>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.CharBuffer put(int,char)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="1" />
+          <to sourceSinkType="Field" AccessPath="[java.nio.CharBuffer: char[] buffer]"
+          	AccessPathTypes="[char[]]" />
+        </flow>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.CharBuffer put(java.lang.String)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+          <to sourceSinkType="Field" AccessPath="[java.nio.CharBuffer: char[] buffer]"
+          	AccessPathTypes="[char[]]" />
+        </flow>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.CharBuffer put(java.lang.String,int,int)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+          <to sourceSinkType="Field" AccessPath="[java.nio.CharBuffer: char[] buffer]"
+          	AccessPathTypes="[char[]]" />
+        </flow>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="int read(java.nio.CharBuffer)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Field" AccessPath="[java.nio.CharBuffer: char[] buffer]"
+          	AccessPathTypes="[char[]]" />
+          <to sourceSinkType="Parameter" ParameterIndex="0" AccessPath="[java.nio.CharBuffer: char[] buffer]"
+          	AccessPathTypes="[char[]]" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.CharBuffer slice()">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return"  />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.CharBuffer subSequence(int,int)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return"  />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.lang.String toString()">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Field" AccessPath="[java.nio.CharBuffer: char[] buffer]"
+          	AccessPathTypes="[char[]]" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.CharBuffer wrap(char[])">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+          <to sourceSinkType="Return" AccessPath="[java.nio.CharBuffer: char[] buffer]"
+          	AccessPathTypes="[char[]]" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.CharBuffer wrap(char[],int,int)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+          <to sourceSinkType="Return" AccessPath="[java.nio.CharBuffer: char[] buffer]"
+          	AccessPathTypes="[char[]]" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.CharBuffer wrap(java.lang.CharSequence)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+          <to sourceSinkType="Return" AccessPath="[java.nio.CharBuffer: char[] buffer]"
+          	AccessPathTypes="[char[]]" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.CharBuffer wrap(java.lang.CharSequence,int,int)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+          <to sourceSinkType="Return" AccessPath="[java.nio.CharBuffer: char[] buffer]"
+          	AccessPathTypes="[char[]]" />
+        </flow>
+      </flows>
+    </method>
+  </methods>
+ </summary>

--- a/OPAL/tac/src/main/resources/summaries/java.nio.DoubleBuffer.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.nio.DoubleBuffer.xml
@@ -1,0 +1,175 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<hierarchy superClass="java.nio.Buffer" />
+  <methods>
+    <method id="double[] array()">
+      <flows>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" AccessPath="[java.nio.DoubleBuffer: double[] buffer]"
+          	AccessPathTypes="[double[]]" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.DoubleBuffer asReadOnlyBuffer()">
+      <flows>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.DoubleBuffer compact()">
+      <flows>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.DoubleBuffer duplicate()">
+      <flows>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="double get()">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Field" AccessPath="[java.nio.DoubleBuffer: double[] buffer]"
+          	AccessPathTypes="[double[]]" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.DoubleBuffer get(double[])">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Field" AccessPath="[java.nio.DoubleBuffer: double[] buffer]"
+          	AccessPathTypes="[double[]]" />
+          <to sourceSinkType="Parameter" ParameterIndex="0" />
+        </flow>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.DoubleBuffer get(double[],int,int)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Field" AccessPath="[java.nio.DoubleBuffer: double[] buffer]"
+          	AccessPathTypes="[double[]]" />
+          <to sourceSinkType="Parameter" ParameterIndex="0" />
+        </flow>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="double get(int)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Field" AccessPath="[java.nio.DoubleBuffer: double[] buffer]"
+          	AccessPathTypes="[double[]]" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.DoubleBuffer put(double)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+          <to sourceSinkType="Field" AccessPath="[java.nio.DoubleBuffer: double[] buffer]"
+          	AccessPathTypes="[double[]]" />
+        </flow>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.DoubleBuffer put(double[])">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+          <to sourceSinkType="Field" AccessPath="[java.nio.DoubleBuffer: double[] buffer]"
+          	AccessPathTypes="[double[]]" />
+        </flow>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.DoubleBuffer put(double[],int,int)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+          <to sourceSinkType="Field" AccessPath="[java.nio.DoubleBuffer: double[] buffer]"
+          	AccessPathTypes="[double[]]" />
+        </flow>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.DoubleBuffer put(java.nio.DoubleBuffer)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+          <to sourceSinkType="Field" AccessPath="[java.nio.DoubleBuffer: double[] buffer]"
+          	AccessPathTypes="[double[]]" />
+        </flow>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.DoubleBuffer put(int,double)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="1" />
+          <to sourceSinkType="Field" AccessPath="[java.nio.DoubleBuffer: double[] buffer]"
+          	AccessPathTypes="[double[]]" />
+        </flow>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.lang.String toString()">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Field" AccessPath="[java.nio.DoubleBuffer: double[] buffer]"
+          	AccessPathTypes="[double[]]" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.DoubleBuffer wrap(double[])">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+          <to sourceSinkType="Return" AccessPath="[java.nio.DoubleBuffer: double[] buffer]"
+          	AccessPathTypes="[double[]]" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.DoubleBuffer wrap(double[],int,int)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+          <to sourceSinkType="Return" AccessPath="[java.nio.DoubleBuffer: double[] buffer]"
+          	AccessPathTypes="[double[]]" />
+        </flow>
+      </flows>
+    </method>
+  </methods>
+ </summary>

--- a/OPAL/tac/src/main/resources/summaries/java.nio.FloatBuffer.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.nio.FloatBuffer.xml
@@ -1,0 +1,174 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+  <methods>
+    <method id="float[] array()">
+      <flows>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" AccessPath="[java.nio.FloatBuffer: float[] buffer]"
+          	AccessPathTypes="[float[]]" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.FloatBuffer asReadOnlyBuffer()">
+      <flows>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.FloatBuffer compact()">
+      <flows>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.FloatBuffer duplicate()">
+      <flows>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="float get()">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Field" AccessPath="[java.nio.FloatBuffer: float[] buffer]"
+          	AccessPathTypes="[float[]]" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.FloatBuffer get(float[])">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Field" AccessPath="[java.nio.FloatBuffer: float[] buffer]"
+          	AccessPathTypes="[float[]]" />
+          <to sourceSinkType="Parameter" ParameterIndex="0" />
+        </flow>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.FloatBuffer get(float[],int,int)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Field" AccessPath="[java.nio.FloatBuffer: float[] buffer]"
+          	AccessPathTypes="[float[]]" />
+          <to sourceSinkType="Parameter" ParameterIndex="0" />
+        </flow>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="float get(int)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Field" AccessPath="[java.nio.FloatBuffer: float[] buffer]"
+          	AccessPathTypes="[float[]]" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.FloatBuffer put(float)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+          <to sourceSinkType="Field" AccessPath="[java.nio.FloatBuffer: float[] buffer]"
+          	AccessPathTypes="[float[]]" />
+        </flow>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.FloatBuffer put(float[])">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+          <to sourceSinkType="Field" AccessPath="[java.nio.FloatBuffer: float[] buffer]"
+          	AccessPathTypes="[float[]]" />
+        </flow>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.FloatBuffer put(float[],int,int)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+          <to sourceSinkType="Field" AccessPath="[java.nio.FloatBuffer: float[] buffer]"
+          	AccessPathTypes="[float[]]" />
+        </flow>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.FloatBuffer put(java.nio.FloatBuffer)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+          <to sourceSinkType="Field" AccessPath="[java.nio.FloatBuffer: float[] buffer]"
+          	AccessPathTypes="[float[]]" />
+        </flow>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.FloatBuffer put(int,float)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="1" />
+          <to sourceSinkType="Field" AccessPath="[java.nio.FloatBuffer: float[] buffer]"
+          	AccessPathTypes="[float[]]" />
+        </flow>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.lang.String toString()">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Field" AccessPath="[java.nio.FloatBuffer: float[] buffer]"
+          	AccessPathTypes="[float[]]" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.FloatBuffer wrap(float[])">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+          <to sourceSinkType="Return" AccessPath="[java.nio.FloatBuffer: float[] buffer]"
+          	AccessPathTypes="[float[]]" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.FloatBuffer wrap(float[],int,int)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+          <to sourceSinkType="Return" AccessPath="[java.nio.FloatBuffer: float[] buffer]"
+          	AccessPathTypes="[float[]]" />
+        </flow>
+      </flows>
+    </method>
+  </methods>
+ </summary>

--- a/OPAL/tac/src/main/resources/summaries/java.nio.IntBuffer.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.nio.IntBuffer.xml
@@ -1,0 +1,174 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+  <methods>
+    <method id="int[] array()">
+      <flows>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" AccessPath="[java.nio.IntBuffer: int[] buffer]"
+          	AccessPathTypes="[int[]]" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.IntBuffer asReadOnlyBuffer()">
+      <flows>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.IntBuffer compact()">
+      <flows>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.IntBuffer duplicate()">
+      <flows>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="int get()">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Field" AccessPath="[java.nio.IntBuffer: int[] buffer]"
+          	AccessPathTypes="[int[]]" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.IntBuffer get(int[])">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Field" AccessPath="[java.nio.IntBuffer: int[] buffer]"
+          	AccessPathTypes="[int[]]" />
+          <to sourceSinkType="Parameter" ParameterIndex="0" />
+        </flow>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.IntBuffer get(int[],int,int)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Field" AccessPath="[java.nio.IntBuffer: int[] buffer]"
+          	AccessPathTypes="[int[]]" />
+          <to sourceSinkType="Parameter" ParameterIndex="0" />
+        </flow>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="int get(int)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Field" AccessPath="[java.nio.IntBuffer: int[] buffer]"
+          	AccessPathTypes="[int[]]" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.IntBuffer put(int)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+          <to sourceSinkType="Field" AccessPath="[java.nio.IntBuffer: int[] buffer]"
+          	AccessPathTypes="[int[]]" />
+        </flow>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.IntBuffer put(int[])">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+          <to sourceSinkType="Field" AccessPath="[java.nio.IntBuffer: int[] buffer]"
+          	AccessPathTypes="[int[]]" />
+        </flow>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.IntBuffer put(int[],int,int)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+          <to sourceSinkType="Field" AccessPath="[java.nio.IntBuffer: int[] buffer]"
+          	AccessPathTypes="[int[]]" />
+        </flow>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.IntBuffer put(java.nio.IntBuffer)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+          <to sourceSinkType="Field" AccessPath="[java.nio.IntBuffer: int[] buffer]"
+          	AccessPathTypes="[int[]]" />
+        </flow>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.IntBuffer put(int,int)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="1" />
+          <to sourceSinkType="Field" AccessPath="[java.nio.IntBuffer: int[] buffer]"
+          	AccessPathTypes="[int[]]" />
+        </flow>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.lang.String toString()">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Field" AccessPath="[java.nio.IntBuffer: int[] buffer]"
+          	AccessPathTypes="[int[]]" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.IntBuffer wrap(int[])">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+          <to sourceSinkType="Return" AccessPath="[java.nio.IntBuffer: int[] buffer]"
+          	AccessPathTypes="[int[]]" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.IntBuffer wrap(int[],int,int)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+          <to sourceSinkType="Return" AccessPath="[java.nio.IntBuffer: int[] buffer]"
+          	AccessPathTypes="[int[]]" />
+        </flow>
+      </flows>
+    </method>
+  </methods>
+ </summary>

--- a/OPAL/tac/src/main/resources/summaries/java.nio.LongBuffer.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.nio.LongBuffer.xml
@@ -1,0 +1,174 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+  <methods>
+    <method id="long[] array()">
+      <flows>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" AccessPath="[java.nio.LongBuffer: long[] buffer]"
+          	AccessPathTypes="[long[]]" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.LongBuffer asReadOnlyBuffer()">
+      <flows>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.LongBuffer compact()">
+      <flows>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.LongBuffer duplicate()">
+      <flows>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="long get()">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Field" AccessPath="[java.nio.LongBuffer: long[] buffer]"
+          	AccessPathTypes="[long[]]" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.LongBuffer get(long[])">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Field" AccessPath="[java.nio.LongBuffer: long[] buffer]"
+          	AccessPathTypes="[long[]]" />
+          <to sourceSinkType="Parameter" ParameterIndex="0" />
+        </flow>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.LongBuffer get(long[],int,int)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Field" AccessPath="[java.nio.LongBuffer: long[] buffer]"
+          	AccessPathTypes="[long[]]" />
+          <to sourceSinkType="Parameter" ParameterIndex="0" />
+        </flow>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="long get(int)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Field" AccessPath="[java.nio.LongBuffer: long[] buffer]"
+          	AccessPathTypes="[long[]]" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.LongBuffer put(long)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+          <to sourceSinkType="Field" AccessPath="[java.nio.LongBuffer: long[] buffer]"
+          	AccessPathTypes="[long[]]" />
+        </flow>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.LongBuffer put(long[])">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+          <to sourceSinkType="Field" AccessPath="[java.nio.LongBuffer: long[] buffer]"
+          	AccessPathTypes="[long[]]" />
+        </flow>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.LongBuffer put(long[],int,int)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+          <to sourceSinkType="Field" AccessPath="[java.nio.LongBuffer: long[] buffer]"
+          	AccessPathTypes="[long[]]" />
+        </flow>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.LongBuffer put(java.nio.LongBuffer)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+          <to sourceSinkType="Field" AccessPath="[java.nio.LongBuffer: long[] buffer]"
+          	AccessPathTypes="[long[]]" />
+        </flow>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.LongBuffer put(int,long)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="1" />
+          <to sourceSinkType="Field" AccessPath="[java.nio.LongBuffer: long[] buffer]"
+          	AccessPathTypes="[long[]]" />
+        </flow>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.lang.String toString()">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Field" AccessPath="[java.nio.LongBuffer: long[] buffer]"
+          	AccessPathTypes="[long[]]" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.LongBuffer wrap(long[])">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+          <to sourceSinkType="Return" AccessPath="[java.nio.LongBuffer: long[] buffer]"
+          	AccessPathTypes="[long[]]" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.LongBuffer wrap(long[],int,int)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+          <to sourceSinkType="Return" AccessPath="[java.nio.LongBuffer: long[] buffer]"
+          	AccessPathTypes="[long[]]" />
+        </flow>
+      </flows>
+    </method>
+  </methods>
+ </summary>

--- a/OPAL/tac/src/main/resources/summaries/java.nio.ShortBuffer.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.nio.ShortBuffer.xml
@@ -1,0 +1,174 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+  <methods>
+    <method id="long[] array()">
+      <flows>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" AccessPath="[java.nio.ShortBuffer: short[] buffer]"
+          	AccessPathTypes="[short[]]" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.ShortBuffer asReadOnlyBuffer()">
+      <flows>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.ShortBuffer compact()">
+      <flows>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.ShortBuffer duplicate()">
+      <flows>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="short get()">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Field" AccessPath="[java.nio.ShortBuffer: short[] buffer]"
+          	AccessPathTypes="[short[]]" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.ShortBuffer get(short[])">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Field" AccessPath="[java.nio.ShortBuffer: short[] buffer]"
+          	AccessPathTypes="[short[]]" />
+          <to sourceSinkType="Parameter" ParameterIndex="0" />
+        </flow>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.ShortBuffer get(short[],int,int)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Field" AccessPath="[java.nio.ShortBuffer: short[] buffer]"
+          	AccessPathTypes="[short[]]" />
+          <to sourceSinkType="Parameter" ParameterIndex="0" />
+        </flow>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="short get(int)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Field" AccessPath="[java.nio.ShortBuffer: short[] buffer]"
+          	AccessPathTypes="[short[]]" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.ShortBuffer put(short)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+          <to sourceSinkType="Field" AccessPath="[java.nio.ShortBuffer: short[] buffer]"
+          	AccessPathTypes="[short[]]" />
+        </flow>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.ShortBuffer put(short[])">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+          <to sourceSinkType="Field" AccessPath="[java.nio.ShortBuffer: short[] buffer]"
+          	AccessPathTypes="[short[]]" />
+        </flow>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.ShortBuffer put(short[],int,int)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+          <to sourceSinkType="Field" AccessPath="[java.nio.ShortBuffer: short[] buffer]"
+          	AccessPathTypes="[short[]]" />
+        </flow>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.ShortBuffer put(java.nio.ShortBuffer)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+          <to sourceSinkType="Field" AccessPath="[java.nio.ShortBuffer: short[] buffer]"
+          	AccessPathTypes="[short[]]" />
+        </flow>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.ShortBuffer put(int,short)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="1" />
+          <to sourceSinkType="Field" AccessPath="[java.nio.ShortBuffer: short[] buffer]"
+          	AccessPathTypes="[short[]]" />
+        </flow>
+        <flow isAlias="true" typeChecking="false">
+          <from sourceSinkType="Field" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.lang.String toString()">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Field" AccessPath="[java.nio.ShortBuffer: short[] buffer]"
+          	AccessPathTypes="[short[]]" />
+          <to sourceSinkType="Return" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.ShortBuffer wrap(short[])">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+          <to sourceSinkType="Return" AccessPath="[java.nio.ShortBuffer: short[] buffer]"
+          	AccessPathTypes="[short[]]" />
+        </flow>
+      </flows>
+    </method>
+    <method id="java.nio.ShortBuffer wrap(short[],int,int)">
+      <flows>
+        <flow isAlias="false" typeChecking="false">
+          <from sourceSinkType="Parameter" ParameterIndex="0" />
+          <to sourceSinkType="Return" AccessPath="[java.nio.ShortBuffer: short[] buffer]"
+          	AccessPathTypes="[short[]]" />
+        </flow>
+      </flows>
+    </method>
+  </methods>
+ </summary>

--- a/OPAL/tac/src/main/resources/summaries/java.nio.file.Path.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.nio.file.Path.xml
@@ -1,0 +1,157 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<methods>
+		<method id="java.nio.file.Path getFileName()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.nio.file.Path: java.lang.String fileName]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.nio.file.Path getName()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.nio.file.Path: java.lang.String fileName]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.nio.file.Path getRoot()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.nio.file.Path: java.lang.String fileName]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.nio.file.Path normalize()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.nio.file.Path: java.lang.String fileName]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.nio.file.Path relativize(java.nio.file.Path)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.nio.file.Path: java.lang.String fileName]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.nio.file.Path: java.lang.String fileName]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.nio.file.Path resolve(java.nio.file.Path)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.nio.file.Path: java.lang.String fileName]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.nio.file.Path: java.lang.String fileName]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.nio.file.Path resolveSibling(java.nio.file.Path)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.nio.file.Path: java.lang.String fileName]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.nio.file.Path: java.lang.String fileName]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.nio.file.Path subpath(int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.nio.file.Path: java.lang.String fileName]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.nio.file.Path toAbsolutePath()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.nio.file.Path: java.lang.String fileName]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.io.File toFile()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.nio.file.Path: java.lang.String fileName]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.io.File: java.lang.String fileName]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.nio.file.Path toRealPath(java.nio.file.LinkOption[])">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.nio.file.Path: java.lang.String fileName]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toString()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.nio.file.Path: java.lang.String fileName]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.net.URI toURI()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.nio.file.Path: java.lang.String fileName]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.net.URI: java.lang.String path]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.sql.ResultSet.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.sql.ResultSet.xml
@@ -1,0 +1,679 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<hierarchy>
+        <interface name="java.lang.AutoCloseable" />
+        <interface name="java.sql.Wrapper" />
+	</hierarchy>
+	<methods>
+		<method id="java.sql.Array getArray(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.sql.Array getArray(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.io.InputStream getAsciiStream(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.io.InputStream getAsciiStream(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigDecimal getBigDecimal(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigDecimal getBigDecimal(int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigDecimal getBigDecimal(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigDecimal getBigDecimal(java.lang.String,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.io.InputStream getBinaryStream(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.io.InputStream getBinaryStream(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.sql.Blob getBlob(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.sql.Blob getBlob(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="boolean getBoolean(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="boolean getBoolean(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="byte getByte(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="byte getByte(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="byte[] getBytes(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="byte[] getBytes(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.io.Reader getCharacterStream(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.io.Reader getCharacterStream(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.sql.Clob getClob(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.sql.Clob getClob(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.sql.Date getDate(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.sql.Date getDate(int,java.util.Calendar)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.sql.Date getDate(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.sql.Date getDate(java.lang.String,java.util.Calendar)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="double getDouble(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="double getDouble(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="float getFloat(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="float getFloat(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int getInt(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int getInt(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="long getLong(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="long getLong(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.io.Reader getNCharacterStream(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.io.Reader getNCharacterStream(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.sql.NClob getNClob(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.sql.NClob getNClob(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String getNString(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String getNString(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Object getObject(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Object getObject(int,java.lang.Class)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Object getObject(int,java.util.Map)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Object getObject(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Object getObject(java.lang.String,java.lang.Class)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Object getObject(java.lang.String,java.util.Map)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.sql.Ref getRef(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.sql.Ref getRef(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="short getShort(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="short getShort(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.sql.SQLXML getSQLXML(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.sql.SQLXML getSQLXML(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.sql.Statement getStatement()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.sql.Statement statement]"
+						AccessPathTypes="[java.sql.Statement]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String getString(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String getString(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.sql.Time getTime(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.sql.Time getTime(int,java.util.Calendar)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.sql.Time getTime(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.sql.Time getTime(java.lang.String,java.util.Calendar)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.sql.Timestamp getTimestamp(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.sql.Timestamp getTimestamp(int,java.util.Calendar)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.sql.Timestamp getTimestamp(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.sql.Timestamp getTimestamp(java.lang.String,java.util.Calendar)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.io.InputStream getUnicodeStream(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.io.InputStream getUnicodeStream(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.net.URL getURL(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.net.URL getURL(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" BaseType="java.sql.ResultSet"
+						AccessPath="[java.sql.ResultSet: java.lang.Object resultData]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.util.ArrayList.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.util.ArrayList.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="102">
+	<hierarchy>
+		<interface name="java.util.List" />
+	</hierarchy>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.util.Arrays.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.util.Arrays.xml
@@ -1,0 +1,390 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<methods>
+		<method id="java.util.List asList(java.lang.Object[])">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="boolean[] copyOf(boolean[],int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="byte[] copyOf(byte[],int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="char[] copyOf(char[],int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="double[] copyOf(double[],int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="float[] copyOf(float[],int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int[] copyOf(int[],int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="long[] copyOf(long[],int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="short[] copyOf(short[],int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Object[] copyOf(java.lang.Object[],int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Object[] copyOf(java.lang.Object[],int,java.lang.Class)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="boolean[] copyOfRange(boolean[],int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="byte[] copyOfRange(byte[],int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="char[] copyOfRange(char[],int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="double[] copyOfRange(double[],int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="float[] copyOfRange(float[],int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int[] copyOfRange(int[],int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="long[] copyOfRange(long[],int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="short[] copyOfRange(short[],int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Object[] copyOfRange(java.lang.Object[],int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Object[] copyOfRange(java.lang.Object[],int,int,java.lang.Class)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void fill(boolean[],boolean)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Parameter" ParameterIndex="0" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void fill(boolean[],int,int,boolean)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="3" />
+					<to sourceSinkType="Parameter" ParameterIndex="0" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void fill(byte[],byte)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Parameter" ParameterIndex="0" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void fill(byte[],int,int,byte)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="3" />
+					<to sourceSinkType="Parameter" ParameterIndex="0" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void fill(char[],char)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Parameter" ParameterIndex="0" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void fill(char[],int,int,char)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="3" />
+					<to sourceSinkType="Parameter" ParameterIndex="0" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void fill(double[],double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Parameter" ParameterIndex="0" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void fill(double[],int,int,double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="3" />
+					<to sourceSinkType="Parameter" ParameterIndex="0" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void fill(float[],float)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Parameter" ParameterIndex="0" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void fill(float[],int,int,float)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="3" />
+					<to sourceSinkType="Parameter" ParameterIndex="0" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void fill(int[],int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Parameter" ParameterIndex="0" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void fill(int[],int,int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="3" />
+					<to sourceSinkType="Parameter" ParameterIndex="0" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void fill(long[],long)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Parameter" ParameterIndex="0" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void fill(long[],int,int,long)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="3" />
+					<to sourceSinkType="Parameter" ParameterIndex="0" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void fill(java.lang.Object[],java.lang.Object)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Parameter" ParameterIndex="0" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void fill(java.lang.Object[],int,int,java.lang.Object)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="3" />
+					<to sourceSinkType="Parameter" ParameterIndex="0" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void fill(short[],short)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Parameter" ParameterIndex="0" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void fill(short[],int,int,short)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="3" />
+					<to sourceSinkType="Parameter" ParameterIndex="0" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toString(boolean[])">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toString(byte[])">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toString(char[])">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toString(double[])">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toString(float[])">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toString(int[])">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toString(long[])">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toString(java.lang.Object[])">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toString(short[])">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.util.Collection.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.util.Collection.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101" isInterface="true">
+	<hierarchy>
+		<interface name="java.lang.Iterable" />
+	</hierarchy>
+	<methods>
+		<method id="boolean add(java.lang.Object)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="boolean addAll(java.util.Collection)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void clear()">
+			<clears>
+				<clear sourceSinkType="Field" AccessPath="[java.util.Collection: java.lang.Object[] innerArray]" />
+			</clears>
+		</method>
+		<method id="java.util.Iterator iterator()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.util.Iterator: java.lang.Object innerCollection]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Object[] toArray()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Object[] toArray(java.lang.Object[])">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.util.Collections.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.util.Collections.xml
@@ -1,0 +1,285 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<methods>
+		<method id="boolean addAll(java.util.Collection,java.lang.Object[])">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.util.Queue asLifoQueue(java.util.Deque)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.util.Collection checkedCollection(java.util.Collection,java.lang.Class)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.util.List checkedList(java.util.List,java.lang.Class)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.util.Map checkedMap(java.util.Map,java.lang.Class,java.lang.Class)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.util.Set checkedSet(java.util.Set,java.lang.Class)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.util.SortedMap checkedSortedMap(java.util.SortedMap,java.lang.Class,java.lang.Class)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.util.SortedSet checkedSortedSet(java.util.SortedSet,java.lang.Class)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void copy(java.util.List,java.util.List)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Parameter" ParameterIndex="0" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.util.Enumeration enumeration(java.util.Collection)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" AccessPath="[java.util.Enumeration: java.util.Collection innerCollection]"
+						AccessPathTypes="[java.util.Collection]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void fill(java.util.List,java.lang.Object)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.util.ArrayList list(java.util.Enumeration)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.util.Enumeration: java.util.Collection innerCollection]"
+						AccessPathTypes="[java.util.Collection]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Object max(java.util.Collection)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Object max(java.util.Collection,java.util.Comparator)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Object min(java.util.Collection)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Object min(java.util.Collection,java.util.Comparator)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.util.List nCopies(int,java.lang.Object)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Return" AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.util.Set singleton(java.lang.Object)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.util.List singletonList(java.lang.Object)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.util.Map singletonMap(java.lang.Object,java.lang.Object)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" AccessPath="[java.util.Map: java.lang.Object[] keys]"
+						AccessPathTypes="[java.lang.Object[]]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Return" AccessPath="[java.util.Map: java.lang.Object[] values]"
+						AccessPathTypes="[java.lang.Object[]]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.util.Collection synchronizedCollection(java.util.Collection)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.util.List synchronizedList(java.util.List)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.util.Map synchronizedMap(java.util.Map)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.util.Set synchronizedSet(java.util.Set)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.util.SortedMap synchronizedSortedMap(java.util.SortedMap)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.util.SortedSet synchronizedSortedSet(java.util.SortedSet)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.util.Collection unmodifiableCollection(java.util.Collection)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.util.List unmodifiableList(java.util.List)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.util.Map unmodifiableMap(java.util.Map)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.util.Set unmodifiableSet(java.util.Set)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.util.SortedMap unmodifiableSortedMap(java.util.SortedMap)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.util.SortedSet unmodifiableSortedSet(java.util.SortedSet)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.util.Deque.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.util.Deque.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101" isInterface="true">
+	<hierarchy>
+		<interface name="java.util.Queue" />
+		<interface name="java.util.Collection" />
+		<interface name="java.lang.Iterable" />
+	</hierarchy>
+	<methods>
+		<method id="void addFirst(java.lang.Object)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void addLast(java.lang.Object)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.util.Iterator descendingIterator()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.util.Iterator: java.lang.Object innerCollection]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Object getFirst()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Object getLast()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void offerFirst(java.lang.Object)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void offerLast(java.lang.Object)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Object peekFirst()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Object peekLast()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Object pollFirst()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Object pollLast()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.util.Enumeration.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.util.Enumeration.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<methods>
+		<method id="java.lang.Object nextElement()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.Enumeration: java.util.Collection innerCollection,java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.util.Collection,java.lang.Object[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.util.HashMap.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.util.HashMap.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="102">
+	<hierarchy>
+		<interface name="java.util.Map" />
+	</hierarchy>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.util.HashSet.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.util.HashSet.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<hierarchy>
+		<interface name="java.util.Set" />
+	</hierarchy>
+	<methods>
+		<method id="void &lt;init&gt;(java.util.Collection)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" 
+						AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.util.Iterator.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.util.Iterator.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<methods>
+		<method id="java.lang.Object next()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.Iterator: java.lang.Object innerCollection]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.util.LinkedList.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.util.LinkedList.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="102">
+	<hierarchy>
+		<interface name="java.util.List" />
+	</hierarchy>
+	<methods>
+		<method id="java.lang.Object clone()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						  AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						  AccessPathTypes="[java.lang.Object[]]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.util.List.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.util.List.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101" isInterface="true">
+	<hierarchy>
+		<interface name="java.util.Collection" />
+		<interface name="java.lang.Iterable" />
+	</hierarchy>
+	<methods>
+		<method id="void add(int,java.lang.Object)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="boolean addAll(int,java.util.Collection)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Object get(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.util.ListIterator listIterator()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.util.ListIterator: java.util.List innerList]"
+						AccessPathTypes="[java.util.List]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.util.ListIterator listIterator(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.util.ListIterator: java.util.List innerList]"
+						AccessPathTypes="[java.util.List]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Object remove(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void set(int,java.lang.Object)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.util.List subList(int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.util.ListIterator.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.util.ListIterator.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<methods>
+		<method id="void add(java.lang.Object)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" AccessPath="[java.util.Iterator: java.util.List innerList,java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.util.List,java.lang.Object[]]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Object next()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.util.Iterator: java.util.List innerList,java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.util.List,java.lang.Object[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Object previous()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.util.Iterator: java.util.List innerList,java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.util.List,java.lang.Object[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void set(java.lang.Object)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" AccessPath="[java.util.Iterator: java.util.List innerList,java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.util.List,java.lang.Object[]]" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.util.Map.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.util.Map.xml
@@ -1,0 +1,177 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101" isInterface="true">
+	<methods>
+		<method id="java.lang.Object put(java.lang.Object,java.lang.Object)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.util.Map: java.lang.Object[] keys]"
+						AccessPathTypes="[java.lang.Object[]]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.util.Map: java.lang.Object[] values]"
+						AccessPathTypes="[java.lang.Object[]]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.Map: java.lang.Object[] values]"
+						AccessPathTypes="[java.lang.Object[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void putAll(java.util.Map)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.util.Map: java.lang.Object[] keys]"
+						AccessPathTypes="[java.lang.Object[]]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.util.Map: java.lang.Object[] values]"
+						AccessPathTypes="[java.lang.Object[]]" />
+				</flow>
+			</flows>
+		</method>
+		<method
+			id="java.lang.Object putIfAbsent(java.lang.Object,java.lang.Object)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.util.Map: java.lang.Object[] keys]"
+						AccessPathTypes="[java.lang.Object[]]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.util.Map: java.lang.Object[] values]"
+						AccessPathTypes="[java.lang.Object[]]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.Map: java.lang.Object[] values]"
+						AccessPathTypes="[java.lang.Object[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void clear()">
+			<clears>
+				<clear sourceSinkType="Field"
+					AccessPath="[java.util.Set: java.lang.Object[] keys]" />
+				<clear sourceSinkType="Field"
+					AccessPath="[java.util.Set: java.lang.Object[] values]" />
+			</clears>
+		</method>
+		<method id="java.lang.Object remove(java.lang.Object)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.Map: java.lang.Object[] values]"
+						AccessPathTypes="[java.lang.Object[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method
+			id="java.lang.Object replace(java.lang.Object,java.lang.Object)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.Map: java.lang.Object[] values]"
+						AccessPathTypes="[java.lang.Object[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.util.Map: java.lang.Object[] values]"
+						AccessPathTypes="[java.lang.Object[]]" />
+				</flow>
+			</flows>
+		</method>
+		<method
+			id="void replace(java.lang.Object,java.lang.Object,java.lang.Object)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.util.Map: java.lang.Object[] values]"
+						AccessPathTypes="[java.lang.Object[]]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.util.Collection values()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.Map: java.lang.Object[] values]"
+						AccessPathTypes="[java.lang.Object[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.util.Set keySet()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.Map: java.lang.Object[] keys]"
+						AccessPathTypes="[java.lang.Object[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.util.Set entrySet()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.Map: java.lang.Object[] keys]"
+						AccessPathTypes="[java.lang.Object[]]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.util.Map$Entry: java.lang.Object key]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.Map: java.lang.Object[] values]"
+						AccessPathTypes="[java.lang.Object[]]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.util.Map$Entry: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Object get(java.lang.Object)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.Map: java.lang.Object[] values]"
+						AccessPathTypes="[java.lang.Object[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method
+			id="java.lang.Object getOrDefault(java.lang.Object,java.lang.Object)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.Map: java.lang.Object[] values]"
+						AccessPathTypes="[java.lang.Object[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.util.Optional.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.util.Optional.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<methods>
+		<method id="java.lang.Object get()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.Optional: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.util.Optional of(java.lang.Object)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.util.Optional: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.util.Optional ofNullable(java.lang.Object)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.util.Optional: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Object orElse(java.lang.Object)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.Optional: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toString()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.Optional: java.lang.Object value]"
+						AccessPathTypes="[java.lang.Object]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.util.OptionalDouble.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.util.OptionalDouble.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<methods>
+		<method id="double getAsDouble()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.OptionalDouble: double value]"
+						AccessPathTypes="[double]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.util.OptionalDouble of(double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.util.OptionalDouble: double value]"
+						AccessPathTypes="[double]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="double orElse(double)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.OptionalDouble: double value]"
+						AccessPathTypes="[double]" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toString()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.OptionalDouble: double value]"
+						AccessPathTypes="[double]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.util.OptionalInt.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.util.OptionalInt.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<methods>
+		<method id="int getAsInt()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.OptionalInt: int value]"
+						AccessPathTypes="[int]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.util.OptionalInt of(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.util.OptionalInt: int value]"
+						AccessPathTypes="[int]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int orElse(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.OptionalInt: int value]"
+						AccessPathTypes="[int]" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toString()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.OptionalInt: int value]"
+						AccessPathTypes="[int]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.util.OptionalLong.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.util.OptionalLong.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<methods>
+		<method id="long getAsLong()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.OptionalLong: long value]"
+						AccessPathTypes="[long]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.util.OptionalLong of(long)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.util.OptionalLong: long value]"
+						AccessPathTypes="[long]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="long orElse(long)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.OptionalLong: long value]"
+						AccessPathTypes="[long]" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="true" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toString()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.OptionalLong: long value]"
+						AccessPathTypes="[long]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.util.Properties.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.util.Properties.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<methods>
+		<method id="void &lt;init&gt;(java.util.Properties)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" AccessPath="[java.util.Properties: java.lang.Object[] entries]"
+						AccessPathTypes="[java.lang.Object[]]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void load(java.io.InputStream)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" AccessPath="[java.util.Properties: java.lang.Object[] entries]"
+						AccessPathTypes="[java.lang.Object[]]"  />
+				</flow>
+			</flows>
+		</method>
+		<method id="void load(java.io.Reader)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" AccessPath="[java.util.Properties: java.lang.Object[] entries]"
+						AccessPathTypes="[java.lang.Object[]]"  />
+				</flow>
+			</flows>
+		</method>
+		<method id="void loadFromXML(java.io.InputStream)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" AccessPath="[java.util.Properties: java.lang.Object[] entries]"
+						AccessPathTypes="[java.lang.Object[]]"  />
+				</flow>
+			</flows>
+		</method>
+	    <method id="java.lang.String getProperty(java.lang.String)">
+	      <flows>
+	        <flow isAlias="false" typeChecking="false">
+	          <from sourceSinkType="Field" AccessPath="[java.util.Properties: java.lang.Object[] entries]"
+	          	AccessPathTypes="[java.lang.Object[]]"  />
+	          <to sourceSinkType="Return" />
+	        </flow>
+	      </flows>
+	    </method>
+	    <method id="java.lang.String getProperty(java.lang.String,java.lang.String)">
+	      <flows>
+	        <flow isAlias="false" typeChecking="false">
+	          <from sourceSinkType="Field" AccessPath="[java.util.Properties: java.lang.Object[] entries]"
+	          	AccessPathTypes="[java.lang.Object[]]"  />
+	          <to sourceSinkType="Return" />
+	        </flow>
+	      </flows>
+	    </method>
+    </methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.util.Queue.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.util.Queue.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101" isInterface="true">
+	<hierarchy>
+		<interface name="java.util.Collection" />
+		<interface name="java.lang.Iterable" />
+	</hierarchy>
+	<methods>
+		<method id="java.lang.Object element()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void offer(java.lang.Object)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Object peek()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Object poll()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Object pop()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void push(java.lang.Object)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Object remove()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Object removeFirst()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Object removeLast()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.util.Random.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.util.Random.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<methods>
+		<method id="void nextBytes(byte[])">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Parameter" ParameterIndex="0" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.util.Scanner.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.util.Scanner.xml
@@ -1,0 +1,317 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<hierarchy superClass="java.lang.Object">
+		<interface name="java.io.Closeable" />
+		<interface name="java.util.Iterator" />
+	</hierarchy>
+	<methods>
+		<method id="void &lt;init&gt;(java.io.InputStream)">
+			<flows>
+				<flow isAlias="true">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.util.Scanner: java.io.InputStream innerStream]"
+						AccessPathTypes="[java.io.InputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.io.InputStream,java.lang.String)">
+			<flows>
+				<flow isAlias="true">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.util.Scanner: java.io.InputStream innerStream]"
+						AccessPathTypes="[java.io.InputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.io.InputStream,java.nio.charset.Charset)">
+			<flows>
+				<flow isAlias="true">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.util.Scanner: java.io.InputStream innerStream]"
+						AccessPathTypes="[java.io.InputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.io.File)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.util.Scanner: java.io.InputStream innerStream]"
+						AccessPathTypes="[java.io.InputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.io.File,java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.util.Scanner: java.io.InputStream innerStream]"
+						AccessPathTypes="[java.io.InputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.io.File,java.nio.charset.Charset)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.util.Scanner: java.io.InputStream innerStream]"
+						AccessPathTypes="[java.io.InputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.lang.Readable)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.util.Scanner: java.io.InputStream innerStream]"
+						AccessPathTypes="[java.io.InputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.util.Scanner: java.io.InputStream innerStream]"
+						AccessPathTypes="[java.io.InputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.nio.channels.ReadableByteChannel)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.util.Scanner: java.io.InputStream innerStream]"
+						AccessPathTypes="[java.io.InputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.nio.channels.ReadableByteChannel,java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.util.Scanner: java.io.InputStream innerStream]"
+						AccessPathTypes="[java.io.InputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.nio.channels.ReadableByteChannel,java.nio.charset.Charset)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.util.Scanner: java.io.InputStream innerStream]"
+						AccessPathTypes="[java.io.InputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.nio.file.Path)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.util.Scanner: java.io.InputStream innerStream]"
+						AccessPathTypes="[java.io.InputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.nio.file.Path,java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.util.Scanner: java.io.InputStream innerStream]"
+						AccessPathTypes="[java.io.InputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.nio.file.Path,java.nio.charset.Charset)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.util.Scanner: java.io.InputStream innerStream]"
+						AccessPathTypes="[java.io.InputStream]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.util.regex.MatchResult match()">
+			<flows>
+				<flow isAlias="false" cutSubfields="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String next()">
+			<flows>
+				<flow isAlias="false" cutSubfields="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String next(java.lang.String)">
+			<flows>
+				<flow isAlias="false" cutSubfields="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String next(java.util.regex.Pattern)">
+			<flows>
+				<flow isAlias="false" cutSubfields="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String nextLine()">
+			<flows>
+				<flow isAlias="false" cutSubfields="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String findInLine(java.lang.String)">
+			<flows>
+				<flow isAlias="false" cutSubfields="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String findInLine(java.util.regex.Pattern)">
+			<flows>
+				<flow isAlias="false" cutSubfields="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String findWithinHorizon(java.lang.String,int)">
+			<flows>
+				<flow isAlias="false" cutSubfields="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String findWithinHorizon(java.util.regex.Pattern,int)">
+			<flows>
+				<flow isAlias="false" cutSubfields="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="boolean nextBoolean()">
+			<flows>
+				<flow isAlias="false" cutSubfields="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="byte nextByte()">
+			<flows>
+				<flow isAlias="false" cutSubfields="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="byte nextByte(int)">
+			<flows>
+				<flow isAlias="false" cutSubfields="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="short nextShort()">
+			<flows>
+				<flow isAlias="false" cutSubfields="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int nextInt()">
+			<flows>
+				<flow isAlias="false" cutSubfields="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int nextInt(int)">
+			<flows>
+				<flow isAlias="false" cutSubfields="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="long nextLong(int)">
+			<flows>
+				<flow isAlias="false" cutSubfields="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="float nextFloat()">
+			<flows>
+				<flow isAlias="false" cutSubfields="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="double nextDouble()">
+			<flows>
+				<flow isAlias="false" cutSubfields="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigInteger nextBigInteger()">
+			<flows>
+				<flow isAlias="false" cutSubfields="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigInteger nextBigInteger(int)">
+			<flows>
+				<flow isAlias="false" cutSubfields="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.math.BigDecimal nextBigDecimal()">
+			<flows>
+				<flow isAlias="false" cutSubfields="true" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.util.Set.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.util.Set.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101" isInterface="true">
+	<hierarchy>
+		<interface name="java.util.Collection" />
+		<interface name="java.lang.Iterable" />
+	</hierarchy>
+	<methods>
+		<method id="java.util.Spliterator spliterator()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" AccessPath="[java.util.Spliterator: java.lang.Object innerCollection]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.util.Stack.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.util.Stack.xml
@@ -1,0 +1,139 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<hierarchy superClass="java.util.Vector">
+		<interface name="java.util.List" />
+		<interface name="java.util.Collection" />
+		<interface name="java.util.RandomAccess" />
+		<interface name="java.lang.Iterable" />
+		<interface name="java.lang.Cloneable" />
+		<interface name="java.io.Serializable" />
+	</hierarchy>
+    <methods>
+		<method id="void addElement(java.lang.Object)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+				</flow>
+			</flows>
+		</method>
+        <method id="java.lang.Object clone()">
+            <flows>
+                <flow isAlias="true">
+                    <from sourceSinkType="Field" />
+                    <to sourceSinkType="Return" />
+                </flow>
+            </flows>
+        </method>
+		<method id="void copyInto(java.lang.Object[])">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+					<to sourceSinkType="Parameter" ParameterIndex="0" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Object elementAt(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.util.Enumeration elements()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.util.Enumeration: java.util.Collection innerCollection,java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.util.Collection,java.lang.Object[]]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Object firstElement()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void insertElementAt(java.lang.Object,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Object lastElement()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+        <method id="java.lang.Object pop()">
+            <flows>
+                <flow isAlias="true">
+                    <from sourceSinkType="Field" BaseType="java.util.Collection"
+                        AccessPath="[&lt;java.util.Collection: java.lang.Object[] innerArray&gt;]"
+                        AccessPathTypes="[java.lang.Object[]]"></from>
+                    <to sourceSinkType="Return" BaseType="java.lang.Object" taintSubFields="true"></to>
+                </flow>
+            </flows>
+        </method>
+        <method id="java.lang.Object push(java.lang.Object)">
+            <flows>
+                <flow isAlias="true">
+                    <from sourceSinkType="Parameter" ParameterIndex="0" BaseType="java.lang.Object"></from>
+                    <to sourceSinkType="Field" BaseType="java.util.Collection"
+                        AccessPath="[&lt;java.util.Collection: java.lang.Object[] innerArray&gt;]"
+                        AccessPathTypes="[java.lang.Object[]]"
+                        taintSubFields="true"></to>
+                </flow>
+            </flows>
+        </method>
+		<method id="void removeAllElements()">
+			<clears>
+				<clear sourceSinkType="Field" AccessPath="[java.util.Collection: java.lang.Object[] innerArray]" />
+			</clears>
+		</method>
+		<method id="void setElementAt(java.lang.Object,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toString()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+    </methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.util.StringTokenizer.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.util.StringTokenizer.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<methods>
+		<method id="void &lt;init&gt;(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.lang.StringTokenizer: java.lang.String[] tokens]"
+						AccessPathTypes="[java.lang.String[]]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.lang.String,java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.lang.StringTokenizer: java.lang.String[] tokens]"
+						AccessPathTypes="[java.lang.String[]]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void &lt;init&gt;(java.lang.String,java.lang.String,boolean)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.lang.StringTokenizer: java.lang.String[] tokens]"
+						AccessPathTypes="[java.lang.String[]]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Object nextElement()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.lang.StringTokenizer: java.lang.String[] tokens]"
+						AccessPathTypes="[java.lang.String[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String nextToken()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.lang.StringTokenizer: java.lang.String[] tokens]"
+						AccessPathTypes="[java.lang.String[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String nextToken(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.lang.StringTokenizer: java.lang.String[] tokens]"
+						AccessPathTypes="[java.lang.String[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.util.Vector.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.util.Vector.xml
@@ -1,0 +1,253 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<hierarchy superClass="java.util.AbstractList">
+		<interface name="java.util.List" />
+		<interface name="java.util.Collection" />
+		<interface name="java.util.RandomAccess" />
+		<interface name="java.lang.Iterable" />
+		<interface name="java.lang.Cloneable" />
+		<interface name="java.io.Serializable" />
+	</hierarchy>
+	<methods>
+		<method id="void &lt;init&gt;(java.util.Collection)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0"
+						AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+					<to sourceSinkType="Field" AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="boolean add(java.lang.Object)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="boolean add(int,java.lang.Object)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field" AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="boolean addAll(java.util.Collection)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="boolean addAll(int,java.util.Collection)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field" AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void addElement(java.lang.Object)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void clear()">
+			<clears>
+				<clear sourceSinkType="Field" AccessPath="[java.util.Collection: java.lang.Object[] innerArray]" />
+			</clears>
+		</method>
+        <method id="java.lang.Object clone()">
+            <flows>
+                <flow isAlias="true">
+                    <from sourceSinkType="Field" />
+                    <to sourceSinkType="Return" />
+                </flow>
+            </flows>
+        </method>
+		<method id="void copyInto(java.lang.Object[])">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+					<to sourceSinkType="Parameter" ParameterIndex="0" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Object elementAt(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.util.Enumeration elements()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.util.Enumeration: java.util.Collection innerCollection,java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.util.Collection,java.lang.Object[]]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Object firstElement()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Object get(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void insertElementAt(java.lang.Object,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.util.Iterator iterator()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" AccessPath="[java.util.Iterator: java.lang.Object innerCollection]"
+						AccessPathTypes="[java.lang.Object]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Object lastElement()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.util.ListIterator listIterator()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" AccessPath="[java.util.ListIterator: java.util.List innerList]"
+						AccessPathTypes="[java.util.List]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.util.ListIterator listIterator(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" AccessPath="[java.util.ListIterator: java.util.List innerList]"
+						AccessPathTypes="[java.util.List]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Object remove(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void removeAllElements()">
+			<clears>
+				<clear sourceSinkType="Field" AccessPath="[java.util.Collection: java.lang.Object[] innerArray]" />
+			</clears>
+		</method>
+		<method id="void set(int,java.lang.Object)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="void setElementAt(java.lang.Object,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field"
+						AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.util.List subList(int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Object[] toArray()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Object[] toArray(java.lang.Object[])">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toString()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.Collection: java.lang.Object[] innerArray]"
+						AccessPathTypes="[java.lang.Object[]]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+	</methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.util.regex.Matcher.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.util.regex.Matcher.xml
@@ -1,0 +1,241 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<methods>
+		<method id="java.lang.String group()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.regex.Matcher: java.lang.String str]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String group(int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.regex.Matcher: java.lang.String str]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String group(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.regex.Matcher: java.lang.String str]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.util.regex.Pattern pattern()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.regex.Matcher: java.util.regex.Pattern pattern]"
+						AccessPathTypes="[java.util.regex.Pattern]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String quoteReplacement(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.util.regex.Matcher region(int,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.regex.Matcher: java.lang.String str]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.util.regex.Matcher: java.lang.String str]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.regex.Matcher: java.util.regex.Pattern pattern]"
+						AccessPathTypes="[java.util.regex.Pattern]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.util.regex.Matcher: java.util.regex.Pattern pattern]"
+						AccessPathTypes="[java.util.regex.Pattern]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.util.regex.Matcher: int regionStart]"
+						AccessPathTypes="[int]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.util.regex.Matcher: int regionEnd]"
+						AccessPathTypes="[int]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int regionEnd()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.regex.Matcher: int regionEnd]"
+						AccessPathTypes="[int]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int regionStart()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.regex.Matcher: int regionStart]"
+						AccessPathTypes="[int]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String replaceAll(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.regex.Matcher: java.lang.String str]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String replaceFirst(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.regex.Matcher: java.lang.String str]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.util.regex.Matcher reset()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.util.regex.Matcher reset(java.lang.CharSequence)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.regex.Matcher: java.util.regex.Pattern pattern]"
+						AccessPathTypes="[java.util.regex.Pattern]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.util.regex.Matcher: java.util.regex.Pattern pattern]"
+						AccessPathTypes="[java.util.regex.Pattern]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.util.regex.Matcher: java.lang.String str]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.regex.Matcher: int regionStart]"
+						AccessPathTypes="[int]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.util.regex.Matcher: int regionStart]"
+						AccessPathTypes="[int]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.regex.Matcher: int regionEnd]"
+						AccessPathTypes="[int]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.util.regex.Matcher: int regionEnd]"
+						AccessPathTypes="[int]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toString()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.regex.Matcher: java.lang.String str]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.regex.Matcher: java.util.regex.Pattern pattern]"
+						AccessPathTypes="[java.util.regex.Pattern]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.util.regex.Matcher useAnchoringBounds(boolean)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.util.regex.Matcher usePattern(java.util.regex.Pattern)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.regex.Matcher: java.lang.String str]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.util.regex.Matcher: java.lang.String str]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.util.regex.Matcher: java.util.regex.Pattern pattern]"
+						AccessPathTypes="[java.util.regex.Pattern]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.regex.Matcher: int regionStart]"
+						AccessPathTypes="[int]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.util.regex.Matcher: int regionStart]"
+						AccessPathTypes="[int]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.regex.Matcher: int regionEnd]"
+						AccessPathTypes="[int]" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.util.regex.Matcher: int regionEnd]"
+						AccessPathTypes="[int]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.util.regex.Matcher useTransparentBounds(boolean)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+  </methods>
+</summary>

--- a/OPAL/tac/src/main/resources/summaries/java.util.regex.Pattern.xml
+++ b/OPAL/tac/src/main/resources/summaries/java.util.regex.Pattern.xml
@@ -1,0 +1,179 @@
+<?xml version="1.0" ?>
+<summary fileFormatVersion="101">
+	<methods>
+		<method id="java.util.regex.Pattern compile(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.util.regex.Pattern: java.lang.String pattern]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.util.regex.Pattern compile(java.lang.String,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.util.regex.Pattern: java.lang.String pattern]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="1" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.util.regex.Pattern: int flags]"
+						AccessPathTypes="[int]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="int flags()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.regex.Pattern: int flags]"
+						AccessPathTypes="[int]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.util.regex.Matcher matcher(java.lang.CharSequence)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.util.regex.Matcher: java.util.regex.Pattern pattern]"
+						AccessPathTypes="[java.util.regex.Pattern]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.util.regex.Matcher: java.lang.String str]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.util.regex.Matcher matcher(java.lang.String,java.lang.CharSequence)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.util.regex.Matcher: java.util.regex.Pattern pattern]"
+						AccessPathTypes="[java.util.regex.Pattern]" />
+				</flow>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return"
+						AccessPath="[java.util.regex.Matcher: java.lang.String str]"
+						AccessPathTypes="[java.lang.String]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String pattern()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field"
+						AccessPath="[java.util.regex.Pattern: java.lang.String pattern]"
+						AccessPathTypes="[java.lang.String]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String quote(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String[] split(java.lang.CharSequence)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String[] split(java.lang.CharSequence,int)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+
+		<method id="void &lt;init&gt;(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Field" AccessPath="[java.lang.Boolean: boolean value]"
+						AccessPathTypes="[boolean]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="boolean booleanValue()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.lang.Boolean: boolean value]"
+						AccessPathTypes="[boolean]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Boolean parseBoolean(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" AccessPath="[java.lang.Boolean: boolean value]"
+						AccessPathTypes="[boolean]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toString()">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Field" AccessPath="[java.lang.Boolean: boolean value]"
+						AccessPathTypes="[boolean]" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.String toString(boolean)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Boolean valueOf(boolean)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" AccessPath="[java.lang.Boolean: boolean value]"
+						AccessPathTypes="[boolean]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Boolean valueOf(boolean)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" AccessPath="[java.lang.Boolean: boolean value]"
+						AccessPathTypes="[boolean]" />
+				</flow>
+			</flows>
+		</method>
+		<method id="java.lang.Boolean valueOf(java.lang.String)">
+			<flows>
+				<flow isAlias="false" typeChecking="false">
+					<from sourceSinkType="Parameter" ParameterIndex="0" />
+					<to sourceSinkType="Return" AccessPath="[java.lang.Boolean: boolean value]"
+						AccessPathTypes="[boolean]" />
+				</flow>
+			</flows>
+		</method>
+  </methods>
+</summary>

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/ifds/JavaIFDSProblem.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/ifds/JavaIFDSProblem.scala
@@ -6,7 +6,7 @@ import org.opalj.br.analyses.SomeProject
 import org.opalj.br.cfg.{CFG, CFGNode}
 import org.opalj.ifds.Dependees.Getter
 import org.opalj.ifds.{AbstractIFDSFact, IFDSProblem, Statement}
-import org.opalj.tac.{Assignment, Call, DUVar, ExprStmt, Return, ReturnValue, Stmt, TACStmts}
+import org.opalj.tac.{Assignment, Call, DUVar, Expr, ExprStmt, Return, ReturnValue, Stmt, TACStmts}
 import org.opalj.tac.fpcf.analyses.ifds.JavaIFDSProblem.V
 import org.opalj.value.ValueInformation
 
@@ -112,4 +112,17 @@ object JavaIFDSProblem {
             ).isReferenceType
         }
 
+    val NO_MATCH = 256
+    def getParameterIndex(allParamsWithIndex: Seq[(Expr[JavaIFDSProblem.V], Int)], index: Int): Int = {
+        getParameterIndex(allParamsWithIndex, index, isStaticMethod = false)
+    }
+
+    def getParameterIndex(allParamsWithIndex: Seq[(Expr[JavaIFDSProblem.V], Int)], index: Int, isStaticMethod: Boolean): Int = {
+        allParamsWithIndex.find {
+            case (param, paramI) => param.asVar.definedBy.contains(index)
+        } match {
+            case Some((param, paramI)) => JavaIFDSProblem.switchParamAndVariableIndex(paramI, isStaticMethod)
+            case None                  => NO_MATCH
+        }
+    }
 }

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/ifds/taint/ForwardTaintProblem.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/ifds/taint/ForwardTaintProblem.scala
@@ -6,12 +6,19 @@ import org.opalj.br.analyses.{DeclaredMethodsKey, SomeProject}
 import org.opalj.ifds.Dependees.Getter
 import org.opalj.tac._
 import org.opalj.tac.fpcf.analyses.ifds.JavaIFDSProblem.V
+import org.opalj.tac.fpcf.analyses.ifds.taint.summaries.TaintSummaries
 import org.opalj.tac.fpcf.analyses.ifds.{JavaIFDSProblem, JavaMethod, JavaStatement}
+
+import java.io.File
 
 abstract class ForwardTaintProblem(project: SomeProject)
     extends JavaIFDSProblem[TaintFact](project)
     with TaintProblem[Method, JavaStatement, TaintFact] {
     val declaredMethods = project.get(DeclaredMethodsKey)
+
+    def useSummaries: Boolean = false
+    lazy val summaries: TaintSummaries = TaintSummaries(new File(getClass.getResource("/summaries/").getPath).listFiles().toList)
+
     override def nullFact: TaintFact = TaintNullFact
 
     override def needsPredecessor(statement: JavaStatement): Boolean = false
@@ -41,16 +48,28 @@ abstract class ForwardTaintProblem(project: SomeProject)
             case PutField.ASTID =>
                 val put = statement.stmt.asPutField
                 val definedBy = put.objRef.asVar.definedBy
-                if (isTainted(put.value, in))
+                if (isTainted(put.value, in)) {
+                    // RHS is tainted, thus the lhs as well
                     Set(in) ++ definedBy.map { InstanceField(_, put.declaringClass, put.name) }
-                else
+                } else if (isTainted(put.objRef, in)) {
+                    // the lhs is tainted and overwritten
+                    Set()
+                } else {
+                    // if the taint is not affected, just leave it alive
                     Set(in)
+                }
             case PutStatic.ASTID =>
                 val put = statement.stmt.asPutStatic
-                if (isTainted(put.value, in))
+                if (isTainted(put.value, in)) {
+                    // RHS is tainted, thus the lhs as well
                     Set(in, StaticField(put.declaringClass, put.name))
-                else
+                } else if (in == StaticField(put.declaringClass, put.name)) {
+                    // If LHS is equal to the taint, untaint the field here
+                    Set.empty
+                } else {
+                    // if the taint is not affected, just leave it alive
                     Set(in)
+                }
             case _ => Set(in)
         }
     }
@@ -87,7 +106,6 @@ abstract class ForwardTaintProblem(project: SomeProject)
                         ))
                     case _ => None // Nothing to do
                 }.toSet
-
             case InstanceField(index, declClass, taintedField) =>
                 // Taint field of formal parameter if field of actual parameter is tainted
                 // Only if the formal parameter is of a type that may have that field!
@@ -182,8 +200,42 @@ abstract class ForwardTaintProblem(project: SomeProject)
     /**
      * Removes taints according to `sanitizesParameter`.
      */
-    override def callToReturnFlow(call: JavaStatement, in: TaintFact, successor: JavaStatement): Set[TaintFact] =
-        if (sanitizesParameter(call, in)) Set() else Set(in)
+
+    override def callToReturnFlow(call: JavaStatement, in: TaintFact, successor: JavaStatement): Set[TaintFact] = {
+        if (sanitizesParameter(call, in)) return Set.empty
+
+        val callStmt = JavaIFDSProblem.asCall(call.stmt)
+        val allParams = callStmt.allParams
+
+        def isRefTypeParam(index: Int): Boolean = {
+            allParams.find(p => p.asVar.definedBy.contains(index)) match {
+                case Some(param) => param.asVar.value.isReferenceValue
+                case None        => false
+            }
+        }
+
+        if (useSummaries && summaries.isSummarized(callStmt)) {
+            summaries.compute(call, callStmt, in)
+        } else if (icfg.getCalleesIfCallStatement(call).isEmpty) {
+            // If the call does not have any callees, the code is unknown
+            // and we safely handle it as the identity
+            Set(in)
+        } else {
+            // Otherwise use the java call semantics
+            in match {
+                // Local variables that are of a reference type flow through the callee
+                case Variable(index) if isRefTypeParam(index) => Set.empty
+                // Arrays are references passed-by-value, thus their contents might change in the callee
+                case ArrayElement(index, _) if allParams.exists(p => p.asVar.definedBy.contains(index)) => Set.empty
+                // Fields can be written by reference, thus always through through the callee
+                case InstanceField(index, _, _) if allParams.exists(p => p.asVar.definedBy.contains(index)) => Set.empty
+                // Static fields are accessible everywhere, thus have to flow through all callee.
+                case StaticField(_, _) => Set.empty
+                // All facts that do not match any parameter or base object, as well as primitives flow over a call
+                case f: TaintFact => Set(f)
+            }
+        }
+    }
 
     /**
      * Called, when the exit to return facts are computed for some `callee` with the null fact and
@@ -212,27 +264,30 @@ abstract class ForwardTaintProblem(project: SomeProject)
      * We assume that the callee does not call the source method.
      */
     override def outsideAnalysisContext(callee: Method): Option[OutsideAnalysisContextHandler] = {
-        super.outsideAnalysisContext(callee) match {
-            case Some(_) => Some(((call: JavaStatement, successor: JavaStatement, in: TaintFact, _: Getter) => {
-                val allParams = JavaIFDSProblem.asCall(call.stmt).receiverOption ++ JavaIFDSProblem.asCall(call.stmt).params
-                if (call.stmt.astID == Assignment.ASTID && (in match {
-                    case Variable(index) =>
-                        allParams.zipWithIndex.exists {
-                            case (param, _) if param.asVar.definedBy.contains(index) => true
-                            case _                                                   => false
-                        }
-                    case ArrayElement(index, _) =>
-                        allParams.zipWithIndex.exists {
-                            case (param, _) if param.asVar.definedBy.contains(index) => true
-                            case _                                                   => false
-                        }
-                    case _ => false
-                })) Set(Variable(call.index))
-                else Set.empty
-            }): OutsideAnalysisContextHandler)
-            case None => None
-        }
-
+        if (useSummaries && summaries.isSummarized(callee)) {
+            /* Kill the flow and apply the summary in CallToReturn. */
+            Some(((_: JavaStatement, _: JavaStatement, _: TaintFact, _: Getter) => Set.empty): OutsideAnalysisContextHandler)
+        } else
+            super.outsideAnalysisContext(callee) match {
+                case Some(_) => Some(((call: JavaStatement, successor: JavaStatement, in: TaintFact, _: Getter) => {
+                    val allParams = JavaIFDSProblem.asCall(call.stmt).receiverOption ++ JavaIFDSProblem.asCall(call.stmt).params
+                    if (call.stmt.astID == Assignment.ASTID && (in match {
+                        case Variable(index) =>
+                            allParams.zipWithIndex.exists {
+                                case (param, _) if param.asVar.definedBy.contains(index) => true
+                                case _                                                   => false
+                            }
+                        case ArrayElement(index, _) =>
+                            allParams.zipWithIndex.exists {
+                                case (param, _) if param.asVar.definedBy.contains(index) => true
+                                case _                                                   => false
+                            }
+                        case _ => false
+                    })) Set(Variable(call.index))
+                    else Set.empty
+                }): OutsideAnalysisContextHandler)
+                case None => None
+            }
     }
 
     /**
@@ -302,7 +357,7 @@ abstract class ForwardTaintProblem(project: SomeProject)
      * @param in The current data flow facts.
      * @return True, if the expression could be tainted
      */
-    private def isTainted(expression: Expr[V], in: TaintFact): Boolean = {
+    protected def isTainted(expression: Expr[V], in: TaintFact): Boolean = {
         val definedBy = expression.asVar.definedBy
         expression.isVar && (in match {
             case Variable(index)            => definedBy.contains(index)

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/ifds/taint/summaries/TaintSummaries.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/ifds/taint/summaries/TaintSummaries.scala
@@ -1,0 +1,324 @@
+/* BSD 2-Clause License - see OPAL/LICENSE for details. */
+package org.opalj.tac.fpcf.analyses.ifds.taint.summaries
+
+import org.opalj.br.{ArrayType, BooleanType, ByteType, CharType, DoubleType, FieldType, FloatType, IntegerType, LongType, Method, ObjectType, ShortType, Type, VoidType}
+import org.opalj.tac.Call
+import org.opalj.tac.fpcf.analyses.ifds.JavaIFDSProblem.V
+import org.opalj.tac.fpcf.analyses.ifds.{JavaIFDSProblem, JavaStatement}
+import org.opalj.tac.fpcf.analyses.ifds.taint.{ArrayElement, InstanceField, TaintFact, TaintNullFact, Variable}
+import org.opalj.tac.fpcf.analyses.ifds.taint.summaries.Flow.nodeToTaint
+import org.opalj.tac.fpcf.analyses.ifds.taint.summaries.ClassSummary.{signaturePattern, stringToFieldType, stringToType}
+
+import java.io.File
+import scala.util.matching.Regex
+import scala.xml.{Node, XML}
+
+/**
+ * This file implements a subset of the StubDroid summary specification.
+ *
+ * Not implemented (yet):
+ * - Summaries for inner classes
+ * - Type Checking
+ * - Metadata/Exclusiveness
+ * - Aliasing (depends on the IFDS analysis)
+ * - Access Paths with k > 1 (again, depends on the IFS analysis)
+ */
+
+/**
+ * Holds summaries for all classes.
+ *
+ * @param files summary XML files
+ */
+case class TaintSummaries(files: List[File]) {
+    val summaries: Map[String, ClassSummary] =
+        (files.map(f => f.getName.replace(".xml", "").replace(".", "/"))
+            zip
+            files.map(f => new ClassSummary(XML.loadFile(f)))).toMap
+
+    private def isSummarized(objType: ObjectType): Boolean =
+        summaries.contains(objType.fqn)
+
+    /**
+     * Return true if the method is summarized.
+     *
+     * @param callStmt call site in TACAI
+     * @return whether the method is summarized.
+     */
+    def isSummarized(callStmt: Call[JavaIFDSProblem.V]): Boolean =
+        isSummarized(callStmt.declaringClass.mostPreciseObjectType)
+
+    /**
+     * Return true if the method is summarized.
+     *
+     * @param method callee
+     * @return whether the method is summarized.
+     */
+    def isSummarized(method: Method): Boolean =
+        isSummarized(method.classFile.thisType)
+
+    /**
+     * Applies the summary if available, else does nothing.
+     * Precondition: callee class is summarized.
+     *
+     * @param call     call java statement
+     * @param callStmt call TAC statement
+     * @param in       fact
+     * @return out set of facts
+     */
+    def compute(call: JavaStatement, callStmt: Call[V], in: TaintFact): Set[TaintFact] = {
+        val classFqn = callStmt.declaringClass.mostPreciseObjectType.fqn
+        assert(summaries.contains(classFqn))
+
+        summaries(classFqn).compute(call, callStmt, in)
+    }
+}
+
+/**
+ * Holds the methods summaries for a single class.
+ *
+ * @param summaryNode 'summary' XML node
+ */
+case class ClassSummary(summaryNode: Node) {
+    /* Method summaries. */
+    def methods: Seq[MethodSummary] = (summaryNode \\ "methods" \\ "method")
+        .map(methodNode => {
+            val sig = (methodNode \@ "id")
+                .replace("&lt;", "<")
+                .replace("&gt;", ">")
+            signaturePattern.findFirstMatchIn(sig) match {
+                case Some(m) =>
+                    val paramTypes: List[FieldType] =
+                        if (m.group(3) == "") List()
+                        else m.group(3)
+                            .split(",")
+                            .map(s => stringToFieldType(s.strip()))
+                            .toList
+                    MethodSummary(
+                        stringToType(m.group(1)),
+                        m.group(2),
+                        paramTypes,
+                        methodNode
+                    )
+                case None =>
+                    throw new RuntimeException("couldn't parse the signature of "+sig);
+            }
+        }).toList
+
+    /**
+     * Applies the summary if available, else does perform the identity.
+     *
+     * @param call call java statement
+     * @param callStmt call TAC statement
+     * @param in fact
+     * @return out set of facts
+     */
+    def compute(call: JavaStatement, callStmt: Call[V], in: TaintFact): Set[TaintFact] = {
+        in match {
+            /* We do not have any summaries for null facts. */
+            case TaintNullFact => Set(in)
+            case _ =>
+                /* Find the right method, even when overloaded. */
+                val methodSummary = methods.find(m => m.methodName == callStmt.name
+                    && m.paramTypes
+                    .zip(callStmt.descriptor.parameterTypes)
+                    .forall(t => t._1 == t._2))
+                methodSummary match {
+                    case Some(methodSummary) => methodSummary.compute(call, callStmt, in) + in
+                    case None                => Set(in)
+                }
+        }
+    }
+}
+
+object ClassSummary {
+    /* group 1 = return type, group 2 = method name, group 3 = param list */
+    val signaturePattern: Regex = """([a-zA-Z.\[\]]*?) ([a-zA-Z0-9_<>]*?)\(([a-zA-Z.\[\],\s]*?)\)""".r
+
+    /**
+     * Converts the type string in Soot's format to the OPAL ObjectType, excluding void.
+     *
+     * @param str type string
+     * @return ObjectType
+     */
+    def stringToFieldType(str: String): FieldType = {
+        str match {
+            case "boolean" => BooleanType
+            case "byte"    => ByteType
+            case "char"    => CharType
+            case "short"   => ShortType
+            case "int"     => IntegerType
+            case "long"    => LongType
+            case "float"   => FloatType
+            case "double"  => DoubleType
+            case "String"  => ObjectType.String
+            case _ =>
+                if (str.endsWith("[]"))
+                    ArrayType(stringToFieldType(str.substring(0, str.length - 2)))
+                else
+                    ObjectType(str.replace(".", "/"))
+        }
+    }
+
+    /**
+     * Converts the type string in Soot's format to the OPAL ObjectType, including void.
+     *
+     * @param str type string
+     * @return ObjectType
+     */
+    def stringToType(str: String): Type = {
+        str match {
+            case "void" => VoidType
+            case _      => stringToFieldType(str)
+        }
+    }
+}
+
+/**
+ * Represents the summary of a single method.
+ *
+ * @param returnType return type
+ * @param methodName method name
+ * @param paramTypes parameter types
+ * @param methodNode 'method' XML node
+ */
+case class MethodSummary(returnType: Type, methodName: String, paramTypes: List[FieldType], methodNode: Node) {
+    def flows: Seq[Flow] = methodNode.head.map(flowNode => Flow(flowNode))
+
+    def compute(call: JavaStatement, callStmt: Call[V], in: TaintFact): Set[TaintFact] = {
+        flows.flatMap(f =>
+            if (f.matchesFrom(callStmt, in))
+                f.createTaint(call, callStmt, in)
+            else
+                Set.empty).toSet
+    }
+
+    override def toString: String = s"${returnType.toString} ${methodName}(${paramTypes.mkString(", ")})"
+}
+
+/**
+ * Represents one summarized flow.
+ *
+ * @param flowNode 'flow' XML node
+ */
+case class Flow(flowNode: Node) {
+    // only needed if we'd use a on-demand alias analysis
+    val isAlias: Boolean = (flowNode \@ "isAlias").equals("true")
+    // TODO: how important is type checking?
+    val typeChecking: Boolean = (flowNode \@ "typeChecking").equals("true")
+    val from: SummaryTaint = nodeToTaint((flowNode \\ "from").head)
+    val to: SummaryTaint = nodeToTaint((flowNode \\ "to").head)
+
+    /**
+     * Return true if the taint matches the 'from' rule.
+     *
+     * @param callStmt call TAC statement
+     * @param in fact
+     * @return Boolean
+     */
+    def matchesFrom(callStmt: Call[V], in: TaintFact): Boolean = {
+        val isStatic = callStmt.receiverOption.isEmpty
+        val allParamsWithIndex = callStmt.allParams.zipWithIndex
+
+        from match {
+            case ParameterSummaryTaint(summaryIndex) =>
+                in match {
+                    case Variable(index) =>
+                        JavaIFDSProblem.getParameterIndex(allParamsWithIndex, index, isStatic) == summaryIndex
+                    /* Summaries do not know array elements. */
+                    case ArrayElement(index, _) =>
+                        JavaIFDSProblem.getParameterIndex(allParamsWithIndex, index, isStatic) == summaryIndex
+                    case InstanceField(index, _, fieldName) =>
+                        JavaIFDSProblem.getParameterIndex(allParamsWithIndex, index, isStatic) == summaryIndex
+                    case _ => false
+                }
+            case ParameterSummaryTaintWithField(summaryIndex, summaryFieldName) =>
+                in match {
+                    case Variable(index) =>
+                        JavaIFDSProblem.getParameterIndex(allParamsWithIndex, index, isStatic) == summaryIndex
+                    /* Summaries do not know array elements. */
+                    case ArrayElement(index, _) =>
+                        JavaIFDSProblem.getParameterIndex(allParamsWithIndex, index, isStatic) == summaryIndex
+                    case InstanceField(index, _, fieldName) =>
+                        (JavaIFDSProblem.getParameterIndex(allParamsWithIndex, index, isStatic) == summaryIndex
+                            && summaryFieldName == fieldName)
+                    case _ => false
+                }
+            case BaseObjectSummaryTaint(summaryFieldName) =>
+                in match {
+                    case InstanceField(index, _, fieldName) =>
+                        (JavaIFDSProblem.getParameterIndex(allParamsWithIndex, index, isStatic) == -1
+                            && summaryFieldName == fieldName)
+                    /* Over-approximation: apply the rule even though if no field is known. */
+                    case Variable(index) =>
+                        JavaIFDSProblem.getParameterIndex(allParamsWithIndex, index, isStatic) == -1
+                    case _ => false
+                }
+            case _ => false
+        }
+    }
+
+    /**
+     * Return the resulting set of facts after applying the summary.
+     *
+     * @param call call java statement
+     * @param callStmt call TAC statement
+     * @param in fact
+     * @return Out set of facts
+     */
+    def createTaint(call: JavaStatement, callStmt: Call[V], in: TaintFact): Set[TaintFact] = {
+        to match {
+            case ParameterSummaryTaint(summaryIndex) =>
+                callStmt.params(summaryIndex).asVar.definedBy.map(i => Variable(i))
+            case ParameterSummaryTaintWithField(summaryIndex, fieldName) =>
+                callStmt.params(summaryIndex).asVar.definedBy.map(i =>
+                    InstanceField(i, callStmt.declaringClass.mostPreciseObjectType, fieldName))
+            case BaseObjectSummaryTaint(fieldName) if callStmt.receiverOption.isDefined =>
+                callStmt.receiverOption.get.asVar.definedBy.map(i =>
+                    InstanceField(i, callStmt.declaringClass.mostPreciseObjectType, fieldName))
+            case ReturnSummaryTaint() if call.stmt.isAssignment =>
+                Set(Variable(call.index))
+            case ReturnSummaryTaintWithField(fieldName) if call.stmt.isAssignment =>
+                Set(InstanceField(call.index, callStmt.declaringClass.mostPreciseObjectType, fieldName))
+            case _ => Set.empty
+        }
+    }
+}
+
+object Flow {
+    val firstFieldPattern: Regex = """\[[A-Za-z\.\[\]]*?: [A-Za-z\.\[\]]*? ([a-zA-z]*?)[,\]]""".r
+
+    private def getFieldNameFromAttribute(attr: String): String = {
+        firstFieldPattern.findFirstMatchIn(attr) match {
+            case Some(m) => m.group(1)
+            case None    => throw new RuntimeException("Failed to parse Access Path: "+attr)
+        }
+    }
+
+    /**
+     * Maps a 'from' or 'to' XML node to an SummaryTaint
+     *
+     * @param node 'from' or 'to' node
+     * @return SummaryTaint
+     */
+    def nodeToTaint(node: Node): SummaryTaint = {
+        (node \@ "sourceSinkType", node \@ "AccessPath") match {
+            case ("Parameter", "") =>
+                ParameterSummaryTaint((node \@ "ParameterIndex").toInt - 2)
+            case ("Parameter", attr) =>
+                ParameterSummaryTaintWithField(
+                    (node \@ "ParameterIndex").toInt - 2,
+                    getFieldNameFromAttribute(attr)
+                )
+            case ("Field", attr)  => BaseObjectSummaryTaint(getFieldNameFromAttribute(attr))
+            case ("Return", "")   => ReturnSummaryTaint()
+            case ("Return", attr) => ReturnSummaryTaintWithField(getFieldNameFromAttribute(attr))
+        }
+    }
+}
+
+trait SummaryTaint
+case class ParameterSummaryTaint(index: Int) extends SummaryTaint
+case class ParameterSummaryTaintWithField(index: Int, fieldName: String) extends SummaryTaint
+case class BaseObjectSummaryTaint(fieldName: String) extends SummaryTaint
+case class ReturnSummaryTaint() extends SummaryTaint
+case class ReturnSummaryTaintWithField(fieldName: String) extends SummaryTaint

--- a/OPAL/tac/src/test/scala/org/opalj/tac/fpcf/analyses/ifds/taint/ForwardTaintAnalysisFixture.scala
+++ b/OPAL/tac/src/test/scala/org/opalj/tac/fpcf/analyses/ifds/taint/ForwardTaintAnalysisFixture.scala
@@ -20,6 +20,8 @@ class ForwardTaintAnalysisFixture(project: SomeProject)
     extends IFDSAnalysis()(project, new ForwardTaintProblemFixture(project), Taint)
 
 class ForwardTaintProblemFixture(p: SomeProject) extends ForwardTaintProblem(p) {
+    override def useSummaries = true
+
     /**
      * The analysis starts with all public methods in TaintAnalysisTestClass.
      */

--- a/build.sbt
+++ b/build.sbt
@@ -168,6 +168,7 @@ lazy val `OPAL` = (project in file("."))
     de,
     av,
     ll,
+    js,
     framework,
     //  bp, (just temporarily...)
     tools,
@@ -362,6 +363,26 @@ lazy val `LLVM` = (project in file("OPAL/ll"))
   .dependsOn(tac % "it->it;it->test;test->test;compile->compile")
   .configs(IntegrationTest)
 
+lazy val js = `JavaScript`
+lazy val `JavaScript` = (project in file("OPAL/js"))
+  .settings(buildSettings: _*)
+  .settings(
+    name := "JavaScript",
+    Compile / doc / scalacOptions ++= Opts.doc.title("OPAL - JS"),
+    fork := true,
+    libraryDependencies ++= Seq("com.ibm.wala" % "com.ibm.wala.core" % "1.5.7",
+                                "com.ibm.wala" % "com.ibm.wala.util" % "1.5.7",
+                                "com.ibm.wala" % "com.ibm.wala.shrike" % "1.5.7",
+                                "com.ibm.wala" % "com.ibm.wala.cast" % "1.5.7",
+                                "com.ibm.wala" % "com.ibm.wala.cast.java" % "1.5.7",
+                                "com.ibm.wala" % "com.ibm.wala.cast.java.ecj" % "1.5.7",
+                                "com.ibm.wala" % "com.ibm.wala.cast.js" % "1.5.7",
+                                "com.ibm.wala" % "com.ibm.wala.cast.js.rhino" % "1.5.7",
+                                "org.mozilla" % "rhino" % "1.7.10")
+  )
+  .dependsOn(tac % "it->it;it->test;test->test;compile->compile")
+  .configs(IntegrationTest)
+
 lazy val framework = `Framework`
 lazy val `Framework` = (project in file("OPAL/framework"))
   .settings(buildSettings: _*)
@@ -374,7 +395,8 @@ lazy val `Framework` = (project in file("OPAL/framework"))
     ba  % "it->it;it->test;test->test;compile->compile",
     av  % "it->it;it->test;test->test;compile->compile",
     tac % "it->it;it->test;test->test;compile->compile",
-    ll  % "it->it;it->test;test->test;compile->compile"
+    ll  % "it->it;it->test;test->test;compile->compile",
+    js  % "it->it;it->test;test->test;compile->compile"
   )
   .configs(IntegrationTest)
 


### PR DESCRIPTION
This PR draft contains
* Some fixes regarding overwrites to the ForwardTaintProblem
* A JavaScript-aware taint analysis calling another taint analysis for JavaScript (in this case WALA)
* Use of serialized summaries to speed up the analysis

The WALA code is adapted from [0] and the summaries are from the StubDroid paper. Not sure whether merging this PR conflicts with the licenses. Also, this patch is based on Marc's work and thus targets his branch to make the diff more readable.

[0] https://github.com/wala/Examples/