### PR TITLE
Allow negative PCs for simulated native/configured allocations

### DIFF
--- a/OPAL/br/src/main/scala/org/opalj/br/fpcf/properties/pointsto/package.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/fpcf/properties/pointsto/package.scala
@@ -15,13 +15,13 @@ package object pointsto {
         tpe:          ReferenceType,
         isEmptyArray: Boolean       = false
     ): Long = {
-        val contextId = if (context eq NoContext) 0x7FFFFFF else context.id
+        val contextId = if (context eq NoContext) 0x3FFFFFF else context.id
         val typeId = tpe.id
         val emptyArray = if (isEmptyArray) 1L else 0L
-        assert(pc >= 0 && pc <= 0xFFFF)
-        assert(contextId >= 0 && contextId <= 0x7FFFFFF)
+        assert(pc >= -0x10000 && pc <= 0xFFFF)
+        assert(contextId >= 0 && contextId <= 0x3FFFFFF)
         assert(typeId >= -0x80000 && typeId <= 0x7FFFF)
-        contextId.toLong | (pc.toLong << 27) | (emptyArray << 43) | (typeId.toLong << 44)
+        contextId.toLong | ((pc.toLong << 26) & 0x1FFFF) | (emptyArray << 43) | (typeId.toLong << 44)
     }
 
     @inline def allocationSiteLongToTypeId(encodedAllocationSite: AllocationSite): Int = {

--- a/OPAL/br/src/main/scala/org/opalj/br/fpcf/properties/pointsto/package.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/fpcf/properties/pointsto/package.scala
@@ -21,7 +21,7 @@ package object pointsto {
         assert(pc >= -0x10000 && pc <= 0xFFFF)
         assert(contextId >= 0 && contextId <= 0x3FFFFFF)
         assert(typeId >= -0x80000 && typeId <= 0x7FFFF)
-        contextId.toLong | ((pc.toLong << 26) & 0x1FFFF) | (emptyArray << 43) | (typeId.toLong << 44)
+        contextId.toLong | ((pc.toLong & 0x1FFFF) << 26) | (emptyArray << 43) | (typeId.toLong << 44)
     }
 
     @inline def allocationSiteLongToTypeId(encodedAllocationSite: AllocationSite): Int = {

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/AllocationsUtil.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/AllocationsUtil.scala
@@ -66,7 +66,7 @@ object AllocationsUtil {
         failure:           () => Unit
     )(process: (ContextType, Int, Array[Stmt[V]]) => Unit): Unit = {
         val tacO = tacEOptP.ub.tac
-        if (tacO.isDefined) {
+        if (tacO.isDefined && allocationPC >= 0) {
             val tac = tacO.get
             process(allocationContext, tac.properStmtIndexForPC(allocationPC), tac.stmts)
         } else {

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/reflection/MethodHandlesUtil.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/reflection/MethodHandlesUtil.scala
@@ -71,9 +71,13 @@ object MethodHandlesUtil {
             if (descriptorOpt.isDefined) {
                 descriptorOpt.map { md =>
                     // for instance methods, we need to peel off the receiver type
-                    if (!isStatic && !isConstructor)
-                        Set(MethodDescriptor(md.parameterTypes.tail, md.returnType))
-                    else
+                    if (!isStatic && !isConstructor) {
+                        // but the method handle might not match the expected descriptor
+                        if(md.parameterTypes.isEmpty)
+                            Set.empty[MethodDescriptor]
+                        else
+                            Set(MethodDescriptor(md.parameterTypes.tail, md.returnType))
+                    } else
                         Set(md)
                 }
             } else

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/reflection/MethodHandlesUtil.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/reflection/MethodHandlesUtil.scala
@@ -73,7 +73,7 @@ object MethodHandlesUtil {
                     // for instance methods, we need to peel off the receiver type
                     if (!isStatic && !isConstructor) {
                         // but the method handle might not match the expected descriptor
-                        if(md.parameterTypes.isEmpty)
+                        if (md.parameterTypes.isEmpty)
                             Set.empty[MethodDescriptor]
                         else
                             Set(MethodDescriptor(md.parameterTypes.tail, md.returnType))

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/reflection/ReflectionRelatedCallsAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/reflection/ReflectionRelatedCallsAnalysis.scala
@@ -1257,13 +1257,18 @@ class MethodHandleInvokeAnalysis private[analyses] (
                     if (isVirtual) {
                         val receiverTypes =
                             if (actualParams.isDefined && actualParams.get.nonEmpty && actualParams.get.head.isDefined) {
-                                val rcvr = actualParams.get.head.get.value.asReferenceValue
-                                Some(
-                                    if (rcvr.isNull.isYes) Set.empty[ObjectType]
-                                    else if (rcvr.leastUpperType.get.isArrayType) Set(ObjectType.Object)
-                                    else if (rcvr.isPrecise) Set(rcvr.leastUpperType.get.asObjectType)
-                                    else project.classHierarchy.allSubtypes(rcvr.leastUpperType.get.asObjectType, true)
-                                )
+                                val receiverValue = actualParams.get.head.get.value
+                                if (!receiverValue.isReferenceValue)
+                                    None
+                                else {
+                                    val rcvr = receiverValue.asReferenceValue
+                                    Some(
+                                        if (rcvr.isNull.isYes) Set.empty[ObjectType]
+                                        else if (rcvr.leastUpperType.get.isArrayType) Set(ObjectType.Object)
+                                        else if (rcvr.isPrecise) Set(rcvr.leastUpperType.get.asObjectType)
+                                        else project.classHierarchy.allSubtypes(rcvr.leastUpperType.get.asObjectType, true)
+                                    )
+                                }
                             } else None
                         if (receiverTypes.isDefined)
                             matchers += new ClassBasedMethodMatcher(

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/LibraryPointsToAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/LibraryPointsToAnalysis.scala
@@ -66,7 +66,7 @@ abstract class LibraryPointsToAnalysis( final val project: SomeProject)
         val seenArrayTypes = UIDSet.newBuilder[ArrayType]
 
         def createExternalAllocation(tpe: ReferenceType): PointsToSet = {
-            createPointsToSet(0xFFFF, NoContext.asInstanceOf[ContextType], tpe, false)
+            createPointsToSet(-1, NoContext.asInstanceOf[ContextType], tpe, false)
         }
 
         def initialize(param: Entity, types: UIDSet[ReferenceType]): Unit = {

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/package.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/package.scala
@@ -23,9 +23,10 @@ package object pointsto {
         typeIterator: TypeIterator
     ): (Context, PC, Int) /* method, pc, typeid */ = {
         val contextID = encodedAllocationSite.toInt & 0x3FFFFFF
+        val pc = (encodedAllocationSite >> 26).toInt & 0x1FFFF
         (
             typeIterator.contextFromId(if (contextID == 0x3FFFFFF) -1 else contextID),
-            (encodedAllocationSite >> 26).toInt & 0x1FFFF,
+            if (pc > 0xFFFF) pc | 0xFFFF0000 else pc,
             (encodedAllocationSite >> 44).toInt
         )
     }

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/package.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/package.scala
@@ -22,10 +22,10 @@ package object pointsto {
         implicit
         typeIterator: TypeIterator
     ): (Context, PC, Int) /* method, pc, typeid */ = {
-        val contextID = encodedAllocationSite.toInt & 0x7FFFFFF
+        val contextID = encodedAllocationSite.toInt & 0x3FFFFFF
         (
-            typeIterator.contextFromId(if (contextID == 0x7FFFFFF) -1 else contextID),
-            (encodedAllocationSite >> 27).toInt & 0xFFFF,
+            typeIterator.contextFromId(if (contextID == 0x3FFFFFF) -1 else contextID),
+            (encodedAllocationSite >> 26).toInt & 0x1FFFF,
             (encodedAllocationSite >> 44).toInt
         )
     }


### PR DESCRIPTION
We use them so they don't collide with actual PCs in non-native but configured methods. Hurts to mostly waste a bit here, but seems to be the most practical solution for now.