### PR TITLE
Consider return types of unknown native methods instantiated

### DIFF
--- a/OPAL/tac/src/main/resources/reference.conf
+++ b/OPAL/tac/src/main/resources/reference.conf
@@ -274,7 +274,7 @@ org.opalj {
                   cf = "java/lang/Class",
                   name = "forName",
                   desc = "(Ljava/lang/String;)Ljava/lang/Class;",
-                  instantiatedType = "java/lang/Class"
+                  instantiatedType = "Ljava/lang/Class;"
                 }
               }
             ]
@@ -294,7 +294,7 @@ org.opalj {
                   cf = "java/lang/Class",
                   name = "forName",
                   desc = "(Ljava/lang/String;ZLjava/lang/ClassLoader;)Ljava/lang/Class;",
-                  instantiatedType = "java/lang/Class"
+                  instantiatedType = "Ljava/lang/Class;"
                 }
               }
             ]
@@ -314,7 +314,7 @@ org.opalj {
                   cf = "java/lang/Class",
                   name = "forName",
                   desc = "(Ljava/lang/Module;Ljava/lang/String;)Ljava/lang/Class;",
-                  instantiatedType = "java/lang/Class"
+                  instantiatedType = "Ljava/lang/Class;"
                 }
               }
             ]
@@ -334,7 +334,7 @@ org.opalj {
                   cf = "java/lang/Class",
                   name = "getConstantPool",
                   desc = "()Ljdk/internal/reflect/ConstantPool;",
-                  instantiatedType = "java/lang/reflect/ConstantPool"
+                  instantiatedType = "Ljava/lang/reflect/ConstantPool;"
                 }
               }
             ]
@@ -354,7 +354,7 @@ org.opalj {
                   cf = "java/lang/Class",
                   name = "getConstructor",
                   desc = "([Ljava/lang/Class;)Ljava/lang/reflect/Constructor;",
-                  instantiatedType = "java/lang/reflect/Constructor"
+                  instantiatedType = "Ljava/lang/reflect/Constructor;"
                 }
               }
             ]
@@ -395,7 +395,7 @@ org.opalj {
                   cf = "java/lang/Class",
                   name = "getDeclaredConstructor",
                   desc = "([Ljava/lang/Class;)Ljava/lang/reflect/Constructor;",
-                  instantiatedType = "java/lang/reflect/Constructor"
+                  instantiatedType = "Ljava/lang/reflect/Constructor;"
                 }
               }
             ]
@@ -436,7 +436,7 @@ org.opalj {
                   cf = "java/lang/Class",
                   name = "getDeclaredField",
                   desc = "(Ljava/lang/String;)Ljava/lang/reflect/Field;",
-                  instantiatedType = "java/lang/reflect/Field"
+                  instantiatedType = "Ljava/lang/reflect/Field;"
                 }
               }
             ]
@@ -477,7 +477,7 @@ org.opalj {
                   cf = "java/lang/Class",
                   name = "getDeclaredMethod",
                   desc = "(Ljava/lang/String;[Ljava/lang/Class;)Ljava/lang/reflect/Method;",
-                  instantiatedType = "java/lang/reflect/Method"
+                  instantiatedType = "Ljava/lang/reflect/Method;"
                 }
               }
             ]
@@ -518,7 +518,7 @@ org.opalj {
                   cf = "java/lang/Class",
                   name = "getField",
                   desc = "(Ljava/lang/String;)Ljava/lang/reflect/Field;",
-                  instantiatedType = "java/lang/reflect/Field"
+                  instantiatedType = "Ljava/lang/reflect/Field;"
                 }
               }
             ]
@@ -559,7 +559,7 @@ org.opalj {
                   cf = "java/lang/Class",
                   name = "getMethod",
                   desc = "(Ljava/lang/String;[Ljava/lang/Class;)Ljava/lang/reflect/Method;",
-                  instantiatedType = "java/lang/reflect/Method"
+                  instantiatedType = "Ljava/lang/reflect/Method;"
                 }
               }
             ]
@@ -600,7 +600,7 @@ org.opalj {
                   cf = "java/lang/Class",
                   name = "getPrimitiveClass",
                   desc = "(Ljava/lang/String;)Ljava/lang/Class;",
-                  instantiatedType = "java/lang/Class"
+                  instantiatedType = "Ljava/lang/Class;"
                 }
               }
             ]
@@ -620,7 +620,7 @@ org.opalj {
                   cf = "java/lang/Class",
                   name = "getProtectionDomain0",
                   desc = "()Ljava/security/ProtectionDomain;",
-                  instantiatedType = "java/security/ProtectionDomain"
+                  instantiatedType = "Ljava/security/ProtectionDomain;"
                 }
               }
             ]
@@ -660,7 +660,7 @@ org.opalj {
                   cf = "java/lang/invoke/MethodHandles",
                   name = "lookup",
                   desc = "()Ljava/lang/invoke/MethodHandles$Lookup;",
-                  instantiatedType = "java/lang/invoke/MethodHandles$Lookup"
+                  instantiatedType = "Ljava/lang/invoke/MethodHandles$Lookup;"
                 }
               }
             ]
