### PR TITLE
Fix/configured cg methods

### DIFF
--- a/OPAL/br/src/main/scala/org/opalj/br/analyses/cg/EntryPointFinder.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/analyses/cg/EntryPointFinder.scala
@@ -66,7 +66,8 @@ trait ApplicationWithoutJREEntryPointsFinder extends ApplicationEntryPointsFinde
     override def collectEntryPoints(project: SomeProject): Iterable[Method] = {
         super.collectEntryPoints(project).filterNot { ep =>
             packagesToExclude.exists { prefix =>
-                ep.declaringClassFile.thisType.packageName.startsWith(prefix)
+                ep.declaringClassFile.thisType.packageName.startsWith(prefix) &&
+                    ep.name == "main"
             }
         }.filterNot { ep =>
             // The WrapperGenerator class file is part of the rt.jar in 1.7., but is in the

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/ConfiguredNativeMethodsCallGraphAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/ConfiguredNativeMethodsCallGraphAnalysis.scala
@@ -112,14 +112,18 @@ class ConfiguredNativeMethodsCallGraphAnalysis private[analyses] (
 
         var results: Iterator[PartialResult[_, _ >: Null <: Property]] = Iterator.empty
         callers.forNewCalleeContexts(seen, eOptP.e) { calleeContext =>
-            val directCalls = new DirectCalls()
+            val calls = new DirectCallsBase with VMReachableMethodsBase()
             for (tgt <- tgts) {
                 val tgtMethod = tgt.method(declaredMethods)
-                directCalls.addCall(
-                    calleeContext, 0, typeIterator.expandContext(calleeContext, tgtMethod, 0)
-                )
+                if (tgtMethod.name == "<clinit>") {
+                    calls.addVMReachableMethod(tgtMethod);
+                } else {
+                    calls.addCall(
+                        calleeContext, 0, typeIterator.expandContext(calleeContext, tgtMethod, 0)
+                    )
+                }
             }
-            results ++= directCalls.partialResults(calleeContext)
+            results ++= calls.partialResults(calleeContext)
         }
 
         Results(InterimPartialResult(Set(eOptP), c(eOptP.ub)), results)


### PR DESCRIPTION
Fixes two issues with configured methods for call-graph analyses
- Configured entry points could be filtered out by accident if the are in a JDK package
- <clinit> methods if configured as called would not have been properly added to the call-graph as VMReachable