### PR TITLE
Use FQN instead of JVMBinaryName for ObjectTypes

### DIFF
--- a/OPAL/br/src/main/scala/org/opalj/br/Type.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/Type.scala
@@ -1185,6 +1185,8 @@ object ObjectType {
      *         comparison is explicitly supported.
      */
     def apply(fqn: String): ObjectType = {
+        assert(!fqn.endsWith(";")) // Catch errors where we accidentally use a JVMTypeName instead
+
         val readLock = cacheRWLock.readLock()
         readLock.lock()
         try {

--- a/OPAL/tac/src/main/resources/reference.conf
+++ b/OPAL/tac/src/main/resources/reference.conf
@@ -414,7 +414,7 @@ org.opalj {
                   cf = "java/lang/Class",
                   name = "getDeclaredField",
                   desc = "(Ljava/lang/String;)Ljava/lang/reflect/Field;",
-                  instantiatedType = "Ljava/lang/reflect/Field;"
+                  instantiatedType = "java/lang/reflect/Field"
                 }
               }
             ]
@@ -496,7 +496,7 @@ org.opalj {
                   cf = "java/lang/Class",
                   name = "getField",
                   desc = "(Ljava/lang/String;)Ljava/lang/reflect/Field;",
-                  instantiatedType = "Ljava/lang/reflect/Field;"
+                  instantiatedType = "java/lang/reflect/Field"
                 }
               }
             ]

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/rta/ConfiguredNativeMethodsInstantiatedTypesAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/rta/ConfiguredNativeMethodsInstantiatedTypesAnalysis.scala
@@ -27,7 +27,6 @@ import org.opalj.tac.fpcf.properties.cg.Callers
 import org.opalj.tac.fpcf.properties.cg.InstantiatedTypes
 import org.opalj.tac.fpcf.properties.cg.NoCallers
 import org.opalj.br.ReferenceType
-
 import scala.collection.immutable.ArraySeq
 
 /**


### PR DESCRIPTION
Fixes several issues where we accidentally used the JVMBinaryName for creating an ObjectType