@@ -680,7 +680,7 @@ org.opalj {
                   cf = "java/lang/invoke/MethodHandles$Lookup",
                   name = "findStatic",
                   desc = "(Ljava/lang/Class;Ljava/lang/String;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/MethodHandle;",
-                  instantiatedType = "java/lang/invoke/MethodHandle"
+                  instantiatedType = "Ljava/lang/invoke/MethodHandle;"
                 }
               }
             ]
@@ -700,7 +700,7 @@ org.opalj {
                   cf = "java/lang/invoke/MethodHandles$Lookup",
                   name = "findVirtual",
                   desc = "(Ljava/lang/Class;Ljava/lang/String;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/MethodHandle;",
-                  instantiatedType = "java/lang/invoke/MethodHandle"
+                  instantiatedType = "Ljava/lang/invoke/MethodHandle;"
                 }
               }
             ]
@@ -720,7 +720,7 @@ org.opalj {
                   cf = "java/lang/invoke/MethodHandles$Lookup",
                   name = "findConstructor",
                   desc = "(Ljava/lang/Class;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/MethodHandle;",
-                  instantiatedType = "java/lang/invoke/MethodHandle"
+                  instantiatedType = "Ljava/lang/invoke/MethodHandle;"
                 }
               }
             ]
@@ -740,7 +740,7 @@ org.opalj {
                   cf = "java/lang/invoke/MethodHandles$Lookup",
                   name = "findSpecial",
                   desc = "(Ljava/lang/Class;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/Class;)Ljava/lang/invoke/MethodHandle;",
-                  instantiatedType = "java/lang/invoke/MethodHandle"
+                  instantiatedType = "Ljava/lang/invoke/MethodHandle;"
                 }
               }
             ]
@@ -760,7 +760,7 @@ org.opalj {
                   cf = "java/lang/ClassLoader",
                   name = "defineClass0",
                   desc = "(Ljava/lang/String;[BIILjava/security/ProtectionDomain;)Ljava/lang/Class;",
-                  instantiatedType = "java/lang/Class"
+                  instantiatedType = "Ljava/lang/Class;"
                 }
               }
             ]
@@ -780,7 +780,7 @@ org.opalj {
                   cf = "java/lang/ClassLoader",
                   name = "defineClass0",
                   desc = "(Ljava/lang/ClassLoader;Ljava/lang/Class;Ljava/lang/String;[BIILjava/security/ProtectionDomain;ZILjava/lang/Object;)Ljava/lang/Class;",
-                  instantiatedType = "java/lang/Class"
+                  instantiatedType = "Ljava/lang/Class;"
                 }
               }
             ]
@@ -800,7 +800,7 @@ org.opalj {
                   cf = "java/lang/ClassLoader",
                   name = "defineClass1",
                   desc = "(Ljava/lang/String;[BIILjava/security/ProtectionDomain;Ljava/lang/String;)Ljava/lang/Class;",
-                  instantiatedType = "java/lang/Class"
+                  instantiatedType = "Ljava/lang/Class;"
                 }
               }
             ]
@@ -820,7 +820,7 @@ org.opalj {
                   cf = "java/lang/ClassLoader",
                   name = "defineClass1",
                   desc = "(Ljava/lang/ClassLoader;Ljava/lang/String;[BIILjava/security/ProtectionDomain;Ljava/lang/String;)Ljava/lang/Class;",
-                  instantiatedType = "java/lang/Class"
+                  instantiatedType = "Ljava/lang/Class;"
                 }
               }
             ]
@@ -840,7 +840,7 @@ org.opalj {
                   cf = "java/lang/ClassLoader",
                   name = "defineClass2",
                   desc = "(Ljava/lang/String;Ljava/nio/ByteBuffer;IILjava/security/ProtectionDomain;Ljava/lang/String;)Ljava/lang/Class;",
-                  instantiatedType = "java/lang/Class"
+                  instantiatedType = "Ljava/lang/Class;"
                 }
               }
             ]
@@ -860,7 +860,7 @@ org.opalj {
                   cf = "java/lang/ClassLoader",
                   name = "defineClass2",
                   desc = "(Ljava/lang/ClassLoader;Ljava/lang/String;Ljava/nio/ByteBuffer;IILjava/security/ProtectionDomain;Ljava/lang/String;)Ljava/lang/Class;",
-                  instantiatedType = "java/lang/Class"
+                  instantiatedType = "Ljava/lang/Class;"
                 }
               }
             ]
@@ -880,7 +880,7 @@ org.opalj {
                   cf = "java/lang/ClassLoader",
                   name = "findBootstrapClass",
                   desc = "(Ljava/lang/String;)Ljava/lang/Class;",
-                  instantiatedType = "java/lang/Class"
+                  instantiatedType = "Ljava/lang/Class;"
                 }
               }
             ]
