### PR TITLE
Analysis auto config

### DIFF
--- a/OPAL/br/src/main/resources/reference.conf
+++ b/OPAL/br/src/main/resources/reference.conf
@@ -116,27 +116,32 @@ org.opalj {
         "L0CompileTimeConstancyAnalysis" {
           description = "Determines if static fields are compile time constants.",
           eagerFactory = "org.opalj.br.fpcf.analyses.EagerL0CompileTimeConstancyAnalysis",
-          lazyFactory = "org.opalj.br.fpcf.analyses.LazyL0CompileTimeConstancyAnalysis"
+          lazyFactory = "org.opalj.br.fpcf.analyses.LazyL0CompileTimeConstancyAnalysis",
+          default = true
         },
         "L0SelfReferenceLeakageAnalysis" {
           description = "Determines if an object may leak its self reference (`this`).",
-          eagerFactory = "org.opalj.br.fpcf.analyses.L0SelfReferenceLeakageAnalysis"
+          eagerFactory = "org.opalj.br.fpcf.analyses.L0SelfReferenceLeakageAnalysis",
+          default = true
           #TODO This one does not yet have a lazy factory
         },
         "L1ThrownExceptionsAnalysis" {
           description = "Determines the exceptions that are thrown by a method.",
           eagerFactory = "org.opalj.br.fpcf.analyses.EagerL1ThrownExceptionsAnalysis",
-          lazyFactory = "org.opalj.br.fpcf.analyses.LazyL1ThrownExceptionsAnalysis"
+          lazyFactory = "org.opalj.br.fpcf.analyses.LazyL1ThrownExceptionsAnalysis",
+          default = true
         },
         "L0AllocationFreenessAanalysis" {
           description = "Determines if a method may (transitively) cause allocations.",
           eagerFactory = "org.opalj.br.fpcf.analyses.EagerL0AllocationFreenessAnalysis",
-          lazyFactory = "org.opalj.br.fpcf.analyses.LazyL0AllocationFreenessAnalysis"
+          lazyFactory = "org.opalj.br.fpcf.analyses.LazyL0AllocationFreenessAnalysis",
+          default = true
         },
         "StaticDataUsageAnalysis" {
           description = "Determines if a method uses only compile time constant static state.",
           eagerFactory = "org.opalj.br.fpcf.analyses.EagerStaticDataUsageAnalysis",
-          lazyFactory = "org.opalj.br.fpcf.analyses.LazyStaticDataUsageAnalysis"
+          lazyFactory = "org.opalj.br.fpcf.analyses.LazyStaticDataUsageAnalysis",
+          default = true
         },
         "L0PurityAnalysis" {
           description = "Determines a method's purity.",
@@ -146,43 +151,51 @@ org.opalj {
         "ClassImmutabilityAnalysis" {
           description = "Determines the immutability of individual classes.",
           eagerFactory = "org.opalj.br.fpcf.analyses.immutability.EagerClassImmutabilityAnalysis",
-          lazyFactory = "org.opalj.br.fpcf.analyses.immutability.LazyClassImmutabilityAnalysis"
+          lazyFactory = "org.opalj.br.fpcf.analyses.immutability.LazyClassImmutabilityAnalysis",
+          default = true
         },
         "TypeImmutabilityAnalysis" {
           description = "Determines the immutability of types (i.e., sets of classes).",
           eagerFactory = "org.opalj.br.fpcf.analyses.immutability.EagerTypeImmutabilityAnalysis",
-          lazyFactory = "org.opalj.br.fpcf.analyses.immutability.LazyTypeImmutabilityAnalysis"
+          lazyFactory = "org.opalj.br.fpcf.analyses.immutability.LazyTypeImmutabilityAnalysis",
+          default = true
         },
         // The virtual/aggregating ones...
         "VirtualMethodThrownExceptionsAnalysis" {
           description = "Determines the aggregated thrown exceptions for a virtual method.",
           eagerFactory = "org.opalj.br.fpcf.analyses.EagerVirtualMethodThrownExceptionsAnalysis",
-          lazyFactory = "org.opalj.br.fpcf.analyses.LazyVirtualMethodThrownExceptionsAnalysis"
+          lazyFactory = "org.opalj.br.fpcf.analyses.LazyVirtualMethodThrownExceptionsAnalysis",
+          default = true
         },
         "VirtualMethodAllocationFreenessAnalysis" {
           description = "Determines the aggregated allocation freeness for a virtual method.",
-          eagerFactory = "org.opalj.br.fpcf.analyses.EagerVirtualMethodPurityAnalysis",
-          lazyFactory = "org.opalj.br.fpcf.analyses.LazyVirtualMethodPurityAnalysis"
+          eagerFactory = "org.opalj.br.fpcf.analyses.EagerVirtualMethodAllocationFreenessAnalysis",
+          lazyFactory = "org.opalj.br.fpcf.analyses.LazyVirtualMethodAllocationFreenessAnalysis",
+          default = true
         },
         "VirtualMethodStaticDataUsageAnalysis" {
           description = "Determines the aggregated static data use freeness for a virtual method.",
           eagerFactory = "org.opalj.br.fpcf.analyses.EagerVirtualMethodStaticDataUsageAnalysis",
-          lazyFactory = "org.opalj.br.fpcf.analyses.LazyVirtualMethodStaticDataUsageAnalysis"
+          lazyFactory = "org.opalj.br.fpcf.analyses.LazyVirtualMethodStaticDataUsageAnalysis",
+          default = true
         },
         "VirtualMethodPurityAnalysis" {
           description = "Determines the aggregated purity for a virtual method.",
           eagerFactory = "org.opalj.br.fpcf.analyses.EagerVirtualMethodPurityAnalysis",
-          lazyFactory = "org.opalj.br.fpcf.analyses.LazyVirtualMethodPurityAnalysis"
+          lazyFactory = "org.opalj.br.fpcf.analyses.LazyVirtualMethodPurityAnalysis",
+          default = true
         },
         "VirtualCallAggregatingEscapeAnalysis" {
           description = "Determines the aggregated escape level for a virtual formal parameter.",
           eagerFactory = "org.opalj.br.fpcf.analyses.EagerVirtualCallAggregatingEscapeAnalysis",
-          lazyFactory = "org.opalj.br.fpcf.analyses.LazyVirtualCallAggregatingEscapeAnalysis"
+          lazyFactory = "org.opalj.br.fpcf.analyses.LazyVirtualCallAggregatingEscapeAnalysis",
+          default = true
         },
         "VirtualReturnValueFreshnessAnalysis" {
           description = "Determines the aggregated return value freshness for a virtual method.",
           eagerFactory = "org.opalj.br.fpcf.analyses.EagerVirtualReturnValueFreshnessAnalysis",
-          lazyFactory = "org.opalj.br.fpcf.analyses.LazyVirtualReturnValueFreshnessAnalysis"
+          lazyFactory = "org.opalj.br.fpcf.analyses.LazyVirtualReturnValueFreshnessAnalysis",
+          default = true
         }
       }
     }

--- a/OPAL/br/src/main/scala/org/opalj/br/fpcf/FPCFAnalysesManager.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/fpcf/FPCFAnalysesManager.scala
@@ -51,7 +51,7 @@ class FPCFAnalysesManager private[fpcf] (val project: SomeProject) {
 
         val scenario = AnalysisScenario(analyses, propertyStore)
 
-        val schedule = scenario.computeSchedule(propertyStore)
+        val schedule = scenario.computeSchedule(propertyStore, FPCFAnalysesRegistry.defaultAnalysis)
         schedules ::= schedule
 
         if (trace) { debug("analysis progress", "executing "+schedule) }

--- a/OPAL/si/src/main/resources/reference.conf
+++ b/OPAL/si/src/main/resources/reference.conf
@@ -16,4 +16,6 @@ org.opalj {
   // For tasks managers for the par. store see PKECPropertyStore.Strategies
   fpcf.par.PKECPropertyStore.TasksManager = "NoPriority"
   fpcf.par.PKECPropertyStore.MaxEvaluationDepth = 32
+
+  fpcf.AnalysisScenario.AnalysisAutoConfig = false
 }

--- a/OPAL/tac/src/main/resources/reference.conf
+++ b/OPAL/tac/src/main/resources/reference.conf
@@ -12,7 +12,8 @@ org.opalj {
         "L0TACAIAnalysis" {
           description = "Performs an abstract interpretation using the configured domain and then computes the 3-address code.",
           eagerFactory = "org.opalj.tac.fpcf.analyses.EagerL0TACAIAnalysis",
-          lazyFactory = "org.opalj.tac.fpcf.analyses.LazyL0TACAIAnalysis"
+          lazyFactory = "org.opalj.tac.fpcf.analyses.LazyL0TACAIAnalysis",
+          default = true
         },
         "L0FieldAssignabilityAnalysis" {
           description = "Determines the assignability of (instance and static) fields.",
@@ -28,12 +29,14 @@ org.opalj {
           description = "Determines the assignability of (instance and static) fields.",
           eagerFactory = "org.opalj.tac.fpcf.analyses.fieldassignability.EagerL2FieldAssignabilityAnalysis",
           lazyFactory = "org.opalj.tac.fpcf.analyses.fieldassignability.LazyL2FieldAssignabilityAnalysis",
+          default = true,
           considerLazyInitialization = true
         },
         "FieldImmutabilityAnalysis" {
           description = "Determines the immutability of (instance and static) fields.",
           eagerFactory = "org.opalj.tac.fpcf.analyses.EagerFieldImmutabilityAnalysis",
-          lazyFactory = "org.opalj.tac.fpcf.analyses.LazyFieldImmutabilityAnalysis"
+          lazyFactory = "org.opalj.tac.fpcf.analyses.LazyFieldImmutabilityAnalysis",
+          default = true
         },
         "SimpleEscapeAnalysis" {
           description = "Determines whether objects escape a method.",
@@ -43,17 +46,20 @@ org.opalj {
         "InterProceduralEscapeAnalysis" {
           description = "Determines whether objects escape a method.",
           eagerFactory = "org.opalj.tac.fpcf.analyses.escape.EagerInterProceduralEscapeAnalysis",
-          lazyFactory = "org.opalj.tac.fpcf.analyses.escape.LazyInterProceduralEscapeAnalysis"
+          lazyFactory = "org.opalj.tac.fpcf.analyses.escape.LazyInterProceduralEscapeAnalysis",
+          default = true
         },
         "FieldLocalityAnalysis" {
           description = "Determines if a field's lifetime is bound to its owning instance.",
           eagerFactory = "org.opalj.tac.fpcf.analyses.EagerFieldLocalityAnalysis",
-          lazyFactory = "org.opalj.tac.fpcf.analyses.LazyFieldLocalityAnalysis"
+          lazyFactory = "org.opalj.tac.fpcf.analyses.LazyFieldLocalityAnalysis",
+          default = true
         },
         "ReturnValueFreshnessAnalysis" {
           description = "Determines if a method's return value is always freshly allocated.",
           eagerFactory = "org.opalj.tac.fpcf.analyses.escape.EagerReturnValueFreshnessAnalysis",
-          lazyFactory = "org.opalj.tac.fpcf.analyses.escape.LazyReturnValueFreshnessAnalysis"
+          lazyFactory = "org.opalj.tac.fpcf.analyses.escape.LazyReturnValueFreshnessAnalysis",
+          default = true
         },
         "L1PurityAnalysis" {
           description = "Determines a method's purity.",
@@ -63,7 +69,8 @@ org.opalj {
         "L2PurityAnalysis" {
           description = "Determines a method's purity.",
           eagerFactory = "org.opalj.tac.fpcf.analyses.purity.EagerL2PurityAnalysis",
-          lazyFactory = "org.opalj.tac.fpcf.analyses.purity.LazyL2PurityAnalysis"
+          lazyFactory = "org.opalj.tac.fpcf.analyses.purity.LazyL2PurityAnalysis",
+          default = true
         }
       }
     },


### PR DESCRIPTION
If no analysis is specified for a property, OPAL can now automatically select a default analysis.
Defaults to off to ensure backwards compatibility and because using cheap fallbacks may often still be preferential.