@@ -900,7 +900,7 @@ org.opalj {
                   cf = "java/lang/ClassLoader",
                   name = "findLoadedClass0",
                   desc = "(Ljava/lang/String;)Ljava/lang/Class;",
-                  instantiatedType = "java/lang/Class"
+                  instantiatedType = "Ljava/lang/Class;"
                 }
               }
             ]
@@ -920,7 +920,7 @@ org.opalj {
                   cf = "java/lang/ClassLoader",
                   name = "retrieveDirectives",
                   desc = "()Ljava/lang/AssertionStatusDirectives;",
-                  instantiatedType = "java/lang/AssertionStatusDirectives"
+                  instantiatedType = "Ljava/lang/AssertionStatusDirectives;"
                 }
               }
             ]
@@ -940,7 +940,7 @@ org.opalj {
                   cf = "java/lang/SecurityManager",
                   name = "currentClassLoader0",
                   desc = "()Ljava/lang/ClassLoader;",
-                  instantiatedType = "java/lang/ClassLoader"
+                  instantiatedType = "Ljava/lang/ClassLoader;"
                 }
               }
             ]
@@ -960,7 +960,7 @@ org.opalj {
                   cf = "java/lang/SecurityManager",
                   name = "currentLoadedClass0",
                   desc = "()Ljava/lang/Class;",
-                  instantiatedType = "java/lang/Class"
+                  instantiatedType = "Ljava/lang/Class;"
                 }
               }
             ]
@@ -1006,7 +1006,7 @@ org.opalj {
                   cf = "java/lang/Thread",
                   name = "currentThread",
                   desc = "()Ljava/lang/Thread;",
-                  instantiatedType = "java/lang/Thread"
+                  instantiatedType = "Ljava/lang/Thread;"
                 }
               },
               {
@@ -1020,7 +1020,7 @@ org.opalj {
                   cf = "java/lang/Thread",
                   name = "currentThread",
                   desc = "()Ljava/lang/Thread;",
-                  instantiatedType = "java/lang/ThreadGroup"
+                  instantiatedType = "Ljava/lang/ThreadGroup;"
                 }
               },
               {
@@ -1034,7 +1034,7 @@ org.opalj {
                   cf = "java/lang/Thread",
                   name = "currentThread",
                   desc = "()Ljava/lang/Thread;",
-                  instantiatedType = "java/lang/ThreadGroup"
+                  instantiatedType = "Ljava/lang/ThreadGroup;"
                 }
               },
               {
@@ -1048,7 +1048,7 @@ org.opalj {
                   cf = "java/lang/Thread",
                   name = "currentThread",
                   desc = "()Ljava/lang/Thread;",
-                  instantiatedType = "java/lang/ThreadGroup"
+                  instantiatedType = "Ljava/lang/ThreadGroup;"
                 }
               },
               {
@@ -1061,7 +1061,7 @@ org.opalj {
                   cf = "java/lang/Thread",
                   name = "currentThread",
                   desc = "()Ljava/lang/Thread;",
-                  instantiatedType = "java/lang/Thread"
+                  instantiatedType = "Ljava/lang/Thread;"
                 }
               }
             ]
@@ -1123,7 +1123,7 @@ org.opalj {
                   cf = "java/lang/Throwable",
                   name = "getStackTraceElement",
                   desc = "(I)Ljava/lang/StackTraceElement;",
-                  instantiatedType = "java/lang/StackTraceElement"
+                  instantiatedType = "Ljava/lang/StackTraceElement;"
                 }
               }
             ]
@@ -1164,7 +1164,7 @@ org.opalj {
                   cf = "java/lang/reflect/Proxy",
                   name = "defineClass0",
                   desc = "(Ljava/lang/ClassLoader;Ljava/lang/String;[BII)Ljava/lang/Class;",
-                  instantiatedType = "java/lang/Class"
+                  instantiatedType = "Ljava/lang/Class;"
                 }
               }
             ]
@@ -1280,7 +1280,7 @@ org.opalj {
                   cf = "sun/misc/Perf",
                   name = "createLong",
                   desc = "(Ljava/lang/String;IIJ)Ljava/nio/ByteBuffer;"
-                  instantiatedType = "java/nio/DirectByteBuffer"
+                  instantiatedType = "Ljava/nio/DirectByteBuffer;"
                 }
               }
             ]
@@ -1308,7 +1308,7 @@ org.opalj {
                   cf = "java/io/FileSystem",
                   name = "getFileSystem",
                   desc = "()Ljava/io/FileSystem;",
-                  instantiatedType = "java/io/UnixFileSystem"
+                  instantiatedType = "Ljava/io/UnixFileSystem;"
                 }
               },
               {
@@ -1321,7 +1321,7 @@ org.opalj {
                   cf = "java/io/FileSystem",
                   name = "getFileSystem",
                   desc = "()Ljava/io/FileSystem;",
-                  instantiatedType = "java/io/UnixFileSystem"
+                  instantiatedType = "Ljava/io/UnixFileSystem;"
                 }
               }
             ]


### PR DESCRIPTION
We do this for the PointsTo Call Graphs, so we ought to do it for RTA/PropagationBassed as well to ensure they are at least as sound