### PR TITLE
Bump to Scala 2.13.11

### DIFF
--- a/DEVELOPING_OPAL/demos/src/main/scala/org/opalj/ba/ThirdInstrumentation.scala
+++ b/DEVELOPING_OPAL/demos/src/main/scala/org/opalj/ba/ThirdInstrumentation.scala
@@ -6,9 +6,11 @@ import java.io.ByteArrayInputStream
 import java.io.File
 import java.util.ArrayList
 import java.util.Arrays
+
 import org.opalj.log.LogContext
 import org.opalj.log.GlobalLogContext
 import org.opalj.io.writeAndOpen
+
 import org.opalj.ai.BaseAI
 import org.opalj.ai.domain.l0.TypeCheckingDomain
 import org.opalj.da.ClassFileReader.ClassFile
@@ -33,8 +35,9 @@ import org.opalj.br.instructions.IFGT
 import org.opalj.br.instructions.NEW
 import org.opalj.br.instructions.INVOKESPECIAL
 import org.opalj.br.PCAndInstruction
-
 import scala.collection.immutable.ArraySeq
+
+import org.opalj.br.ClassHierarchy
 
 /**
  * Demonstrates how to perform an instrumentation where we need more information about the code
@@ -56,7 +59,7 @@ object ThirdInstrumentation extends App {
     // local variables and stack values during instrumentation.
     val f = new File(this.getClass.getResource("SimpleInstrumentationDemo.class").getFile)
     val p = Project(f.getParentFile, org.opalj.bytecode.RTJar)
-    implicit val classHierarchy = p.classHierarchy // STRICTLY REQUIRED WHEN A StackMapTable NEEDS TO BE COMPUTED!
+    implicit val classHierarchy: ClassHierarchy = p.classHierarchy // STRICTLY REQUIRED WHEN A StackMapTable NEEDS TO BE COMPUTED!
     val cf = p.classFile(TheType).get
     // let's transform the methods
     val newMethods = for (m <- cf.methods) yield {

--- a/DEVELOPING_OPAL/demos/src/main/scala/org/opalj/bc/DAandBR.scala
+++ b/DEVELOPING_OPAL/demos/src/main/scala/org/opalj/bc/DAandBR.scala
@@ -5,6 +5,7 @@ package bc
 import java.nio.file.Files
 import java.nio.file.Paths
 import java.io.ByteArrayInputStream
+
 import org.opalj.bi.ACC_PUBLIC
 import org.opalj.bi.ACC_SUPER
 import org.opalj.bi.ACC_STATIC
@@ -22,8 +23,9 @@ import org.opalj.da.CONSTANT_String_info
 import org.opalj.da.Code_attribute
 import org.opalj.da.Code
 import org.opalj.br.reader.Java8Framework
-
 import scala.collection.immutable.ArraySeq
+
+import org.opalj.da.Constant_Pool
 
 /**
  * Demonstrates how to create a "HelloWorld" class and how
@@ -220,11 +222,11 @@ object DAandBR extends App {
     val newBRClassFile = brClassFile.copy(methods = newBRMethods)
 
     val newDAClassFile = cf.copy(methods = cf.methods.filter { daM =>
-        implicit val cp = cf.constant_pool
+        implicit val cp: Constant_Pool = cf.constant_pool
         brClassFile.methods.exists { brM =>
             brM.name == daM.name && brM.descriptor.toJVMDescriptor == daM.descriptor
         }
     })
 
-    println("Created class file: "+Files.write(Paths.get("Test.class"), assembledCF).toAbsolutePath())
+    println("Created class file: "+Files.write(Paths.get("Test.class"), assembledCF).toAbsolutePath)
 }

--- a/DEVELOPING_OPAL/demos/src/main/scala/org/opalj/tac/CloseResources.scala
+++ b/DEVELOPING_OPAL/demos/src/main/scala/org/opalj/tac/CloseResources.scala
@@ -23,7 +23,7 @@ object CloseResources extends ProjectAnalysisApplication {
         params:        Seq[String],
         isInterrupted: () => Boolean
     ): BasicReport = {
-        // implicit val logContext = p.logContext
+        // implicit val logContext: LogContext = p.logContext
         // val tacaiKey = p.get(ComputeTACAIKey)
 
         val issues = new java.util.concurrent.ConcurrentLinkedQueue[String]()

--- a/DEVELOPING_OPAL/demos/src/main/scala/org/opalj/tac/TACTemplate.scala
+++ b/DEVELOPING_OPAL/demos/src/main/scala/org/opalj/tac/TACTemplate.scala
@@ -4,6 +4,8 @@ package tac
 
 import java.io.File
 import java.net.URL
+
+import org.opalj.log.LogContext
 import org.opalj.log.OPALLogger
 import org.opalj.log.StandardLogContext
 import org.opalj.br.Method
@@ -13,7 +15,6 @@ import org.opalj.bytecode.JRELibraryFolder
 import org.opalj.ai.Domain
 import org.opalj.ai.domain.RecordDefUse
 import org.opalj.ai.common.SimpleAIKey
-
 import scala.collection.parallel.CollectionConverters.ImmutableIterableIsParallelizable
 
 /**
@@ -93,7 +94,7 @@ object TACTemplate {
         //
         //      Given that we may use a context-sensitive domain (e.g., ...domain.l2.DefaultDomain),
         //      we also completely load the library code and not just the public API.
-        implicit val logContext = new StandardLogContext()
+        implicit val logContext: LogContext = new StandardLogContext()
         OPALLogger.register(logContext, OPALLogger.globalLogger())
         val reader = Project.JavaClassFileReader(logContext)
         val p = Project(

--- a/DEVELOPING_OPAL/tools/src/main/scala/org/opalj/support/info/Immutability.scala
+++ b/DEVELOPING_OPAL/tools/src/main/scala/org/opalj/support/info/Immutability.scala
@@ -190,7 +190,7 @@ object Immutability {
         time {
             analysesManager.runAll(
                 dependencies, {
-                css: List[ComputationSpecification[FPCFAnalysis]] =>
+                (css: List[ComputationSpecification[FPCFAnalysis]]) =>
                     analysis match {
                         case Assignability =>
                             if (css.contains(LazyL2FieldAssignabilityAnalysis))

--- a/DEVELOPING_OPAL/tools/src/main/scala/org/opalj/support/info/Purity.scala
+++ b/DEVELOPING_OPAL/tools/src/main/scala/org/opalj/support/info/Purity.scala
@@ -249,11 +249,10 @@ object Purity {
 
             manager.runAll(
                 analyses,
-                { css: List[ComputationSpecification[FPCFAnalysis]] =>
+                (css: List[ComputationSpecification[FPCFAnalysis]]) =>
                     if (css.contains(analysis)) {
                         analyzedMethods.foreach { dm => ps.force(dm, br.fpcf.properties.Purity.key) }
                     }
-                }
             )
         } { t => analysisTime = t.toSeconds }
         ps.shutdown()

--- a/DEVELOPING_OPAL/tools/src/main/scala/org/opalj/support/info/ThrownExceptions.scala
+++ b/DEVELOPING_OPAL/tools/src/main/scala/org/opalj/support/info/ThrownExceptions.scala
@@ -96,7 +96,7 @@ object ThrownExceptions extends ProjectAnalysisApplication {
                 epsThrowingExceptionsByClassFile.map { e =>
                     val (cf, epsThrowingExceptionsPerMethod) = e
                     cf.thisType.toJava+"{"+
-                        epsThrowingExceptionsPerMethod.map { eps: SomeEPS =>
+                        epsThrowingExceptionsPerMethod.map { (eps: SomeEPS) =>
                             val m: Method = eps.e.asInstanceOf[Method]
                             val ThrownExceptionsProperty(types) = eps.ub
                             m.descriptor.toJava(m.name)+" throws "+types.toString

--- a/DEVELOPING_OPAL/tools/src/main/scala/org/opalj/support/info/Values.scala
+++ b/DEVELOPING_OPAL/tools/src/main/scala/org/opalj/support/info/Values.scala
@@ -12,6 +12,7 @@ import org.opalj.br.Method
 import org.opalj.br.analyses.BasicReport
 import org.opalj.br.analyses.ProjectAnalysisApplication
 import org.opalj.br.analyses.Project
+import org.opalj.br.ClassHierarchy
 import org.opalj.br.Field
 import org.opalj.ai.fpcf.properties.FieldValue
 import org.opalj.ai.fpcf.properties.MethodReturnValue
@@ -35,7 +36,7 @@ object Values extends ProjectAnalysisApplication {
         isInterrupted: () => Boolean
     ): BasicReport = {
 
-        implicit val classHierarchy = project.classHierarchy
+        implicit val classHierarchy: ClassHierarchy = project.classHierarchy
 
         val (ps, _) =
             PerformanceEvaluation.time {

--- a/DEVELOPING_OPAL/tools/src/main/scala/org/opalj/support/tools/ClassHierarchyExtractor.scala
+++ b/DEVELOPING_OPAL/tools/src/main/scala/org/opalj/support/tools/ClassHierarchyExtractor.scala
@@ -63,7 +63,7 @@ object ClassHierarchyExtractor {
         val classFiles = args.foldLeft(Nil: List[ClassFile]) { (classFiles, filename) =>
             classFiles ++ ClassFiles(new File(filename)).iterator.map(_._1)
         }
-        implicit val classHierarchy =
+        implicit val classHierarchy: ClassHierarchy =
             if (classFiles.forall(cf => cf.thisType != ObjectType.Object)) {
                 println("the class files do not contain java.lang.Object; adding default type hierarchy")
                 // load pre-configured class hierarchy...

--- a/DEVELOPING_OPAL/validate/src/test/java/org/opalj/fpcf/fixtures/immutability/openworld/generic/simple/GenericFields.java
+++ b/DEVELOPING_OPAL/validate/src/test/java/org/opalj/fpcf/fixtures/immutability/openworld/generic/simple/GenericFields.java
@@ -58,11 +58,11 @@ public class GenericFields<T> {
 
     public GenericFields(T t, Object o, FinalClassWithNoFields fcwnf){
 
-        this.singleMutable = new Generic(new ClassWithMutableFields());
+        this.singleMutable = new Generic<>(new ClassWithMutableFields());
         this.multipleMutable = new MultipleGeneric<>(t, new ClassWithMutableFields(), fcwnf);
 
         this.singleNonTransitivelyImmutable =
-                new Generic(new FinalClassWithNonTransitivelyImmutableField(new Object()));
+                new Generic<>(new FinalClassWithNonTransitivelyImmutableField(new Object()));
 
         this.multipleNonTransitivelyImmutable =
                 new MultipleGeneric<>(fcwnf,new FinalClassWithNonTransitivelyImmutableField(new Object()), t);

--- a/OPAL/ai/src/it/scala/org/opalj/ai/domain/l0/DefaultDomainTest.scala
+++ b/OPAL/ai/src/it/scala/org/opalj/ai/domain/l0/DefaultDomainTest.scala
@@ -6,12 +6,13 @@ package l0
 
 import org.junit.runner.RunWith
 import org.scalatestplus.junit.JUnitRunner
-
 import java.net.URL
 
 import org.opalj.br.Method
 import org.opalj.br.PCAndInstruction
 import org.opalj.br.analyses.Project
+import org.opalj.br.ClassHierarchy
+import org.opalj.br.Code
 
 /**
  * This system test(suite) just loads a very large number of class files and performs
@@ -33,12 +34,12 @@ class DefaultDomainTest extends DomainTestInfrastructure("l0.DefaultDomain") {
 
         super.analyzeAIResult(project, method, result)
 
-        implicit val code = result.code
-        implicit val classHierarchy = project.classHierarchy
+        implicit val code: Code = result.code
+        implicit val classHierarchy: ClassHierarchy = project.classHierarchy
         val operandsArray = result.operandsArray
         val evaluatedInstructions = result.evaluatedInstructions
         for {
-            PCAndInstruction(pc, instruction) <- result.code
+            case PCAndInstruction(pc, instruction) <- result.code
             if evaluatedInstructions.contains(pc)
             operands = operandsArray(pc)
         } {

--- a/OPAL/ai/src/main/scala/org/opalj/ai/AI.scala
+++ b/OPAL/ai/src/main/scala/org/opalj/ai/AI.scala
@@ -835,7 +835,7 @@ abstract class AI[D <: Domain](
                     if (IdentifyDeadVariables && cfJoins.contains(targetPC)) {
                         var i = 0
                         val theLiveVariables = liveVariables(targetPC)
-                        val newLocals = locals mapConserve { v: theDomain.DomainValue =>
+                        val newLocals = locals mapConserve { (v: theDomain.DomainValue) =>
                             val lvIndex = i
                             i += 1
                             if ((v eq null) || theLiveVariables.contains(lvIndex)) {

--- a/OPAL/ai/src/main/scala/org/opalj/ai/domain/RecordDefUse.scala
+++ b/OPAL/ai/src/main/scala/org/opalj/ai/domain/RecordDefUse.scala
@@ -592,8 +592,8 @@ trait RecordDefUse extends RecordCFG { defUseDomain: Domain with TheCode =>
         val instructions = code.instructions
         lazy val belongsToSubroutine = code.belongsToSubroutine()
         // println(belongsToSubroutine.zipWithIndex.map(_.swap).mkString("Subroutine association:\n\t", "\n\t", "\n"))
-        implicit val operandsArray = aiResult.operandsArray
-        implicit val localsArray = aiResult.localsArray
+        implicit val operandsArray: aiResult.domain.OperandsArray = aiResult.operandsArray
+        implicit val localsArray: aiResult.domain.LocalsArray = aiResult.localsArray
         implicit val subroutinePCs: IntArraySet = aiResult.subroutinePCs
         implicit val cfJoins: IntTrieSet = aiResult.cfJoins
 

--- a/OPAL/ai/src/main/scala/org/opalj/ai/domain/TheProject.scala
+++ b/OPAL/ai/src/main/scala/org/opalj/ai/domain/TheProject.scala
@@ -4,6 +4,7 @@ package ai
 package domain
 
 import org.opalj.log.LogContext
+import org.opalj.fpcf.PropertyStore
 import org.opalj.br.{ClassHierarchy => BRClassHierarchy}
 import org.opalj.br.analyses.SomeProject
 import org.opalj.br.fpcf.PropertyStoreKey
@@ -48,5 +49,5 @@ trait TheProject extends ThePropertyStore with LogContextProvider {
      */
     @inline final implicit def classHierarchy: BRClassHierarchy = project.classHierarchy
 
-    implicit final override lazy val propertyStore = project.get(PropertyStoreKey)
+    implicit final override lazy val propertyStore: PropertyStore = project.get(PropertyStoreKey)
 }

--- a/OPAL/ai/src/main/scala/org/opalj/ai/domain/l0/TypeLevelReferenceValues.scala
+++ b/OPAL/ai/src/main/scala/org/opalj/ai/domain/l0/TypeLevelReferenceValues.scala
@@ -12,7 +12,6 @@ import org.opalj.value.IsSArrayValue
 import org.opalj.value.IsSReferenceValue
 import org.opalj.value.ValueInformation
 import org.opalj.br.ArrayType
-import org.opalj.br.ClassHierarchy
 import org.opalj.br.FieldType
 import org.opalj.br.ObjectType
 import org.opalj.br.ReferenceType
@@ -248,8 +247,6 @@ trait TypeLevelReferenceValues extends GeneralizedArrayHandling with AsJavaObjec
 
         def theUpperTypeBound: T
 
-        final def classHierarchy: ClassHierarchy = domain.classHierarchy
-
         final override def summarize(pc: Int): this.type = this
 
         override def toString: String = theUpperTypeBound.toJava
@@ -330,7 +327,7 @@ trait TypeLevelReferenceValues extends GeneralizedArrayHandling with AsJavaObjec
         ): ArrayLoadResult
 
         def isIndexValid(pc: Int, index: DomainValue): Answer =
-            length.map { l: Int =>
+            length.map { (l: Int) =>
                 intIsSomeValueNotInRange(pc, index, 0, l - 1) match {
                     case No => Yes
                     case Yes =>

--- a/OPAL/ai/src/main/scala/org/opalj/ai/domain/l1/ReferenceValues.scala
+++ b/OPAL/ai/src/main/scala/org/opalj/ai/domain/l1/ReferenceValues.scala
@@ -654,8 +654,8 @@ trait ReferenceValues extends l0.DefaultTypeLevelReferenceValues with Origin {
 
         def toString(upperTypeBound: String): String = {
             var description = upperTypeBound
-            if (!isPrecise) description = "_ <: "+description
-            if (isNull.isUnknown) description = s"{$description, null}"
+            if (!this.isPrecise) description = "_ <: "+description
+            if (this.isNull.isUnknown) description = s"{$description, null}"
             description += s"[↦$origin;refId=$refId]"
             description
         }
@@ -688,15 +688,15 @@ trait ReferenceValues extends l0.DefaultTypeLevelReferenceValues with Origin {
         with NonNullSingleOriginSReferenceValue[ArrayType] {
         this: DomainArrayValue =>
 
-        assert(isNull.isNoOrUnknown)
-        assert(isPrecise || !classHierarchy.isKnownToBeFinal(theUpperTypeBound))
+        assert(this.isNull.isNoOrUnknown)
+        assert(this.isPrecise || !classHierarchy.isKnownToBeFinal(theUpperTypeBound))
 
         override def updateRefId(
             refId:  RefId,
             origin: ValueOrigin,
             isNull: Answer
         ): DomainArrayValue = {
-            ArrayValue(origin, isNull, isPrecise, theUpperTypeBound, refId)
+            ArrayValue(origin, isNull, this.isPrecise, theUpperTypeBound, refId)
         }
 
         def doRefineUpperTypeBound(supertype: ReferenceType): DomainSingleOriginReferenceValue = {
@@ -705,7 +705,7 @@ trait ReferenceValues extends l0.DefaultTypeLevelReferenceValues with Origin {
             // the type hierarchy is not known to OPAL. In this case, we will definitively
             // perform the upcast - even if the type is precise.
 
-            ArrayValue(origin, isNull, isPrecise = false, supertype.asArrayType, refId)
+            ArrayValue(origin, this.isNull, isPrecise = false, supertype.asArrayType, refId)
         }
 
         override def abstractsOver(other: DomainValue): Boolean = {
@@ -736,7 +736,9 @@ trait ReferenceValues extends l0.DefaultTypeLevelReferenceValues with Origin {
 
                 case thatDomain: l1.ReferenceValues =>
                     val thatT = thatDomain.nextRefId()
-                    thatDomain.ArrayValue(targetOrigin, isNull, isPrecise, theUpperTypeBound, thatT)
+                    thatDomain.ArrayValue(
+                        targetOrigin, this.isNull, this.isPrecise, theUpperTypeBound, thatT
+                    )
 
                 case thatDomain: l0.DefaultTypeLevelReferenceValues =>
                     thatDomain.ReferenceValue(targetOrigin, theUpperTypeBound)
@@ -767,9 +769,9 @@ trait ReferenceValues extends l0.DefaultTypeLevelReferenceValues with Origin {
 
         override def hashCode: Int = {
             ((origin * 41 +
-                (if (isPrecise) 101 else 3)) * 13 +
-                isNull.hashCode()) * 79 +
-                upperTypeBound.hashCode()
+                (if (this.isPrecise) 101 else 3)) * 13 +
+                this.isNull.hashCode()) * 79 +
+                this.upperTypeBound.hashCode()
         }
 
         override def toString: String = toString(theUpperTypeBound.toJava)
@@ -787,9 +789,9 @@ trait ReferenceValues extends l0.DefaultTypeLevelReferenceValues with Origin {
         this: DomainObjectValue =>
 
         assert(this.isNull.isNoOrUnknown)
-        assert(!classHierarchy.isKnownToBeFinal(theUpperTypeBound) || isPrecise)
+        assert(!classHierarchy.isKnownToBeFinal(theUpperTypeBound) || this.isPrecise)
         assert(
-            !isPrecise ||
+            !this.isPrecise ||
                 !classHierarchy.isKnown(theUpperTypeBound) ||
                 classHierarchy.isInterface(theUpperTypeBound).isNo,
             s"the type ${theUpperTypeBound.toJava} defines an interface and, "+
@@ -802,7 +804,7 @@ trait ReferenceValues extends l0.DefaultTypeLevelReferenceValues with Origin {
             origin: ValueOrigin,
             isNull: Answer
         ): DomainObjectValue = {
-            ObjectValue(origin, isNull, isPrecise, theUpperTypeBound, refId)
+            ObjectValue(origin, isNull, this.isPrecise, theUpperTypeBound, refId)
         }
 
         def doRefineUpperTypeBound(supertype: ReferenceType): DomainSingleOriginReferenceValue = {
@@ -810,7 +812,7 @@ trait ReferenceValues extends l0.DefaultTypeLevelReferenceValues with Origin {
 
             assert(thisUTB ne supertype)
             assert(
-                !isPrecise || !domain.isSubtypeOf(supertype, thisUTB),
+                !this.isPrecise || !domain.isSubtypeOf(supertype, thisUTB),
                 s"this type is precise ${thisUTB.toJava}; "+
                     s"refinement goal: ${supertype.toJava} "+
                     "(is this type a subtype of the given type: "+
@@ -876,7 +878,7 @@ trait ReferenceValues extends l0.DefaultTypeLevelReferenceValues with Origin {
             val adaptedValue = target match {
                 case thatDomain: l1.ReferenceValues =>
                     val thatT = thatDomain.nextRefId()
-                    thatDomain.ObjectValue(pc, isNull, isPrecise, theUpperTypeBound, thatT)
+                    thatDomain.ObjectValue(pc, this.isNull, this.isPrecise, theUpperTypeBound, thatT)
 
                 case thatDomain: l0.DefaultTypeLevelReferenceValues =>
                     thatDomain.ReferenceValue(pc, theUpperTypeBound)
@@ -907,8 +909,8 @@ trait ReferenceValues extends l0.DefaultTypeLevelReferenceValues with Origin {
 
         override def hashCode: Int = {
             ((theUpperTypeBound.hashCode * 41 +
-                (if (isPrecise) 11 else 101)) * 13 +
-                isNull.hashCode()) * 79 +
+                (if (this.isPrecise) 11 else 101)) * 13 +
+                this.isNull.hashCode()) * 79 +
                 origin
         }
 
@@ -926,7 +928,7 @@ trait ReferenceValues extends l0.DefaultTypeLevelReferenceValues with Origin {
          * know the precise type of the value.
          */
         override def isPrecise: Boolean = {
-            upperTypeBound.exists(classHierarchy.isKnownToBeFinal)
+            this.upperTypeBound.exists(classHierarchy.isKnownToBeFinal)
         }
 
         override def updateRefId(
@@ -934,14 +936,14 @@ trait ReferenceValues extends l0.DefaultTypeLevelReferenceValues with Origin {
             origin: ValueOrigin,
             isNull: Answer
         ): DomainObjectValue = {
-            ObjectValue(origin, isNull, upperTypeBound, refId)
+            ObjectValue(origin, isNull, this.upperTypeBound, refId)
         }
 
         def doRefineUpperTypeBound(supertype: ReferenceType): DomainSingleOriginReferenceValue = {
             if (supertype.isObjectType) {
                 val theSupertype = supertype.asObjectType
                 var newUTB: UIDSet[ObjectType] = UIDSet.empty
-                upperTypeBound foreach { (anUTB: ObjectType) =>
+                this.upperTypeBound foreach { (anUTB: ObjectType) =>
                     if (domain.isSubtypeOf(supertype, anUTB))
                         newUTB += theSupertype
                     else {
@@ -955,17 +957,17 @@ trait ReferenceValues extends l0.DefaultTypeLevelReferenceValues with Origin {
                     }
                 }
                 if (newUTB.isSingletonSet) {
-                    ObjectValue(origin, isNull, isPrecise = false, newUTB.head, refId)
+                    ObjectValue(origin, this.isNull, isPrecise = false, newUTB.head, refId)
                 } else {
-                    ObjectValue(origin, isNull, newUTB + theSupertype, refId)
+                    ObjectValue(origin, this.isNull, newUTB + theSupertype, refId)
                 }
             } else {
                 /* The supertype is an array type; this implies that this MObjectValue
                  * models the upper type bound "Serializable & Cloneable"; otherwise
                  * the refinement is illegal
                  */
-                assert(upperTypeBound == ObjectType.SerializableAndCloneable)
-                ArrayValue(origin, isNull, isPrecise = false, supertype.asArrayType, refId)
+                assert(this.upperTypeBound == ObjectType.SerializableAndCloneable)
+                ArrayValue(origin, this.isNull, isPrecise = false, supertype.asArrayType, refId)
             }
         }
 
@@ -997,7 +999,7 @@ trait ReferenceValues extends l0.DefaultTypeLevelReferenceValues with Origin {
         override def adapt(target: TargetDomain, origin: ValueOrigin): target.DomainValue =
             target match {
                 case td: ReferenceValues =>
-                    td.ObjectValue(origin, isNull, this.upperTypeBound, td.nextRefId()).
+                    td.ObjectValue(origin, this.isNull, this.upperTypeBound, td.nextRefId()).
                         asInstanceOf[target.DomainValue]
 
                 case td: l0.DefaultTypeLevelReferenceValues =>
@@ -1023,14 +1025,14 @@ trait ReferenceValues extends l0.DefaultTypeLevelReferenceValues with Origin {
         protected def canEqual(other: MObjectValue): Boolean = true
 
         override lazy val hashCode: Int = {
-            ((upperTypeBound.hashCode * 41 +
-                (if (isPrecise) 11 else 101)) * 13 +
-                isNull.hashCode()) * 79 +
+            ((this.upperTypeBound.hashCode * 41 +
+                (if (this.isPrecise) 11 else 101)) * 13 +
+                this.isNull.hashCode()) * 79 +
                 origin
         }
 
         override def toString: String = {
-            toString(upperTypeBound.map(_.toJava).mkString(" with "))
+            toString(this.upperTypeBound.map(_.toJava).mkString(" with "))
         }
     }
 

--- a/OPAL/ai/src/main/scala/org/opalj/ai/domain/l2/CalledMethodsStore.scala
+++ b/OPAL/ai/src/main/scala/org/opalj/ai/domain/l2/CalledMethodsStore.scala
@@ -49,7 +49,7 @@ trait CalledMethodsStore { rootStore =>
             val domain: rootStore.domain.type = rootStore.domain
             val frequentEvaluationWarningLevel = rootStore.frequentEvaluationWarningLevel
             val calledMethods = rootStore.calledMethods.updated(method, operands)
-            implicit val logContext = rootStore.logContext
+            implicit val logContext: LogContext = rootStore.logContext
         }
     }
 
@@ -121,7 +121,7 @@ object CalledMethodsStore {
             val domain: theDomain.type = theDomain
             val frequentEvaluationWarningLevel = theFrequentEvaluationWarningLevel
             val calledMethods = Map.empty[Method, List[Array[theDomain.DomainValue]]]
-            implicit val logContext = theLogContext
+            implicit val logContext: LogContext = theLogContext
         }
     }
 
@@ -139,7 +139,7 @@ object CalledMethodsStore {
             val domain: theDomain.type = theDomain
             val frequentEvaluationWarningLevel = theFrequentEvaluationWarningLevel
             val calledMethods = Map[Method, List[Array[theDomain.DomainValue]]]((method, List(operands)))
-            implicit val logContext = theLogContext
+            implicit val logContext: LogContext = theLogContext
         }
     }
 }

--- a/OPAL/ai/src/main/scala/org/opalj/ai/package.scala
+++ b/OPAL/ai/src/main/scala/org/opalj/ai/package.scala
@@ -2,6 +2,7 @@
 package org.opalj
 
 import scala.language.existentials
+import scala.reflect.ClassTag
 
 import scala.collection.AbstractIterator
 
@@ -526,7 +527,7 @@ package object ai {
         )
 
         import org.opalj.collection.mutable.Locals
-        implicit val domainValueTag = targetDomain.DomainValueTag
+        implicit val domainValueTag: ClassTag[targetDomain.DomainValue] = targetDomain.DomainValueTag
         val parameters = Locals[targetDomain.DomainValue](calledMethod.body.get.maxLocals)
         var localVariableIndex = 0
         var processedOperands = 0
@@ -566,7 +567,7 @@ package object ai {
         theOperands:  Operands[_ <: ValuesDomain#DomainValue],
         targetDomain: ValuesDomain with ValuesFactory
     ): Array[targetDomain.DomainValue] = {
-        // implicit val domainValueTag = targetDomain.DomainValueTag
+        //implicit val domainValueTag: ClassTag[targetDomain.DomainValue] = targetDomain.DomainValueTag
         import targetDomain.DomainValueTag
         val operandsCount = theOperands.size
         val adaptedOperands = new Array[targetDomain.DomainValue](operandsCount)

--- a/OPAL/ai/src/main/scala/org/opalj/ai/project/AIProject.scala
+++ b/OPAL/ai/src/main/scala/org/opalj/ai/project/AIProject.scala
@@ -75,7 +75,7 @@ trait AIProject[Source, D <: Domain with OptionalReport] {
      */
     def analyze(project: Project[Source], parameters: Seq[String]): ReportableAnalysisResult = {
 
-        val analyze: Method => Option[String] = { m: Method =>
+        val analyze: Method => Option[String] = { (m: Method) =>
             val theDomain = domain(project, m)
             ai(m, theDomain)
             theDomain.report

--- a/OPAL/ai/src/main/scala/org/opalj/issues/FieldValues.scala
+++ b/OPAL/ai/src/main/scala/org/opalj/issues/FieldValues.scala
@@ -4,12 +4,14 @@ package issues
 
 import scala.xml.Node
 import scala.xml.Group
+
 import play.api.libs.json.Json
 import play.api.libs.json.JsValue
 
 import org.opalj.br.ClassFile
 import org.opalj.br.Method
 import org.opalj.br.instructions.FieldReadAccess
+import org.opalj.br.Code
 import org.opalj.ai.AIResult
 import org.opalj.br.PCAndAnyRef
 
@@ -25,7 +27,7 @@ class FieldValues(
 
     final def classFile: ClassFile = method.classFile
 
-    private[this] implicit def code = result.code
+    private[this] implicit def code: Code = result.code
 
     private[this] def operandsArray = result.operandsArray
 

--- a/OPAL/ai/src/main/scala/org/opalj/issues/MethodReturnValues.scala
+++ b/OPAL/ai/src/main/scala/org/opalj/issues/MethodReturnValues.scala
@@ -4,12 +4,15 @@ package issues
 
 import scala.xml.Node
 import scala.xml.Group
+
 import play.api.libs.json.Json
 import play.api.libs.json.JsValue
+
 import org.opalj.br.Method
 import org.opalj.br.ClassFile
 import org.opalj.br.instructions.MethodInvocationInstruction
 import org.opalj.br.instructions.INVOKESTATIC
+import org.opalj.br.Code
 import org.opalj.ai.AIResult
 import org.opalj.br.PCAndAnyRef
 
@@ -20,7 +23,7 @@ class MethodReturnValues(
 
     final def classFile: ClassFile = method.classFile
 
-    private[this] implicit def code = result.code
+    private[this] implicit def code: Code = result.code
 
     private[this] def operandsArray = result.operandsArray
 

--- a/OPAL/ai/src/test/scala/org/opalj/ai/domain/MethodsPlainTest.scala
+++ b/OPAL/ai/src/test/scala/org/opalj/ai/domain/MethodsPlainTest.scala
@@ -1035,7 +1035,7 @@ class MethodsPlainTest extends AnyFlatSpec with Matchers {
     }
 
     it should "be able to return the correct type of an object if an object that is passed in is directly returned" in {
-        implicit val domain = new RecordingDomain;
+        implicit val domain: RecordingDomain = new RecordingDomain;
         import domain._
         val method = classFile.methods.find(_.name == "asIs").get
         val t = ObjectType("some/Foo")

--- a/OPAL/ai/src/test/scala/org/opalj/ai/domain/l2/PerformInvocationsWithRecursionDetectionTest.scala
+++ b/OPAL/ai/src/test/scala/org/opalj/ai/domain/l2/PerformInvocationsWithRecursionDetectionTest.scala
@@ -11,6 +11,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.junit.JUnitRunner
 
+import org.opalj.log.LogContext
 import org.opalj.br._
 import org.opalj.br.analyses.Project
 import org.opalj.br.TestSupport.biProject
@@ -148,7 +149,7 @@ object PerformInvocationsWithRecursionDetectionTestFixture {
                 )
 
             new CalledMethodsStore {
-                implicit val logContext = project.logContext
+                implicit val logContext: LogContext = project.logContext
                 val domain: coordinatingDomain.type = callingDomain.coordinatingDomain
                 val frequentEvaluationWarningLevel = callingDomain.frequentEvaluationWarningLevel
                 val calledMethods = Map((method, List(operands)))

--- a/OPAL/ba/src/main/scala/org/opalj/ba/package.scala
+++ b/OPAL/ba/src/main/scala/org/opalj/ba/package.scala
@@ -189,7 +189,7 @@ package object ba { ba =>
         implicit
         toDAConfig: ToDAConfig = ToDAConfig.RetainAllAttributes
     ): da.ClassFile = {
-        implicit val constantsBuffer = ConstantsBuffer(ConstantsBuffer.collectLDCs(classFile))
+        implicit val constantsBuffer: ConstantsBuffer = ConstantsBuffer(ConstantsBuffer.collectLDCs(classFile))
         val thisTypeCPRef = constantsBuffer.CPEClass(classFile.thisType, false)
         val superClassCPRef = classFile.superclassType match {
             case Some(superclassType) => constantsBuffer.CPEClass(superclassType, false)
@@ -602,7 +602,7 @@ package object ba { ba =>
 
             case br.ArrayValue.KindId =>
                 val br.ArrayValue(values) = elementValue
-                val daElementValues = values.map { ev: br.ElementValue => toDA(ev) }
+                val daElementValues = values.map { (ev: br.ElementValue) => toDA(ev) }
                 da.ArrayValue(daElementValues)
 
             case br.AnnotationValue.KindId =>

--- a/OPAL/ba/src/test/scala/org/opalj/ba/CodeAttributeBuilderTest.scala
+++ b/OPAL/ba/src/test/scala/org/opalj/ba/CodeAttributeBuilderTest.scala
@@ -33,7 +33,7 @@ class CodeAttributeBuilderTest extends AnyFlatSpec {
     behavior of "CodeAttributeBuilder when the code is invalid"
 
     "the CodeAttributeBuilder" should "warn about a too small max_locals/max_stack values" in {
-        implicit val ch = br.ClassHierarchy.PreInitializedClassHierarchy
+        implicit val classHierarchy: ClassHierarchy = br.ClassHierarchy.PreInitializedClassHierarchy
         val md = MethodDescriptor("(II)I")
         val code = (CODE(ILOAD_2, IRETURN) MAXSTACK 0 MAXLOCALS 0)
         val (_, (_, warnings)) = code(bi.Java5Version, FakeObjectType, ACC_PUBLIC.mask, "test", md)

--- a/OPAL/bc/src/main/scala/org/opalj/bc/MethodFilter.scala
+++ b/OPAL/bc/src/main/scala/org/opalj/bc/MethodFilter.scala
@@ -42,7 +42,7 @@ object MethodFilter {
         } else {
             classFiles.filter(_.thisType.asJVMType == className) foreach { cf =>
                 val filteredMethods = cf.methods.filter { m =>
-                    implicit val cp = cf.constant_pool
+                    implicit val cp: Constant_Pool = cf.constant_pool
                     val matches = m.name == methodName
                     if (keepMethod)
                         matches

--- a/OPAL/br/src/it/scala/org/opalj/br/CodePropertiesTest.scala
+++ b/OPAL/br/src/it/scala/org/opalj/br/CodePropertiesTest.scala
@@ -148,7 +148,7 @@ class CodePropertiesTest extends AnyFunSuite {
     }
 
     def doAnalyzeStackMapTablePCs(project: SomeProject): Int = {
-        implicit val ch = project.classHierarchy
+        implicit val classHierarchy: ClassHierarchy = project.classHierarchy
         val analyzedMethodsCount = new AtomicInteger(0)
         project.parForeachMethodWithBody(() => false) { mi =>
             if (mi.classFile.version.major > 49) {

--- a/OPAL/br/src/main/scala/org/opalj/br/ClassHierarchy.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/ClassHierarchy.scala
@@ -1327,8 +1327,8 @@ class ClassHierarchy private (
         if (subtypes.isEmpty /*the upper type bound of "null" values*/ || subtypes == supertypes)
             return true;
 
-        supertypes forall { supertype: ReferenceType =>
-            subtypes exists { subtype: ReferenceType =>
+        supertypes forall { (supertype: ReferenceType) =>
+            subtypes exists { (subtype: ReferenceType) =>
                 this.isSubtypeOf(subtype, supertype)
             }
         }
@@ -1342,14 +1342,14 @@ class ClassHierarchy private (
         if (supertypes.isEmpty /*the upper type bound of "null" values*/ )
             return false;
 
-        supertypes forall { supertype: ReferenceType => isSubtypeOf(subtype, supertype) }
+        supertypes forall { (supertype: ReferenceType) => isSubtypeOf(subtype, supertype) }
     }
 
     def isSubtypeOf(subtypes: UIDSet[_ <: ReferenceType], supertype: ReferenceType): Boolean = {
         if (subtypes.isEmpty) /*the upper type bound of "null" values*/
             return true;
 
-        subtypes exists { subtype: ReferenceType => this.isSubtypeOf(subtype, supertype) }
+        subtypes exists { (subtype: ReferenceType) => this.isSubtypeOf(subtype, supertype) }
     }
 
     /**
@@ -1566,10 +1566,10 @@ class ClassHierarchy private (
             return Yes;
 
         Answer(
-            supertypes forall { supertype: ReferenceType =>
+            supertypes forall { (supertype: ReferenceType) =>
                 var subtypingRelationUnknown = false
                 val subtypeExists =
-                    subtypes exists { subtype: ReferenceType =>
+                    subtypes exists { (subtype: ReferenceType) =>
                         val isSubtypeOf = this.isASubtypeOf(subtype, supertype)
                         isSubtypeOf match {
                             case Yes     => true
@@ -1595,7 +1595,7 @@ class ClassHierarchy private (
         if (supertypes.isEmpty /* <=> upper type bound of "null" values */ )
             return No;
 
-        supertypes foreach { supertype: ReferenceType =>
+        supertypes foreach { (supertype: ReferenceType) =>
             isASubtypeOf(subtype, supertype) match {
                 case Yes     => /*Nothing to do*/
                 case Unknown => return Unknown; // FIXME No should have precedence over Unknown even if some supertypes are Unknown...
@@ -1612,7 +1612,7 @@ class ClassHierarchy private (
 
         var subtypeRelationUnknown = false
         val subtypeExists =
-            subtypes exists { subtype: ReferenceType =>
+            subtypes exists { (subtype: ReferenceType) =>
                 this.isASubtypeOf(subtype, supertype) match {
                     case Yes     => true
                     case Unknown => { subtypeRelationUnknown = true; false /* continue search */ }
@@ -1663,7 +1663,7 @@ class ClassHierarchy private (
             val candidateType = typesToProcess.dequeue()
             processedTypes += candidateType
             val isCommonSubtype =
-                remainingTypeBounds.forall { otherTypeBound: ObjectType =>
+                remainingTypeBounds.forall { (otherTypeBound: ObjectType) =>
                     isASubtypeOf(candidateType, otherTypeBound).isYesOrUnknown
                 }
             if (isCommonSubtype) {
@@ -2130,7 +2130,7 @@ class ClassHierarchy private (
      */
     def allSupertypesOf(types: UIDSet[ObjectType], reflexive: Boolean): UIDSet[ObjectType] = {
         var allSupertypesOf: UIDSet[ObjectType] = UIDSet.empty
-        types foreach { t: ObjectType =>
+        types foreach { (t: ObjectType) =>
             if (!allSupertypesOf.contains(t)) {
                 if (isKnown(t))
                     allSupertypesOf ++= allSupertypes(t, reflexive)

--- a/OPAL/br/src/main/scala/org/opalj/br/Code.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/Code.scala
@@ -402,7 +402,7 @@ final class Code private (
      * If the code contains jsr/ret instructions, the full blown CFG is computed.
      */
     def predecessorPCs(implicit classHierarchy: ClassHierarchy): (Array[PCs], PCs, PCs) = {
-        implicit val code = this
+        implicit val code: Code = this
 
         val instructions = this.instructions
         val instructionsLength = instructions.length

--- a/OPAL/br/src/main/scala/org/opalj/br/Type.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/Type.scala
@@ -471,10 +471,7 @@ sealed trait BaseType extends FieldType with TypeSignature {
  */
 object BaseType {
 
-    implicit val BaseTypeOrdering =
-        new Ordering[BaseType] {
-            def compare(a: BaseType, b: BaseType): Int = a.compare(b)
-        }
+    implicit val BaseTypeOrdering: Ordering[BaseType] = (a: BaseType, b: BaseType) => a.compare(b)
 
     /**
      * The set of [BaseType]s sorted by the type's id.

--- a/OPAL/br/src/main/scala/org/opalj/br/analyses/JavaProject.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/analyses/JavaProject.scala
@@ -8,6 +8,7 @@ import scala.jdk.CollectionConverters._
 import org.opalj.log.ConsoleOPALLogger
 import org.opalj.log.Error
 import org.opalj.log.GlobalLogContext
+import org.opalj.log.LogContext
 import org.opalj.log.OPALLogger
 import org.opalj.log.StandardLogContext
 
@@ -26,7 +27,7 @@ class JavaProject( final val project: Project[java.net.URL]) {
      */
     def this(classPath: java.util.List[java.io.File]) =
         this({
-            implicit val logCtx = new StandardLogContext()
+            implicit val logCtx: LogContext = new StandardLogContext()
             OPALLogger.register(logCtx, JavaProject.Logger)
             val cp = classPath.asScala
             Project(

--- a/OPAL/br/src/main/scala/org/opalj/br/analyses/Project.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/analyses/Project.scala
@@ -1105,7 +1105,7 @@ object Project {
      */
     private[this] def validate(project: SomeProject): Seq[InconsistentProjectException] = {
 
-        implicit val logContext = project.logContext
+        implicit val logContext: LogContext = project.logContext
 
         val disclaimer = "(this inconsistency may lead to useless/wrong results)"
 
@@ -1545,7 +1545,7 @@ object Project {
         theLogContext: LogContext
     ): Map[Method, immutable.Set[Method]] = time {
 
-        implicit val classFileRepository = new ClassFileRepository {
+        implicit val classFileRepository: ClassFileRepository = new ClassFileRepository {
             override implicit def logContext: LogContext = theLogContext
             override def classFile(objectType: ObjectType): Option[ClassFile] = {
                 objectTypeToClassFile.get(objectType)
@@ -1868,7 +1868,7 @@ object Project {
         config:        Config     = BaseConfig,
         projectLogger: OPALLogger = OPALLogger.globalLogger()
     ): Project[Source] = {
-        implicit val logContext = new StandardLogContext()
+        implicit val logContext: LogContext = new StandardLogContext()
         OPALLogger.register(logContext, projectLogger)
         this(
             projectClassFilesWithSources,
@@ -1890,8 +1890,8 @@ object Project {
         config:                             Config,
         logContext:                         LogContext
     ): Project[Source] = time {
-        implicit val projectConfig = config
-        implicit val projectLogContext = logContext
+        implicit val projectConfig: Config = config
+        implicit val projectLogContext: LogContext = logContext
 
         try {
             import scala.collection.mutable.Set

--- a/OPAL/br/src/main/scala/org/opalj/br/analyses/StringConstantsInformationKey.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/analyses/StringConstantsInformationKey.scala
@@ -45,7 +45,7 @@ object StringConstantsInformationKey
         project.parForeachMethodWithBody(defaultIsInterrupted) { methodInfo =>
             val method = methodInfo.method
 
-            method.body.get foreach { i: PCAndInstruction =>
+            method.body.get foreach { (i: PCAndInstruction) =>
                 val pc = i.pc
                 val instruction = i.instruction
                 if (instruction.opcode == LDC.opcode || instruction.opcode == LDC_W.opcode) {

--- a/OPAL/br/src/main/scala/org/opalj/br/analyses/cg/EntryPointFinder.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/analyses/cg/EntryPointFinder.scala
@@ -5,8 +5,11 @@ package analyses
 package cg
 
 import scala.collection.mutable.ArrayBuffer
+
 import org.opalj.log.OPALLogger
 import net.ceedubs.ficus.Ficus._
+
+import org.opalj.log.LogContext
 
 /**
  * The EntryPointFinder trait is a common trait for all analyses that can derive an programs entry
@@ -177,7 +180,7 @@ trait ConfigurationEntryPointsFinder extends EntryPointFinder {
     override def collectEntryPoints(project: SomeProject): Iterable[Method] = {
         import net.ceedubs.ficus.readers.ArbitraryTypeReader._
 
-        implicit val logContext = project.logContext
+        implicit val logContext: LogContext = project.logContext
         var entryPoints = Set.empty[Method]
 
         if (!project.config.hasPath(additionalEPConfigKey)) {

--- a/OPAL/br/src/main/scala/org/opalj/br/analyses/cg/InstantiatedTypesFinder.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/analyses/cg/InstantiatedTypesFinder.scala
@@ -5,6 +5,8 @@ package analyses
 package cg
 
 import net.ceedubs.ficus.Ficus._
+
+import org.opalj.log.LogContext
 import org.opalj.log.OPALLogger
 
 /**
@@ -90,7 +92,7 @@ trait ConfigurationInstantiatedTypesFinder extends InstantiatedTypesFinder {
     }
 
     override def collectInstantiatedTypes(project: SomeProject): Iterable[ObjectType] = {
-        implicit val logContext = project.logContext
+        implicit val logContext: LogContext = project.logContext
         var instantiatedTypes = Set.empty[ObjectType]
 
         if (!project.config.hasPath(additionalInstantiatedTypesKey)) {

--- a/OPAL/br/src/main/scala/org/opalj/br/analyses/cg/TypeExtensibilityAnalysis.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/analyses/cg/TypeExtensibilityAnalysis.scala
@@ -88,7 +88,7 @@ class TypeExtensibilityAnalysis(val project: SomeProject) extends (ObjectType =>
     }
 
     private[this] val typeExtensibility: ArrayMap[Answer] = {
-        implicit val isClassExtensible = project.get(ClassExtensibilityKey)
+        implicit val isClassExtensible: ClassExtensibility = project.get(ClassExtensibilityKey)
 
         val leafTypes = classHierarchy.leafTypes
         val objectTypesCount = ObjectType.objectTypesCount

--- a/OPAL/br/src/main/scala/org/opalj/br/cp/ConstantsBuffer.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/cp/ConstantsBuffer.scala
@@ -376,7 +376,7 @@ object ConstantsBuffer {
 
         // 1. let's add the referenced CONSTANT_UTF8 entries required by LoadClass instructions
         var nextIndexAfterLDCRelatedEntries = 1 + ldcs.size
-        implicit val constantsBuffer = new ConstantsBuffer(nextIndexAfterLDCRelatedEntries, buffer)
+        implicit val constantsBuffer: ConstantsBuffer = new ConstantsBuffer(nextIndexAfterLDCRelatedEntries, buffer)
         import constantsBuffer._
         ldClasses foreach { ldc => CPEUtf8OfCPEClass(ldc.asInstanceOf[LoadClass].value) }
         nextIndexAfterLDCRelatedEntries = constantsBuffer.nextIndex

--- a/OPAL/br/src/main/scala/org/opalj/br/fpcf/analyses/MethodComplexityAnalysis.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/fpcf/analyses/MethodComplexityAnalysis.scala
@@ -18,10 +18,10 @@ import org.opalj.br.instructions._
 class MethodComplexityAnalysis(val maxComplexity: Int = Int.MaxValue) {
 
     def apply(method: Method): MethodComplexity = {
-        implicit val code = method.body.get
+        implicit val code: Code = method.body.get
         val instructions = code.instructions
 
-        var complexity = instructions.size;
+        var complexity = instructions.length;
         var hasLoop = false;
         var evaluatedPCs: Set[PC] = Set.empty
         var nextPCs: Set[PC] = Set(0);

--- a/OPAL/br/src/main/scala/org/opalj/br/fpcf/properties/pointsto/PointsToSetLike.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/fpcf/properties/pointsto/PointsToSetLike.scala
@@ -46,5 +46,5 @@ trait PointsToSetLike[ElementType, PointsToSet, T <: PointsToSetLike[ElementType
 }
 
 object PointsToSetLike {
-    val noFilter = { t: ReferenceType => true }
+    val noFilter = (t: ReferenceType) => true
 }

--- a/OPAL/br/src/main/scala/org/opalj/br/instructions/package.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/instructions/package.scala
@@ -9,240 +9,241 @@ package br
  */
 package object instructions {
 
-    implicit final val TypeConversionInstructions = new TypeConversionFactory[Array[Instruction]] {
+    implicit final val TypeConversionInstructions: TypeConversionFactory[Array[Instruction]] =
+        new TypeConversionFactory[Array[Instruction]] {
 
-        final val NoConversion: Array[Instruction] = Array.empty
+            final val NoConversion: Array[Instruction] = Array.empty
 
-        final val IntToByte: Array[Instruction] = Array(I2B)
-        final val IntToChar: Array[Instruction] = Array(I2C)
-        final val IntToDouble: Array[Instruction] = Array(I2D)
-        final val IntToFloat: Array[Instruction] = Array(I2F)
-        final val IntToLong: Array[Instruction] = Array(I2L)
-        final val IntToShort: Array[Instruction] = Array(I2S)
+            final val IntToByte: Array[Instruction] = Array(I2B)
+            final val IntToChar: Array[Instruction] = Array(I2C)
+            final val IntToDouble: Array[Instruction] = Array(I2D)
+            final val IntToFloat: Array[Instruction] = Array(I2F)
+            final val IntToLong: Array[Instruction] = Array(I2L)
+            final val IntToShort: Array[Instruction] = Array(I2S)
 
-        final val Double2Byte: Array[Instruction] = Array(D2I, I2B)
-        final val Double2Char: Array[Instruction] = Array(D2I, I2C)
-        final val Double2Short: Array[Instruction] = Array(D2I, I2S)
-        final val Double2Float: Array[Instruction] = Array(D2F)
-        final val Double2Integer: Array[Instruction] = Array(D2I)
-        final val Double2Long: Array[Instruction] = Array(D2L)
+            final val Double2Byte: Array[Instruction] = Array(D2I, I2B)
+            final val Double2Char: Array[Instruction] = Array(D2I, I2C)
+            final val Double2Short: Array[Instruction] = Array(D2I, I2S)
+            final val Double2Float: Array[Instruction] = Array(D2F)
+            final val Double2Integer: Array[Instruction] = Array(D2I)
+            final val Double2Long: Array[Instruction] = Array(D2L)
 
-        final val Float2Byte: Array[Instruction] = Array(F2I, I2B)
-        final val Float2Char: Array[Instruction] = Array(F2I, I2C)
-        final val Float2Short: Array[Instruction] = Array(F2I, I2S)
-        final val Float2Double: Array[Instruction] = Array(F2D)
-        final val Float2Integer: Array[Instruction] = Array(F2I)
-        final val Float2Long: Array[Instruction] = Array(F2L)
+            final val Float2Byte: Array[Instruction] = Array(F2I, I2B)
+            final val Float2Char: Array[Instruction] = Array(F2I, I2C)
+            final val Float2Short: Array[Instruction] = Array(F2I, I2S)
+            final val Float2Double: Array[Instruction] = Array(F2D)
+            final val Float2Integer: Array[Instruction] = Array(F2I)
+            final val Float2Long: Array[Instruction] = Array(F2L)
 
-        final val Long2Byte: Array[Instruction] = Array(L2I, I2B)
-        final val Long2Char: Array[Instruction] = Array(L2I, I2C)
-        final val Long2Short: Array[Instruction] = Array(L2I, I2S)
-        final val Long2Double: Array[Instruction] = Array(L2D)
-        final val Long2Float: Array[Instruction] = Array(L2F)
-        final val Long2Integer: Array[Instruction] = Array(L2I)
+            final val Long2Byte: Array[Instruction] = Array(L2I, I2B)
+            final val Long2Char: Array[Instruction] = Array(L2I, I2C)
+            final val Long2Short: Array[Instruction] = Array(L2I, I2S)
+            final val Long2Double: Array[Instruction] = Array(L2D)
+            final val Long2Float: Array[Instruction] = Array(L2F)
+            final val Long2Integer: Array[Instruction] = Array(L2I)
 
-        final lazy val LangBooleanToPrimitiveBoolean: Array[Instruction] =
-            Array(
-                INVOKEVIRTUAL(
-                    ObjectType.Boolean,
-                    "booleanValue",
-                    MethodDescriptor.JustReturnsBoolean
-                ),
-                null,
-                null
-            )
+            final lazy val LangBooleanToPrimitiveBoolean: Array[Instruction] =
+                Array(
+                    INVOKEVIRTUAL(
+                        ObjectType.Boolean,
+                        "booleanValue",
+                        MethodDescriptor.JustReturnsBoolean
+                    ),
+                    null,
+                    null
+                )
 
-        final lazy val PrimitiveBooleanToLangBoolean: Array[Instruction] =
-            Array(
-                INVOKESTATIC(
-                    ObjectType.Boolean,
-                    false,
-                    "valueOf",
-                    MethodDescriptor(BooleanType, ObjectType.Boolean)
-                ),
-                null,
-                null
-            )
+            final lazy val PrimitiveBooleanToLangBoolean: Array[Instruction] =
+                Array(
+                    INVOKESTATIC(
+                        ObjectType.Boolean,
+                        false,
+                        "valueOf",
+                        MethodDescriptor(BooleanType, ObjectType.Boolean)
+                    ),
+                    null,
+                    null
+                )
 
-        final lazy val LangLongToPrimitiveLong: Array[Instruction] =
-            Array(
-                INVOKEVIRTUAL(
-                    ObjectType.Long,
-                    "longValue",
-                    MethodDescriptor.JustReturnsLong
-                ),
-                null,
-                null
-            )
+            final lazy val LangLongToPrimitiveLong: Array[Instruction] =
+                Array(
+                    INVOKEVIRTUAL(
+                        ObjectType.Long,
+                        "longValue",
+                        MethodDescriptor.JustReturnsLong
+                    ),
+                    null,
+                    null
+                )
 
-        final lazy val PrimitiveLongToLangLong: Array[Instruction] =
-            Array(
-                INVOKESTATIC(
-                    ObjectType.Long,
-                    false,
-                    "valueOf",
-                    MethodDescriptor(LongType, ObjectType.Long)
-                ),
-                null,
-                null
-            )
+            final lazy val PrimitiveLongToLangLong: Array[Instruction] =
+                Array(
+                    INVOKESTATIC(
+                        ObjectType.Long,
+                        false,
+                        "valueOf",
+                        MethodDescriptor(LongType, ObjectType.Long)
+                    ),
+                    null,
+                    null
+                )
 
-        final lazy val LangByteToPrimitiveByte: Array[Instruction] =
-            Array(
-                INVOKEVIRTUAL(
-                    ObjectType.Byte,
-                    "byteValue",
-                    MethodDescriptor.JustReturnsByte
-                ),
-                null,
-                null
-            )
+            final lazy val LangByteToPrimitiveByte: Array[Instruction] =
+                Array(
+                    INVOKEVIRTUAL(
+                        ObjectType.Byte,
+                        "byteValue",
+                        MethodDescriptor.JustReturnsByte
+                    ),
+                    null,
+                    null
+                )
 
-        final lazy val PrimitiveByteToLangByte: Array[Instruction] =
-            Array(
-                INVOKESTATIC(
-                    ObjectType.Byte,
-                    false,
-                    "valueOf",
-                    MethodDescriptor(ByteType, ObjectType.Byte)
-                ),
-                null,
-                null
-            )
+            final lazy val PrimitiveByteToLangByte: Array[Instruction] =
+                Array(
+                    INVOKESTATIC(
+                        ObjectType.Byte,
+                        false,
+                        "valueOf",
+                        MethodDescriptor(ByteType, ObjectType.Byte)
+                    ),
+                    null,
+                    null
+                )
 
-        final lazy val LangIntegerToPrimitiveInt: Array[Instruction] =
-            Array(
-                INVOKEVIRTUAL(
-                    ObjectType.Integer,
-                    "intValue",
-                    MethodDescriptor.JustReturnsInteger
-                ),
-                null,
-                null
-            )
+            final lazy val LangIntegerToPrimitiveInt: Array[Instruction] =
+                Array(
+                    INVOKEVIRTUAL(
+                        ObjectType.Integer,
+                        "intValue",
+                        MethodDescriptor.JustReturnsInteger
+                    ),
+                    null,
+                    null
+                )
 
-        final lazy val PrimitiveIntToLangInteger: Array[Instruction] =
-            Array(
-                INVOKESTATIC(
-                    ObjectType.Integer,
-                    false,
-                    "valueOf",
-                    MethodDescriptor(IntegerType, ObjectType.Integer)
-                ),
-                null,
-                null
-            )
+            final lazy val PrimitiveIntToLangInteger: Array[Instruction] =
+                Array(
+                    INVOKESTATIC(
+                        ObjectType.Integer,
+                        false,
+                        "valueOf",
+                        MethodDescriptor(IntegerType, ObjectType.Integer)
+                    ),
+                    null,
+                    null
+                )
 
-        final lazy val LangShortToPrimitiveShort: Array[Instruction] =
-            Array(
-                INVOKEVIRTUAL(
-                    ObjectType.Short,
-                    "shortValue",
-                    MethodDescriptor.JustReturnsShort
-                ),
-                null,
-                null
-            )
+            final lazy val LangShortToPrimitiveShort: Array[Instruction] =
+                Array(
+                    INVOKEVIRTUAL(
+                        ObjectType.Short,
+                        "shortValue",
+                        MethodDescriptor.JustReturnsShort
+                    ),
+                    null,
+                    null
+                )
 
-        final lazy val PrimitiveShortToLangShort: Array[Instruction] =
-            Array(
-                INVOKESTATIC(
-                    ObjectType.Short,
-                    false,
-                    "valueOf",
-                    MethodDescriptor(ShortType, ObjectType.Short)
-                ),
-                null,
-                null
-            )
+            final lazy val PrimitiveShortToLangShort: Array[Instruction] =
+                Array(
+                    INVOKESTATIC(
+                        ObjectType.Short,
+                        false,
+                        "valueOf",
+                        MethodDescriptor(ShortType, ObjectType.Short)
+                    ),
+                    null,
+                    null
+                )
 
-        final lazy val LangFloatToPrimitiveFloat: Array[Instruction] =
-            Array(
-                INVOKEVIRTUAL(
-                    ObjectType.Float,
-                    "floatValue",
-                    MethodDescriptor.JustReturnsFloat
-                ),
-                null,
-                null
-            )
+            final lazy val LangFloatToPrimitiveFloat: Array[Instruction] =
+                Array(
+                    INVOKEVIRTUAL(
+                        ObjectType.Float,
+                        "floatValue",
+                        MethodDescriptor.JustReturnsFloat
+                    ),
+                    null,
+                    null
+                )
 
-        final lazy val PrimitiveFloatToLangFloat: Array[Instruction] =
-            Array(
-                INVOKESTATIC(
-                    ObjectType.Float,
-                    false,
-                    "valueOf",
-                    MethodDescriptor(FloatType, ObjectType.Float)
-                ),
-                null,
-                null
-            )
+            final lazy val PrimitiveFloatToLangFloat: Array[Instruction] =
+                Array(
+                    INVOKESTATIC(
+                        ObjectType.Float,
+                        false,
+                        "valueOf",
+                        MethodDescriptor(FloatType, ObjectType.Float)
+                    ),
+                    null,
+                    null
+                )
 
-        final lazy val LangCharacterToPrimitiveChar: Array[Instruction] =
-            Array(
-                INVOKEVIRTUAL(
-                    ObjectType.Character,
-                    "charValue",
-                    MethodDescriptor.JustReturnsChar
-                ),
-                null,
-                null
-            )
+            final lazy val LangCharacterToPrimitiveChar: Array[Instruction] =
+                Array(
+                    INVOKEVIRTUAL(
+                        ObjectType.Character,
+                        "charValue",
+                        MethodDescriptor.JustReturnsChar
+                    ),
+                    null,
+                    null
+                )
 
-        final lazy val PrimitiveCharToLangCharacter: Array[Instruction] =
-            Array(
-                INVOKESTATIC(
-                    ObjectType.Character,
-                    false,
-                    "valueOf",
-                    MethodDescriptor(CharType, ObjectType.Character)
-                ),
-                null,
-                null
-            )
+            final lazy val PrimitiveCharToLangCharacter: Array[Instruction] =
+                Array(
+                    INVOKESTATIC(
+                        ObjectType.Character,
+                        false,
+                        "valueOf",
+                        MethodDescriptor(CharType, ObjectType.Character)
+                    ),
+                    null,
+                    null
+                )
 
-        final lazy val LangDoubleToPrimitiveDouble: Array[Instruction] =
-            Array(
-                INVOKEVIRTUAL(
-                    ObjectType.Double,
-                    "doubleValue",
-                    MethodDescriptor.JustReturnsDouble
-                ),
-                null,
-                null
-            )
+            final lazy val LangDoubleToPrimitiveDouble: Array[Instruction] =
+                Array(
+                    INVOKEVIRTUAL(
+                        ObjectType.Double,
+                        "doubleValue",
+                        MethodDescriptor.JustReturnsDouble
+                    ),
+                    null,
+                    null
+                )
 
-        final lazy val PrimitiveDoubleToLangDouble: Array[Instruction] =
-            Array(
-                INVOKESTATIC(
-                    ObjectType.Double,
-                    false,
-                    "valueOf",
-                    MethodDescriptor(DoubleType, ObjectType.Double)
-                ),
-                null,
-                null
-            )
+            final lazy val PrimitiveDoubleToLangDouble: Array[Instruction] =
+                Array(
+                    INVOKESTATIC(
+                        ObjectType.Double,
+                        false,
+                        "valueOf",
+                        MethodDescriptor(DoubleType, ObjectType.Double)
+                    ),
+                    null,
+                    null
+                )
 
-        private[this] lazy val unboxInstructions: Array[Array[Instruction]] = {
-            val a = new Array[Array[Instruction]](ObjectType.Double.id + 1)
-            a(ObjectType.Boolean.id) = LangBooleanToPrimitiveBoolean
-            a(ObjectType.Byte.id) = LangByteToPrimitiveByte
-            a(ObjectType.Character.id) = LangCharacterToPrimitiveChar
-            a(ObjectType.Short.id) = LangShortToPrimitiveShort
-            a(ObjectType.Integer.id) = LangIntegerToPrimitiveInt
-            a(ObjectType.Long.id) = LangLongToPrimitiveLong
-            a(ObjectType.Float.id) = LangFloatToPrimitiveFloat
-            a(ObjectType.Double.id) = LangDoubleToPrimitiveDouble
-            a
+            private[this] lazy val unboxInstructions: Array[Array[Instruction]] = {
+                val a = new Array[Array[Instruction]](ObjectType.Double.id + 1)
+                a(ObjectType.Boolean.id) = LangBooleanToPrimitiveBoolean
+                a(ObjectType.Byte.id) = LangByteToPrimitiveByte
+                a(ObjectType.Character.id) = LangCharacterToPrimitiveChar
+                a(ObjectType.Short.id) = LangShortToPrimitiveShort
+                a(ObjectType.Integer.id) = LangIntegerToPrimitiveInt
+                a(ObjectType.Long.id) = LangLongToPrimitiveLong
+                a(ObjectType.Float.id) = LangFloatToPrimitiveFloat
+                a(ObjectType.Double.id) = LangDoubleToPrimitiveDouble
+                a
+            }
+
+            def unboxValue(wrapperType: Type): Array[Instruction] = {
+                val wid = wrapperType.id
+                assert(wid >= ObjectType.Boolean.id && wid <= ObjectType.Double.id)
+
+                unboxInstructions(wid)
+            }
         }
-
-        def unboxValue(wrapperType: Type): Array[Instruction] = {
-            val wid = wrapperType.id
-            assert(wid >= ObjectType.Boolean.id && wid <= ObjectType.Double.id)
-
-            unboxInstructions(wid)
-        }
-    }
 }

--- a/OPAL/br/src/main/scala/org/opalj/br/package.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/package.scala
@@ -158,7 +158,7 @@ package object br {
         after:       String      = ""
     ): String = {
 
-        val annotationToJava: Annotation => String = { annotation: Annotation =>
+        val annotationToJava: Annotation => String = { (annotation: Annotation) =>
             val s = annotation.toJava
             if (s.length() > 50 && annotation.elementValuePairs.nonEmpty)
                 annotation.annotationType.toJava+"(...)"

--- a/OPAL/br/src/main/scala/org/opalj/br/reader/BootstrapMethods_attributeBinding.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/reader/BootstrapMethods_attributeBinding.scala
@@ -20,10 +20,10 @@ trait BootstrapMethods_attributeBinding
     type BootstrapMethods_attribute = BootstrapMethodTable
 
     type BootstrapMethod = br.BootstrapMethod
-    override implicit val bootstrapMethodType = ClassTag(classOf[br.BootstrapMethod])
+    override implicit val bootstrapMethodType: ClassTag[BootstrapMethod] = ClassTag(classOf[br.BootstrapMethod])
 
     type BootstrapArgument = br.BootstrapArgument
-    override implicit val bootstrapArgumentType = ClassTag(classOf[br.BootstrapArgument])
+    override implicit val bootstrapArgumentType: ClassTag[BootstrapArgument] = ClassTag(classOf[br.BootstrapArgument])
 
     def BootstrapMethods_attribute(
         cp:                  Constant_Pool,

--- a/OPAL/br/src/main/scala/org/opalj/br/reader/ConstantPoolBinding.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/reader/ConstantPoolBinding.scala
@@ -33,7 +33,8 @@ trait ConstantPoolBinding extends Constant_PoolReader {
     }
 
     type Constant_Pool_Entry = cp.Constant_Pool_Entry
-    override implicit val constantPoolEntryType = ClassTag[cp.Constant_Pool_Entry](classOf[cp.Constant_Pool_Entry])
+    override implicit val constantPoolEntryType: ClassTag[Constant_Pool_Entry] =
+        ClassTag[cp.Constant_Pool_Entry](classOf[cp.Constant_Pool_Entry])
 
     type CONSTANT_Class_info = cp.CONSTANT_Class_info
     type CONSTANT_Double_info = cp.CONSTANT_Double_info

--- a/OPAL/br/src/main/scala/org/opalj/br/reader/LocalVariableTable_attributeBinding.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/reader/LocalVariableTable_attributeBinding.scala
@@ -19,7 +19,8 @@ trait LocalVariableTable_attributeBinding
 
     type LocalVariableTable_attribute = br.LocalVariableTable
     type LocalVariableTableEntry = br.LocalVariable
-    override implicit val localVariableTableEntryType: ClassTag[LocalVariableTableEntry] = ClassTag(classOf[br.LocalVariable])
+    override implicit val localVariableTableEntryType: ClassTag[LocalVariableTableEntry] =
+        ClassTag(classOf[br.LocalVariable])
 
     override def LocalVariableTableEntry(
         cp:               Constant_Pool,

--- a/OPAL/br/src/main/scala/org/opalj/br/reader/LocalVariableTypeTable_attributeBinding.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/reader/LocalVariableTypeTable_attributeBinding.scala
@@ -20,7 +20,8 @@ trait LocalVariableTypeTable_attributeBinding
     type LocalVariableTypeTable_attribute = br.LocalVariableTypeTable
 
     type LocalVariableTypeTableEntry = br.LocalVariableType
-    override implicit val localVariableTypeTableEntryType = ClassTag(classOf[br.LocalVariableType])
+    override implicit val localVariableTypeTableEntryType: ClassTag[LocalVariableType] =
+        ClassTag(classOf[br.LocalVariableType])
 
     def LocalVariableTypeTableEntry(
         cp:              Constant_Pool,

--- a/OPAL/br/src/test/scala/org/opalj/br/analyses/ClassHierarchyTest.scala
+++ b/OPAL/br/src/test/scala/org/opalj/br/analyses/ClassHierarchyTest.scala
@@ -3,6 +3,8 @@ package org.opalj
 package br
 package analyses
 
+import java.net.URL
+
 import org.junit.runner.RunWith
 import org.scalatestplus.junit.JUnitRunner
 import org.scalatest.flatspec.AnyFlatSpec
@@ -589,7 +591,7 @@ class ClassHierarchyTest extends AnyFlatSpec with Matchers {
     behavior of "isASubtypeOf method w.r.t. concrete generics"
 
     it should "return YES iff the type arguments do match considering variance indicators and wildcards" in {
-        implicit val genericProject = ClassHierarchyTest.genericProject
+        implicit val genericProject: Project[URL] = ClassHierarchyTest.genericProject
         import genericProject.classHierarchy.isASubtypeOf
         isASubtypeOf(baseContainer, baseContainer) should be(Yes)
         isASubtypeOf(baseContainer, wildCardContainer) should be(Yes)
@@ -604,7 +606,7 @@ class ClassHierarchyTest extends AnyFlatSpec with Matchers {
     }
 
     it should "return NO if the type arguments doesn't match considering variance indicators and wildcards" in {
-        implicit val genericProject = ClassHierarchyTest.genericProject
+        implicit val genericProject: Project[URL] = ClassHierarchyTest.genericProject
         import genericProject.classHierarchy.isASubtypeOf
         isASubtypeOf(baseContainer, extBaseContainer) should be(No)
         isASubtypeOf(concreteSubGeneric, altContainer) should be(No)
@@ -621,7 +623,7 @@ class ClassHierarchyTest extends AnyFlatSpec with Matchers {
     behavior of "isASubtypeOf method w.r.t. generics with interface types"
 
     it should "return YES iff the subtype directly implements the interface with matching type arguments" in {
-        implicit val genericProject = ClassHierarchyTest.genericProject
+        implicit val genericProject: Project[URL] = ClassHierarchyTest.genericProject
         import genericProject.classHierarchy.isASubtypeOf
         isASubtypeOf(concreteInterfaceWithBase, iContainerWithBase) should be(Yes)
         isASubtypeOf(IBaseContainerWithBase, iContainerWithBase) should be(Yes)
@@ -629,7 +631,7 @@ class ClassHierarchyTest extends AnyFlatSpec with Matchers {
     }
 
     it should "return NO if the subtype doesn't directly implement the interface with matching type arguments" in {
-        implicit val genericProject = ClassHierarchyTest.genericProject
+        implicit val genericProject: Project[URL] = ClassHierarchyTest.genericProject
         import genericProject.classHierarchy.isASubtypeOf
         isASubtypeOf(IBaseContainerWithAltBase, iContainerWithBase) should be(No)
         isASubtypeOf(concreteInterfaceWithAltBase, IBaseContainerWithBase) should be(No)
@@ -637,7 +639,7 @@ class ClassHierarchyTest extends AnyFlatSpec with Matchers {
     }
 
     it should "return YES iff the subtype implements the given interface with matching type arguments through some supertype" in {
-        implicit val genericProject = ClassHierarchyTest.genericProject
+        implicit val genericProject: Project[URL] = ClassHierarchyTest.genericProject
         import genericProject.classHierarchy.isASubtypeOf
         isASubtypeOf(subClassWithInterface, iContainerWithAltBase) should be(Yes)
         isASubtypeOf(subClassWithInterface, concreteSubGeneric) should be(Yes)
@@ -645,13 +647,13 @@ class ClassHierarchyTest extends AnyFlatSpec with Matchers {
     }
 
     it should "return NO if the subtype doesn't implement the given interface with matching type arguments through some supertype" in {
-        implicit val genericProject = ClassHierarchyTest.genericProject
+        implicit val genericProject: Project[URL] = ClassHierarchyTest.genericProject
         import genericProject.classHierarchy.isASubtypeOf
         isASubtypeOf(subClassWithInterface, iContainerWithBase) should be(No)
     }
 
     it should "return UNKNOWN if one of the arguments is an unknown type" in {
-        implicit val genericProject = ClassHierarchyTest.genericProject
+        implicit val genericProject: Project[URL] = ClassHierarchyTest.genericProject
         import genericProject.classHierarchy.isASubtypeOf
         isASubtypeOf(unknownContainer, baseContainer) should be(Unknown)
     }
@@ -659,7 +661,7 @@ class ClassHierarchyTest extends AnyFlatSpec with Matchers {
     behavior of "isASubtypeOf method w.r.t. generics with nested types"
 
     it should "return YES iff if nested type arguments of the supertype and the subtype do match" in {
-        implicit val genericProject = ClassHierarchyTest.genericProject
+        implicit val genericProject: Project[URL] = ClassHierarchyTest.genericProject
         import genericProject.classHierarchy.isASubtypeOf
         isASubtypeOf(nestedInnerCovariantContainer, nestedInnerCovariantContainer) should be(Yes)
         isASubtypeOf(nestedExtBase, nestedInnerCovariantContainer) should be(Yes)
@@ -669,7 +671,7 @@ class ClassHierarchyTest extends AnyFlatSpec with Matchers {
     }
 
     it should "return NO if nested type arguments of the subtype and the supertype doesn't match" in {
-        implicit val genericProject = ClassHierarchyTest.genericProject
+        implicit val genericProject: Project[URL] = ClassHierarchyTest.genericProject
         import genericProject.classHierarchy.isASubtypeOf
         isASubtypeOf(nestedBase, nestedAltBase) should be(No)
         isASubtypeOf(nestedAltBase, nestedInnerCovariantContainer) should be(No)
@@ -680,7 +682,7 @@ class ClassHierarchyTest extends AnyFlatSpec with Matchers {
     behavior of "isASubtypeOf method w.r.t. generics with class suffix (e.g. by inner classes)"
 
     it should "return YES iff the class suffixes of a ClassTypeSignature of inner classes also match when considering generic type arguments" in {
-        implicit val genericProject = ClassHierarchyTest.genericProject
+        implicit val genericProject: Project[URL] = ClassHierarchyTest.genericProject
         import genericProject.classHierarchy.isASubtypeOf
 
         isASubtypeOf(genericWithSuffix_Suffix1_7, baseCTS) should be(Yes)
@@ -695,7 +697,7 @@ class ClassHierarchyTest extends AnyFlatSpec with Matchers {
     }
 
     it should "return NO if the class suffixes of a ClassTypeSignature of inner classes doesn't match when considering generic type arguments " in {
-        implicit val genericProject = ClassHierarchyTest.genericProject
+        implicit val genericProject: Project[URL] = ClassHierarchyTest.genericProject
         import genericProject.classHierarchy.isASubtypeOf
         isASubtypeOf(genericWithSuffix_publicSuffix1_1, genericWithSuffix_publicSuffix1_1_altBase) should be(No)
         isASubtypeOf(genericWithSuffix_altBase_publicSuffix1_1, genericWithSuffix_publicSuffix1_1) should be(No)
@@ -715,7 +717,7 @@ class ClassHierarchyTest extends AnyFlatSpec with Matchers {
     behavior of "isASubtypeOf method w.r.t. generics specified by formal type parameters"
 
     it should "return YES iff the subtype extends the class and implements all declared interfaces of the FormalTypeParameter" in {
-        implicit val genericProject = ClassHierarchyTest.genericProject
+        implicit val genericProject: Project[URL] = ClassHierarchyTest.genericProject
         import genericProject.classHierarchy.isASubtypeOf
         isASubtypeOf(extBaseCTS, FormalTypeParameter("X", Some(baseCTS), Nil)) should be(Yes)
         isASubtypeOf(subClassWithInterface, FormalTypeParameter("T", Some(concreteSubGeneric), List(iContainerWithAltBase))) should be(Yes)
@@ -724,7 +726,7 @@ class ClassHierarchyTest extends AnyFlatSpec with Matchers {
     }
 
     it should "return NO if the subtype doesn't extends the class and implements all declared interfaces of the FormalTypeParameter" in {
-        implicit val genericProject = ClassHierarchyTest.genericProject
+        implicit val genericProject: Project[URL] = ClassHierarchyTest.genericProject
         import genericProject.classHierarchy.isASubtypeOf
         isASubtypeOf(altBaseCTS, FormalTypeParameter("X", Some(baseCTS), Nil)) should be(No)
         isASubtypeOf(subClassWithInterface, FormalTypeParameter("T", Some(concreteSubGeneric), List(iContainerWithAltBase, altInterfaceCTS))) should be(No)
@@ -732,7 +734,7 @@ class ClassHierarchyTest extends AnyFlatSpec with Matchers {
     }
 
     it should "return UNKNOWN if an unknown type is encountered" in {
-        implicit val genericProject = ClassHierarchyTest.genericProject
+        implicit val genericProject: Project[URL] = ClassHierarchyTest.genericProject
         import genericProject.classHierarchy.isASubtypeOf
         isASubtypeOf(unknownContainer, FormalTypeParameter("X", Some(baseCTS), Nil)) should be(Unknown)
     }

--- a/OPAL/br/src/test/scala/org/opalj/br/analyses/JoinObjectTypesTest.scala
+++ b/OPAL/br/src/test/scala/org/opalj/br/analyses/JoinObjectTypesTest.scala
@@ -31,8 +31,8 @@ class JoinObjectTypesTest extends AnyFunSpec with Matchers {
         )(GlobalLogContext)
     }
 
-    implicit def stringToUIDSetObjectType(str: String) = UIDSet(ObjectType(str))
-    implicit def stringToObjectType(str: String) = ObjectType(str)
+    implicit def stringToUIDSetObjectType(str: String): UIDSet[ObjectType] = UIDSet(ObjectType(str))
+    implicit def stringToObjectType(str: String): ObjectType = ObjectType(str)
     implicit def setToUIDSet(s: Set[String]): UIDSet[ObjectType] = {
         UIDSet.empty[ObjectType] ++ s.map(ObjectType.apply)
     }

--- a/OPAL/br/src/test/scala/org/opalj/br/analyses/JoinUpperBoundsTest.scala
+++ b/OPAL/br/src/test/scala/org/opalj/br/analyses/JoinUpperBoundsTest.scala
@@ -23,7 +23,7 @@ class JoinUpperBoundsTest extends AnyFunSpec with Matchers {
             List(() => this.getClass.getResourceAsStream("ClassHierarchyUpperBounds.ths"))
         )(GlobalLogContext)
 
-    implicit def stringToUIDSetObjectType(str: String) = UIDSet(ObjectType(str))
+    implicit def stringToUIDSetObjectType(str: String): UIDSet[ObjectType] = UIDSet(ObjectType(str))
 
     implicit def setToUIDSet(s: Set[String]): UIDSet[ObjectType] = {
         UIDSet.fromSpecific(s.map(ObjectType.apply))

--- a/OPAL/br/src/test/scala/org/opalj/br/cfg/CFGTest.scala
+++ b/OPAL/br/src/test/scala/org/opalj/br/cfg/CFGTest.scala
@@ -26,7 +26,7 @@ class CFGTest extends AbstractCFGTest {
         val testProject: Project[URL] = biProject("controlflow.jar")
         val testClassFile = testProject.classFile(ObjectType("controlflow/BoringCode")).get
 
-        implicit val testClassHierarchy = testProject.classHierarchy
+        implicit val testClassHierarchy: ClassHierarchy = testProject.classHierarchy
 
         it("the cfg of a method with no control flow statements should have one BasicBlock node") {
             val m = testClassFile.findMethod("singleBlock").head

--- a/OPAL/common/src/main/scala/org/opalj/collection/immutable/LongTrieSet.scala
+++ b/OPAL/common/src/main/scala/org/opalj/collection/immutable/LongTrieSet.scala
@@ -458,7 +458,9 @@ private[immutable] final class LongTrieSetN(
     override def iterator: LongIterator = new LongIterator {
         private[this] var leafNode: LongTrieSetLeaf = null
         private[this] var index = 0
-        private[this] val nodes = new scala.collection.mutable.Stack(initialSize = Math.min(16, size / 2)) += root
+        private[this] val nodes =
+            new scala.collection.mutable.Stack(initialSize = Math.min(16, LongTrieSetN.this.size / 2)) += root
+
         @tailrec private[this] def moveToNextLeafNode(): Unit = {
             if (nodes.isEmpty) {
                 leafNode = null

--- a/OPAL/common/src/main/scala/org/opalj/graphs/DominatorTree.scala
+++ b/OPAL/common/src/main/scala/org/opalj/graphs/DominatorTree.scala
@@ -242,7 +242,7 @@ object DominatorTree {
             val w = vertex(i)
 
             // Step 2
-            foreachPredecessorOf(w) { v: Int =>
+            foreachPredecessorOf(w) { (v: Int) =>
                 val u = eval(v)
                 val uSemi = semi(u)
                 if (uSemi < semi(w)) {

--- a/OPAL/common/src/main/scala/org/opalj/util/Milliseconds.scala
+++ b/OPAL/common/src/main/scala/org/opalj/util/Milliseconds.scala
@@ -48,9 +48,8 @@ class Milliseconds(val timeSpan: Long) extends AnyVal with Serializable {
  */
 object Milliseconds {
 
-    implicit val millisecondsWrites = new Writes[Milliseconds] {
-        def writes(millisecond: Milliseconds) = JsNumber(millisecond.timeSpan)
-    }
+    implicit val millisecondsWrites: Writes[Milliseconds] =
+        (millisecond: Milliseconds) => JsNumber(millisecond.timeSpan)
 
     implicit val nanosecondsReads: Reads[Milliseconds] = JsPath.read[Long].map(Milliseconds.apply)
 

--- a/OPAL/common/src/main/scala/org/opalj/util/Nanoseconds.scala
+++ b/OPAL/common/src/main/scala/org/opalj/util/Nanoseconds.scala
@@ -48,9 +48,8 @@ class Nanoseconds(val timeSpan: Long) extends AnyVal with Serializable {
  * @author Michael Eichberg
  */
 object Nanoseconds {
-    implicit val nanosecondsWrites = new Writes[Nanoseconds] {
-        def writes(nanosecond: Nanoseconds) = JsNumber(nanosecond.timeSpan)
-    }
+    implicit val nanosecondsWrites: Writes[Nanoseconds] =
+        (nanosecond: Nanoseconds) => JsNumber(nanosecond.timeSpan)
 
     implicit val nanosecondsReads: Reads[Nanoseconds] = JsPath.read[Long].map(Nanoseconds.apply)
 

--- a/OPAL/common/src/main/scala/org/opalj/util/PerformanceEvaluation.scala
+++ b/OPAL/common/src/main/scala/org/opalj/util/PerformanceEvaluation.scala
@@ -116,7 +116,7 @@ object GlobalPerformanceEvaluation extends PerformanceEvaluation
  * {{{
  * import org.opalj.util.PerformanceEvaluation.{memory,time}
  * var store : Array[Object] = null
- * implicit val logContext = Some(org.opalj.log.GlobalLogContext)
+ * implicit val logContext: Option[LogContext] = Some(org.opalj.log.GlobalLogContext)
  * for(i <- 1 to 5){
  *   memory{store = null}(l => println("empty: "+l))
  *   memory{
@@ -210,7 +210,7 @@ object PerformanceEvaluation {
      * {{{
      * import org.opalj.util.PerformanceEvaluation.{gc,memory,time,avg}
      * var store : Array[Object] = null
-     * implicit val logContext = Some(org.opalj.log.GlobalLogContext)
+     * implicit val logContext: Option[LogContext] = Some(org.opalj.log.GlobalLogContext)
      * time{
      *   for(i <- 1 to 5){
      *     memory{store = null}(l => println("empty: "+l))

--- a/OPAL/common/src/main/scala/org/opalj/util/Seconds.scala
+++ b/OPAL/common/src/main/scala/org/opalj/util/Seconds.scala
@@ -46,9 +46,7 @@ class Seconds(val timeSpan: Double) extends AnyVal with Serializable {
  */
 object Seconds {
 
-    implicit val secondsWrites = new Writes[Seconds] {
-        def writes(second: Seconds) = JsNumber(second.timeSpan)
-    }
+    implicit val secondsWrites: Writes[Seconds] = (second: Seconds) => JsNumber(second.timeSpan)
 
     implicit val secondsReads: Reads[Seconds] = JsPath.read[Double].map(Seconds.apply)
 

--- a/OPAL/common/src/test/scala/org/opalj/collection/IntIteratorProperties.scala
+++ b/OPAL/common/src/test/scala/org/opalj/collection/IntIteratorProperties.scala
@@ -48,15 +48,15 @@ object IntIteratorProperties extends Properties("IntIterator") {
         }
     }
 
-    property("foldLeft") = forAll { is: IntArraySet =>
+    property("foldLeft") = forAll { (is: IntArraySet) =>
         is.iterator.foldLeft(0)(_ + _) == is.iterator.foldLeft(0)(_ + _)
     }
 
-    property("map") = forAll { is: IntArraySet =>
+    property("map") = forAll { (is: IntArraySet) =>
         is.iterator.map(_ + 1).toList == is.map(_ + 1).toList
     }
 
-    property("foreach") = forAll { is: IntArraySet =>
+    property("foreach") = forAll { (is: IntArraySet) =>
         var c: List[Int] = List.empty
         is.iterator.foreach { i => c = i :: c }
         c.reverse == is.toList
@@ -71,7 +71,7 @@ object IntIteratorProperties extends Properties("IntIterator") {
         is.iterator.withFilter(values.contains).toList == is.withFilter(values.contains).toList
     }
 
-    property("map[AnyRef]") = forAll { is: IntArraySet =>
+    property("map[AnyRef]") = forAll { (is: IntArraySet) =>
         val setBased =
             for {
                 i <- is.toArray
@@ -93,7 +93,7 @@ object IntIteratorProperties extends Properties("IntIterator") {
         setBased.toSet == iteratorBased.toSet
     }
 
-    property("flatMap[AnyRef]") = forAll { is: IntArraySet =>
+    property("flatMap[AnyRef]") = forAll { (is: IntArraySet) =>
         val setBased =
             for {
                 i <- is.toArray
@@ -113,17 +113,17 @@ object IntIteratorProperties extends Properties("IntIterator") {
         setBased.toSet == iteratorBased.toSet
     }
 
-    property("toArray") = forAll { is: IntArraySet =>
+    property("toArray") = forAll { (is: IntArraySet) =>
         val itArray = is.iterator.toArray
         val isArray = is.toList.toArray
         JArrays.equals(itArray, isArray) :| isArray.mkString(",")+" vs. "+itArray.mkString(",")
     }
 
-    property("toChain") = forAll { is: IntArraySet =>
+    property("toChain") = forAll { (is: IntArraySet) =>
         is.iterator.toList == is.toList
     }
 
-    property("mkString") = forAll { is: IntArraySet =>
+    property("mkString") = forAll { (is: IntArraySet) =>
         is.iterator.mkString("-", ";", "-!") == is.iterator.mkString("-", ";", "-!")
     }
 

--- a/OPAL/common/src/test/scala/org/opalj/collection/immutable/BitArraySetProperties.scala
+++ b/OPAL/common/src/test/scala/org/opalj/collection/immutable/BitArraySetProperties.scala
@@ -55,7 +55,7 @@ object BitArraySetProperties extends Properties("BitArraySetProperties") {
     ////////////////////////////////////////////////////////////////////////////////////////////////
     //                             P R O P E R T I E S
 
-    property("<BitArraySet>.+|iterator(.forall)|contains") = forAll { s: IntArraySet =>
+    property("<BitArraySet>.+|iterator(.forall)|contains") = forAll { (s: IntArraySet) =>
         val bas = s.foldLeft(BitArraySet.empty)(_ + _)
         classify(s.isEmpty, "empty set") {
             classify(s.nonEmpty && s.max < 32, "set with max value < 32") {
@@ -68,7 +68,7 @@ object BitArraySetProperties extends Properties("BitArraySetProperties") {
         }
     }
 
-    property("BitArraySet.apply(value)") = forAll { s: IntArraySet =>
+    property("BitArraySet.apply(value)") = forAll { (s: IntArraySet) =>
         s.nonEmpty ==> {
             val sIt = s.iterator
             val firstI = sIt.next()
@@ -82,9 +82,10 @@ object BitArraySetProperties extends Properties("BitArraySetProperties") {
         }
     }
 
-    property("the same set is returned if a value in the set should be added") = forAll { s: IntArraySet =>
-        val bas = s.foldLeft(BitArraySet.empty)(_ + _)
-        s.forall(v => (bas + v) eq bas)
+    property("the same set is returned if a value in the set should be added") = forAll {
+        (s: IntArraySet) =>
+            val bas = s.foldLeft(BitArraySet.empty)(_ + _)
+            s.forall(v => (bas + v) eq bas)
     }
 
     property("<BitArraySet>.++(|)") = forAll { (s1: SBitSet, s2: SBitSet) =>
@@ -103,24 +104,26 @@ object BitArraySetProperties extends Properties("BitArraySetProperties") {
         }
     }
 
-    property("adding a subset of this set to this set should return this set") = forAll { s: IntArraySet =>
-        val bas1 = s.foldLeft(BitArraySet.empty)(_ + _)
-        val bas2 = s.foldLeft(BitArraySet.empty)(_ + _)
-        (bas1 ++ bas2) eq bas1
+    property("adding a subset of this set to this set should return this set") = forAll {
+        (s: IntArraySet) =>
+            val bas1 = s.foldLeft(BitArraySet.empty)(_ + _)
+            val bas2 = s.foldLeft(BitArraySet.empty)(_ + _)
+            (bas1 ++ bas2) eq bas1
     }
 
-    property("adding this set to another set of which this set is a subset of should return the other set") = forAll { (s1: IntArraySet, s2: IntArraySet) =>
-        val sMerged = s1 ++ s2
-        val bas1 = s1.foldLeft(BitArraySet.empty)(_ + _)
-        val bas2 = s2.foldLeft(BitArraySet.empty)(_ + _)
-        val basMerged = bas1 ++ bas2
-        val basRemerged = (bas1 ++ basMerged /*use that...*/ )
-        basMerged.iterator.forall(sMerged.contains) :| "all values in the bit array set were added" &&
-            sMerged.iterator.forall(basMerged.contains) :| "the bit array set does not contain all values" &&
-            (basRemerged eq basMerged) :| "same instance"
+    property("adding this set to another set of which this set is a subset of should return the other set") = forAll {
+        (s1: IntArraySet, s2: IntArraySet) =>
+            val sMerged = s1 ++ s2
+            val bas1 = s1.foldLeft(BitArraySet.empty)(_ + _)
+            val bas2 = s2.foldLeft(BitArraySet.empty)(_ + _)
+            val basMerged = bas1 ++ bas2
+            val basRemerged = (bas1 ++ basMerged /*use that...*/ )
+            basMerged.iterator.forall(sMerged.contains) :| "all values in the bit array set were added" &&
+                sMerged.iterator.forall(basMerged.contains) :| "the bit array set does not contain all values" &&
+                (basRemerged eq basMerged) :| "same instance"
     }
 
-    property("iterator") = forAll { s: IntArraySet =>
+    property("iterator") = forAll { (s: IntArraySet) =>
         val bas = s.foldLeft(BitArraySet.empty)(_ + _)
         val basIt = bas.iterator
         val basIntIt = bas.iterator
@@ -145,7 +148,7 @@ object BitArraySetProperties extends Properties("BitArraySetProperties") {
             (bas == BitArraySet0) :| "the empty set is always represented by the singleton instance"
     }
 
-    property("equals And hashCode (expected equal)") = forAll { s: IntArraySet =>
+    property("equals And hashCode (expected equal)") = forAll { (s: IntArraySet) =>
         val bas1 = s.foldLeft(BitArraySet.empty)(_ + _)
         val bas2 = s.foldLeft(BitArraySet.empty)(_ + _)
         bas1 == bas2 && bas1.hashCode == bas2.hashCode
@@ -158,7 +161,7 @@ object BitArraySetProperties extends Properties("BitArraySetProperties") {
         (bas1 == bas2) == sEquals && (!sEquals || bas1.hashCode == bas2.hashCode)
     }
 
-    property("toString") = forAll { s: IntArraySet =>
+    property("toString") = forAll { (s: IntArraySet) =>
         val bas = s.foldLeft(BitArraySet.empty)(_ + _)
         val basToString = bas.toString.substring(8)
         val sToString = s.toString.substring(8)

--- a/OPAL/common/src/test/scala/org/opalj/collection/immutable/IntArraySetProperties.scala
+++ b/OPAL/common/src/test/scala/org/opalj/collection/immutable/IntArraySetProperties.scala
@@ -29,7 +29,7 @@ object IntArraySetProperties extends Properties("IntArraySet") {
     ////////////////////////////////////////////////////////////////////////////////////////////////
     //                             P R O P E R T I E S
 
-    property("create singleton IntArraySet") = forAll { s: Int =>
+    property("create singleton IntArraySet") = forAll { (s: Int) =>
         val fl1 = IntArraySet(s)
         val fl2 = (new IntArraySetBuilder += s).result()
         val fl3 = IntArraySet1(s)
@@ -55,35 +55,35 @@ object IntArraySetProperties extends Properties("IntArraySet") {
             (fl1.size < 3 || (fl3.contains(fl1(1)) && fl3.contains(fl1(2)) && fl3.contains(fl1(2))))
     }
 
-    property("size|empty|nonEmpty|hasMultipleElements") = forAll { s: Set[Int] =>
+    property("size|empty|nonEmpty|hasMultipleElements") = forAll { (s: Set[Int]) =>
         val fl1 = IntArraySetBuilder(s).result()
         s.isEmpty == fl1.isEmpty && fl1.isEmpty != fl1.nonEmpty &&
             s.size == fl1.size &&
             (s.size >= 2 && fl1.hasMultipleElements) || (s.size <= 1 && !fl1.hasMultipleElements)
     }
 
-    property("min|max|head|last") = forAll { s: Set[Int] =>
+    property("min|max|head|last") = forAll { (s: Set[Int]) =>
         val fl1 = IntArraySetBuilder(s).result()
         s.isEmpty && fl1.isEmpty || {
             s.min == fl1.min && s.max == fl1.max && fl1.min == fl1.head && fl1.max == fl1.last
         }
     }
 
-    property("foreach") = forAll { s: Set[Int] =>
+    property("foreach") = forAll { (s: Set[Int]) =>
         val fl1 = IntArraySetBuilder(s).result()
         var newS = Set.empty[Int]
         fl1.foreach(newS += _)
         s == newS
     }
 
-    property("withFilter -> iterator (does not force evaluation)") = forAll { s: Set[Int] =>
+    property("withFilter -> iterator (does not force evaluation)") = forAll { (s: Set[Int]) =>
         val fl1 = IntArraySetBuilder(s).result()
         var newS = Set.empty[Int]
         s.withFilter(_ >= 0).withFilter(_ <= 1000).foreach(newS += _)
         fl1.withFilter(_ >= 0).withFilter(_ <= 1000).iterator.toList == newS.toList.sorted
     }
 
-    property("withFilter -> foreach (does not force evaluation)") = forAll { s: Set[Int] =>
+    property("withFilter -> foreach (does not force evaluation)") = forAll { (s: Set[Int]) =>
         val fl1 = IntArraySetBuilder(s).result()
         var newS = Set.empty[Int]
         var newFLS = Set.empty[Int]
@@ -92,30 +92,31 @@ object IntArraySetProperties extends Properties("IntArraySet") {
         newS == newFLS
     }
 
-    property("withFilter -> size|empty|hasMultipleElements (does not force evaluation)") = forAll { s: Set[Int] =>
-        val fl1 = IntArraySetBuilder(s).result()
-        var newS = Set.empty[Int]
-        s.withFilter(_ >= 0).withFilter(_ <= 1000).foreach(newS += _)
-        val newFLS = fl1.withFilter(_ >= 0).withFilter(_ <= 1000)
-        newS.size == newFLS.size &&
-            newS.isEmpty == newFLS.isEmpty &&
-            (newS.size >= 2) == newFLS.hasMultipleElements &&
-            (newFLS.isEmpty || newS.min == newFLS.min && newS.max == newFLS.max)
+    property("withFilter -> size|empty|hasMultipleElements (does not force evaluation)") = forAll {
+        (s: Set[Int]) =>
+            val fl1 = IntArraySetBuilder(s).result()
+            var newS = Set.empty[Int]
+            s.withFilter(_ >= 0).withFilter(_ <= 1000).foreach(newS += _)
+            val newFLS = fl1.withFilter(_ >= 0).withFilter(_ <= 1000)
+            newS.size == newFLS.size &&
+                newS.isEmpty == newFLS.isEmpty &&
+                (newS.size >= 2) == newFLS.hasMultipleElements &&
+                (newFLS.isEmpty || newS.min == newFLS.min && newS.max == newFLS.max)
     }
 
-    property("map") = forAll { s: Set[Int] =>
+    property("map") = forAll { (s: Set[Int]) =>
         val fl1 = IntArraySetBuilder(s).result()
         val result = fl1.map(_ * 2 / 3)
         result.iterator.toList == s.map(_ * 2 / 3).toList.sorted &&
             result.isInstanceOf[IntArraySet]
     }
 
-    property("map (identity)") = forAll { s: Set[Int] =>
+    property("map (identity)") = forAll { (s: Set[Int]) =>
         val fl1 = IntArraySetBuilder(s).result()
         fl1.map(i => i) eq fl1
     }
 
-    property("flatMap") = forAll { s: Seq[Set[Int]] =>
+    property("flatMap") = forAll { (s: Seq[Set[Int]]) =>
         val fl1: IntArraySet = IntArraySetBuilder(s.flatten: _*).result()
         val indicesSet = IntArraySetBuilder(s.toIndexedSeq.indices.toSet).result()
         val result = indicesSet.flatMap(i => IntArraySetBuilder(s(i)).result())
@@ -147,13 +148,13 @@ object IntArraySetProperties extends Properties("IntArraySet") {
         s1.subsetOf(s2) == fl1.subsetOf(fl2)
     }
 
-    property("iterator") = forAll { s1: Set[Int] =>
+    property("iterator") = forAll { (s1: Set[Int]) =>
         val fl1 = IntArraySetBuilder(s1).result()
         val ss1 = SortedSet.empty[Int] ++ s1
         ss1.iterator.toList == fl1.iterator.toList
     }
 
-    property("apply") = forAll { s1: Set[Int] =>
+    property("apply") = forAll { (s1: Set[Int]) =>
         val fl1 = IntArraySetBuilder(s1).result()
         val ss1 = (SortedSet.empty[Int] ++ s1).toList
         ss1.indices.forall(i => fl1(i) == ss1(i))
@@ -168,20 +169,20 @@ object IntArraySetProperties extends Properties("IntArraySet") {
         }
     }
 
-    property("hashCode") = forAll { s1: Set[Int] =>
+    property("hashCode") = forAll { (s1: Set[Int]) =>
         val fl1 = IntArraySetBuilder(s1).result()
         val setHashCode = fl1.hashCode
         val arraysHashCode = java.util.Arrays.hashCode(s1.toList.sorted.toArray)
         (setHashCode == arraysHashCode) :| "hashCode equality"
     }
 
-    property("intIterator") = forAll { s1: Set[Int] =>
+    property("intIterator") = forAll { (s1: Set[Int]) =>
         val fl1 = IntArraySetBuilder(s1).result()
         val flIt = fl1.iterator
         flIt.isInstanceOf[IntIterator]
     }
 
-    property("toList") = forAll { s1: Set[Int] =>
+    property("toList") = forAll { (s1: Set[Int]) =>
         val fl1 = IntArraySetBuilder(s1).result()
         val iasBasedChaing = fl1.toList
         val sBasedChain = List(s1.toList.sorted: _*)
@@ -193,7 +194,7 @@ object IntArraySetProperties extends Properties("IntArraySet") {
         (s.contains(v) == fl1.contains(v)) :| "is contained in"
     }
 
-    property("exists") = forAll { s: Set[Int] =>
+    property("exists") = forAll { (s: Set[Int]) =>
         val fl1 = IntArraySetBuilder(s).result()
         s.exists(_ / 3 == 0) == fl1.exists(_ / 3 == 0)
     }
@@ -203,7 +204,7 @@ object IntArraySetProperties extends Properties("IntArraySet") {
         s.toList.sorted.foldLeft(v)(_ + _) == fl1.foldLeft(v)(_ + _)
     }
 
-    property("forall") = forAll { s: Set[Int] =>
+    property("forall") = forAll { (s: Set[Int]) =>
         val fl1 = IntArraySetBuilder(s).result()
         s.forall(_ >= 0) == fl1.forall(_ >= 0)
     }

--- a/OPAL/common/src/test/scala/org/opalj/collection/immutable/IntTrieSetProperties.scala
+++ b/OPAL/common/src/test/scala/org/opalj/collection/immutable/IntTrieSetProperties.scala
@@ -67,7 +67,7 @@ object IntTrieSetProperties extends Properties("IntTrieSet") {
     ////////////////////////////////////////////////////////////////////////////////////////////////
     //                             P R O P E R T I E S
 
-    property("create singleton IntTrieSet") = forAll { v: Int =>
+    property("create singleton IntTrieSet") = forAll { (v: Int) =>
         val factoryITS = IntTrieSet1(v)
         val viaEmptyITS = EmptyIntTrieSet + v
         factoryITS.size == 1 &&
@@ -79,7 +79,7 @@ object IntTrieSetProperties extends Properties("IntTrieSet") {
             viaEmptyITS == factoryITS
     }
 
-    property("create IntTrieSet from Set step by step") = forAll { s: IntArraySet =>
+    property("create IntTrieSet from Set step by step") = forAll { (s: IntArraySet) =>
         val its = s.foldLeft(EmptyIntTrieSet: IntTrieSet)(_ + _)
         (its.size == s.size) :| "matching size" &&
             (its.isEmpty == s.isEmpty) &&
@@ -89,7 +89,7 @@ object IntTrieSetProperties extends Properties("IntTrieSet") {
             (its.iterator.toList.sorted == s.iterator.toList.sorted) :| "same content"
     }
 
-    property("create IntTrieSet from IntSet using ++") = forAll { s: IntTrieSet =>
+    property("create IntTrieSet from IntSet using ++") = forAll { (s: IntTrieSet) =>
         val its = EmptyIntTrieSet ++ s
         (its.size == s.size) :| "matching size" &&
             (its.isEmpty == s.isEmpty) &&
@@ -99,7 +99,7 @@ object IntTrieSetProperties extends Properties("IntTrieSet") {
             (its.iterator.toList.sorted == s.iterator.toList.sorted) :| "same content"
     }
 
-    property("create IntTrieSet from Set[Int] using ++") = forAll { s: Set[Int] =>
+    property("create IntTrieSet from Set[Int] using ++") = forAll { (s: Set[Int]) =>
         val its = EmptyIntTrieSet ++ s
         (its.size == s.size) :| "matching size" &&
             (its.isEmpty == s.isEmpty) &&
@@ -109,14 +109,14 @@ object IntTrieSetProperties extends Properties("IntTrieSet") {
             (its.iterator.toList.sorted == s.iterator.toList.sorted) :| "same content"
     }
 
-    property("create IntTrieSet from List (i.e., with duplicates)") = forAll { l: List[Int] =>
+    property("create IntTrieSet from List (i.e., with duplicates)") = forAll { (l: List[Int]) =>
         val its = l.foldLeft(EmptyIntTrieSet: IntTrieSet)(_ + _)
         val lWithoutDuplicates = l.toSet.toList
         (its.size == lWithoutDuplicates.size) :| "matching size" &&
             its.iterator.toList.sorted == lWithoutDuplicates.sorted
     }
 
-    property("create IntTrieSet from Iterator (i.e., with duplicates)") = forAll { l: List[Int] =>
+    property("create IntTrieSet from Iterator (i.e., with duplicates)") = forAll { (l: List[Int]) =>
         val its = EmptyIntTrieSet ++ l.iterator
         val newits = its.iterator.toSet
         its.size == newits.size &&
@@ -125,14 +125,14 @@ object IntTrieSetProperties extends Properties("IntTrieSet") {
             newits.forall(its.contains)
     }
 
-    property("head") = forAll { s: IntArraySet =>
+    property("head") = forAll { (s: IntArraySet) =>
         s.nonEmpty ==> {
             val its = s.foldLeft(EmptyIntTrieSet: IntTrieSet)(_ + _)
             s.contains(its.head)
         }
     }
 
-    property("head and headAndTail should return the same head") = forAll { s: IntTrieSet =>
+    property("head and headAndTail should return the same head") = forAll { (s: IntTrieSet) =>
         var its = s
         var success = true
         while (its.nonEmpty && success) {
@@ -169,14 +169,14 @@ object IntTrieSetProperties extends Properties("IntTrieSet") {
             s2.forall(v => s1.contains(v) == its.contains(v))
     }
 
-    property("foreach") = forAll { s: IntArraySet =>
+    property("foreach") = forAll { (s: IntArraySet) =>
         val its = EmptyIntTrieSet ++ s.iterator
         var newS = IntArraySet.empty
         its foreach { newS += _ } // use foreach to compute a new set
         s == newS
     }
 
-    property("foreachPair") = forAll { s: IntArraySet =>
+    property("foreachPair") = forAll { (s: IntArraySet) =>
         val its = EmptyIntTrieSet ++ s.iterator
         var itsPairs = Set.empty[(Int, Int)]
         its foreachPair { (p1: Int, p2: Int) =>
@@ -190,7 +190,7 @@ object IntTrieSetProperties extends Properties("IntTrieSet") {
         (sPairs == itsPairs) :| s"$sPairs vs. $itsPairs"
     }
 
-    property("map") = forAll { s: IntArraySet =>
+    property("map") = forAll { (s: IntArraySet) =>
         val its = EmptyIntTrieSet ++ s.iterator
         val mappedIts = its.map(_ * 2)
         val mappedS = s.map(_ * 2)
@@ -200,12 +200,12 @@ object IntTrieSetProperties extends Properties("IntTrieSet") {
         }
     }
 
-    property("transform") = forAll { s: IntTrieSet =>
+    property("transform") = forAll { (s: IntTrieSet) =>
         val its = s.transform(_ * 2, List.newBuilder[Int]).iterator.toList.sorted
         its == s.map(_ * 2).iterator.toList.sorted
     }
 
-    property("exists") = forAll { s: IntArraySet =>
+    property("exists") = forAll { (s: IntArraySet) =>
         val its = EmptyIntTrieSet ++ s.iterator
         classify(its.isEmpty, "the set is empty") {
             s.forall(v => its.exists(_ == v)) &&
@@ -213,23 +213,23 @@ object IntTrieSetProperties extends Properties("IntTrieSet") {
         }
     }
 
-    property("forall") = forAll { s: IntArraySet =>
+    property("forall") = forAll { (s: IntArraySet) =>
         val its = EmptyIntTrieSet ++ s.iterator
         its.forall(s.contains) &&
             its.forall(v => s.contains(-v)) == s.forall(v => s.contains(-v))
     }
 
-    property("foldLeft") = forAll { s: IntArraySet =>
+    property("foldLeft") = forAll { (s: IntArraySet) =>
         val its = EmptyIntTrieSet ++ s.iterator
         its.foldLeft(0)(_ + _) == s.foldLeft(0)(_ + _)
     }
 
-    property("toChain") = forAll { s: IntArraySet =>
+    property("toChain") = forAll { (s: IntArraySet) =>
         val its = EmptyIntTrieSet ++ s.iterator
         its.toList.iterator.toList.sorted == s.iterator.toList.sorted
     }
 
-    property("headAndTail") = forAll { s: IntArraySet =>
+    property("headAndTail") = forAll { (s: IntArraySet) =>
         var its = EmptyIntTrieSet ++ s.iterator
         var removed = List.empty[Int]
         while (its.nonEmpty) {
@@ -241,7 +241,7 @@ object IntTrieSetProperties extends Properties("IntTrieSet") {
             (removed.size == s.size) :| "all values are returned"
     }
 
-    property("flatMap") = forAll { listOfSets: List[IntArraySet] =>
+    property("flatMap") = forAll { (listOfSets: List[IntArraySet]) =>
         listOfSets.nonEmpty ==> {
             val arrayOfSets = listOfSets.toArray
             val arrayOfITSets = arrayOfSets.map(s => IntTrieSet.empty ++ s.iterator)
@@ -261,23 +261,23 @@ object IntTrieSetProperties extends Properties("IntTrieSet") {
         }
     }
 
-    property("not equals") = forAll { s: IntArraySet =>
+    property("not equals") = forAll { (s: IntArraySet) =>
         val its = EmptyIntTrieSet ++ s.iterator
         its != (new Object)
     }
 
-    property("+!") = forAll { s: IntTrieSet =>
+    property("+!") = forAll { (s: IntTrieSet) =>
         val its = EmptyIntTrieSet ++! s
         its == s
     }
 
-    property("equals") = forAll { s: IntTrieSet =>
+    property("equals") = forAll { (s: IntTrieSet) =>
         val i = { var i = 0; while (s.contains(i)) i += 1; i }
         val newS = s + i - i
         s == newS && s.hashCode == newS.hashCode
     }
 
-    property("toString") = forAll { s: IntArraySet =>
+    property("toString") = forAll { (s: IntArraySet) =>
         val its = s.foldLeft(IntTrieSet.empty)(_ +! _)
         val itsToString = its.toString
         itsToString.startsWith("IntTrieSet(") && itsToString.endsWith(")")
@@ -307,7 +307,7 @@ object IntTrieSetProperties extends Properties("IntTrieSet") {
         }
     }
 
-    property("filter (identity if no value is filtered)") = forAll { s: IntTrieSet =>
+    property("filter (identity if no value is filtered)") = forAll { (s: IntTrieSet) =>
         val i = { var i = 0; while (s.contains(i)) i += 1; i }
         s.filter(_ != i) eq s
     }
@@ -322,7 +322,7 @@ object IntTrieSetProperties extends Properties("IntTrieSet") {
         }
     }
 
-    property("-") = forAll { ps: (IntArraySet, IntArraySet) =>
+    property("-") = forAll { (ps: (IntArraySet, IntArraySet)) =>
         val (s, other) = ps
         val its = s.foldLeft(IntTrieSet.empty)(_ + _)
         val newits = other.foldLeft(its)(_ - _)
@@ -333,7 +333,7 @@ object IntTrieSetProperties extends Properties("IntTrieSet") {
         }
     }
 
-    property("intersect") = forAll { ps: (IntArraySet, IntArraySet) =>
+    property("intersect") = forAll { (ps: (IntArraySet, IntArraySet)) =>
         val (ias1, ias2) = ps
         val s1 = ias1.foldLeft(IntTrieSet.empty)(_ + _)
         val s2 = ias2.foldLeft(IntTrieSet.empty)(_ + _)
@@ -342,19 +342,19 @@ object IntTrieSetProperties extends Properties("IntTrieSet") {
             (s2 intersect s1) == expected
     }
 
-    property("- (all elements)") = forAll { s: IntArraySet =>
+    property("- (all elements)") = forAll { (s: IntArraySet) =>
         val its = s.foldLeft(IntTrieSet.empty)(_ + _)
         val newits = s.foldLeft(its)(_ - _)
         newits.size == 0 && newits.isEmpty &&
             newits == EmptyIntTrieSet
     }
 
-    property("filter (all elements)") = forAll { s: IntArraySet =>
+    property("filter (all elements)") = forAll { (s: IntArraySet) =>
         val its = s.foldLeft(IntTrieSet.empty)(_ + _)
         its.filter(i => false) eq EmptyIntTrieSet
     }
 
-    property("withFilter") = forAll { ss: (IntArraySet, IntArraySet) =>
+    property("withFilter") = forAll { (ss: (IntArraySet, IntArraySet)) =>
         val (s1: IntArraySet, s2: IntArraySet) = ss
         val its1 = s1.foldLeft(IntTrieSet.empty)(_ + _)
         val its2 = s2.foldLeft(IntTrieSet.empty)(_ + _)

--- a/OPAL/common/src/test/scala/org/opalj/collection/immutable/Long2ListProperties.scala
+++ b/OPAL/common/src/test/scala/org/opalj/collection/immutable/Long2ListProperties.scala
@@ -13,7 +13,7 @@ object Long2ListProperties extends Properties("Long2List") {
 
     def empty(): Long2List = Long2List.empty
 
-    property("+:, size, isSingletonList, isEmpty, foreach") = forAll { sLongSet: Set[Long] =>
+    property("+:, size, isSingletonList, isEmpty, foreach") = forAll { (sLongSet: Set[Long]) =>
         val oLongList = sLongSet.foldLeft(empty())((c, n) => n +: c)
         var newSLongSet = Set.empty[Long]
         oLongList foreach { newSLongSet += _ }
@@ -22,13 +22,13 @@ object Long2ListProperties extends Properties("Long2List") {
             (oLongList.isEmpty != oLongList.nonEmpty) :| "nonEmpty and isEmpty"
     }
 
-    property("forall") = forAll { sLongSet: Set[Long] =>
+    property("forall") = forAll { (sLongSet: Set[Long]) =>
         val sLongList = sLongSet.toList
         val oLongList = sLongList.foldLeft(empty())((c, n) => n +: c)
         oLongList.forall(sLongSet.contains)
     }
 
-    property("forFirstN") = forAll { sLongSet: Set[Long] =>
+    property("forFirstN") = forAll { (sLongSet: Set[Long]) =>
         val sLongList = sLongSet.toList
         val oLongList = sLongList.reverse.foldLeft(empty())((c, n) => n +: c)
         (0 to sLongSet.size).forall { i =>
@@ -43,20 +43,20 @@ object Long2ListProperties extends Properties("Long2List") {
         }
     }
 
-    property("foldLeft") = forAll { sLongSet: Set[Long] =>
+    property("foldLeft") = forAll { (sLongSet: Set[Long]) =>
         val sLongList = sLongSet.toList
         val oLongList = sLongList.foldLeft(empty())((c, n) => n +: c)
         oLongList.foldLeft(0L)(_ + _) == sLongList.foldLeft(0L)(_ + _)
     }
 
-    property("iterator") = forAll { sLongSet: Set[Long] =>
+    property("iterator") = forAll { (sLongSet: Set[Long]) =>
         val oLongList = sLongSet.foldLeft(empty())((c, n) => n +: c)
         var newSLongSet = Set.empty[Long]
         oLongList.iterator foreach { newSLongSet += _ }
         sLongSet == newSLongSet
     }
 
-    property("equals and hashCode: two sets which are definitively equal (the same values are added in the same order) equal have to have the same hash code") = forAll { sLongSet: Set[Long] =>
+    property("equals and hashCode: two sets which are definitively equal (the same values are added in the same order) equal have to have the same hash code") = forAll { (sLongSet: Set[Long]) =>
         val sLongListSet = sLongSet.toList
         val oLongList1 = sLongListSet.foldLeft(empty())((c, n) => n +: c)
         val oLongList2 = sLongListSet.foldLeft(empty())((c, n) => n +: c)
@@ -65,7 +65,7 @@ object Long2ListProperties extends Properties("Long2List") {
             (oLongList1.hashCode == oLongList2.hashCode) :| "hashCode"
     }
 
-    property("equals: two sets which are definitively not equal should not be equal") = forAll { sLongSet: Set[Long] =>
+    property("equals: two sets which are definitively not equal should not be equal") = forAll { (sLongSet: Set[Long]) =>
         sLongSet.nonEmpty ==> {
             val sLongListSet = sLongSet.toList
             val oLongList1 = sLongListSet.foldLeft(empty())((c, n) => n +: c)

--- a/OPAL/common/src/test/scala/org/opalj/collection/immutable/LongLinkedSetProperties.scala
+++ b/OPAL/common/src/test/scala/org/opalj/collection/immutable/LongLinkedSetProperties.scala
@@ -17,7 +17,7 @@ abstract class LongLinkedSetProperties(typeName: String) extends LongSetProperti
 
     def empty(): LongLinkedSet
 
-    property("head") = forAll { sLongSet: Set[Long] =>
+    property("head") = forAll { (sLongSet: Set[Long]) =>
         sLongSet.nonEmpty ==> {
             val sLongList = sLongSet.toList
             val oLongSet = sLongList.reverse.foldLeft(empty())(_ + _)
@@ -25,7 +25,7 @@ abstract class LongLinkedSetProperties(typeName: String) extends LongSetProperti
         }
     }
 
-    property("foreach in reverse insertion order (newest first)") = forAll { sLongSet: Set[Long] =>
+    property("foreach in reverse insertion order (newest first)") = forAll { (sLongSet: Set[Long]) =>
         val sLongList = sLongSet.toList
         val oLongSet = sLongList.foldLeft(empty())(_ + _)
         var newSLongList = List.empty[Long]
@@ -33,7 +33,7 @@ abstract class LongLinkedSetProperties(typeName: String) extends LongSetProperti
         sLongList == newSLongList
     }
 
-    property("forFirstN") = forAll { sLongSet: Set[Long] =>
+    property("forFirstN") = forAll { (sLongSet: Set[Long]) =>
         val sLongList = sLongSet.toList
         val oLongSet = sLongList.reverse.foldLeft(empty())(_ + _)
         (0 to sLongSet.size).forall { initSize =>

--- a/OPAL/common/src/test/scala/org/opalj/collection/immutable/LongSetProperties.scala
+++ b/OPAL/common/src/test/scala/org/opalj/collection/immutable/LongSetProperties.scala
@@ -18,7 +18,7 @@ abstract class LongSetProperties(typeName: String) extends Properties(typeName) 
 
     def empty(): LongSet
 
-    property("+, size, isSingletonSet, isEmpty, foreach") = forAll { sLongSet: Set[Long] =>
+    property("+, size, isSingletonSet, isEmpty, foreach") = forAll { (sLongSet: Set[Long]) =>
         val oLongSet = sLongSet.foldLeft(empty())(_ + _)
         var newSLongSet = Set.empty[Long]
         oLongSet foreach { newSLongSet += _ }
@@ -29,33 +29,33 @@ abstract class LongSetProperties(typeName: String) extends Properties(typeName) 
             oLongSet.isEmpty != oLongSet.nonEmpty
     }
 
-    property("forall and contains") = forAll { sLongSet: Set[Long] =>
+    property("forall and contains") = forAll { (sLongSet: Set[Long]) =>
         val sLongList = sLongSet.toList
         val oLongSet = sLongList.foldLeft(empty())(_ + _)
         oLongSet.forall(sLongSet.contains) &&
             sLongList.forall(oLongSet.contains)
     }
 
-    property("foldLeft") = forAll { sLongSet: Set[Long] =>
+    property("foldLeft") = forAll { (sLongSet: Set[Long]) =>
         val sLongList = sLongSet.toList
         val oLongSet = sLongList.foldLeft(empty())(_ + _)
         oLongSet.foldLeft(0L)(_ + _) == sLongList.foldLeft(0L)(_ + _)
     }
 
-    property("iterator") = forAll { sLongSet: Set[Long] =>
+    property("iterator") = forAll { (sLongSet: Set[Long]) =>
         val oLongSet = sLongSet.foldLeft(empty())(_ + _)
         var newSLongSet = Set.empty[Long]
         oLongSet.iterator foreach { newSLongSet += _ }
         sLongSet == newSLongSet
     }
 
-    property("+: only adding values which are in the set doesn't change the set") = forAll { sLongSet: Set[Long] =>
+    property("+: only adding values which are in the set doesn't change the set") = forAll { (sLongSet: Set[Long]) =>
         val oLongSet = sLongSet.foldLeft(empty())(_ + _)
         val updatedOLongSet = sLongSet.foldLeft(oLongSet)(_ + _)
         oLongSet eq updatedOLongSet
     }
 
-    property("equals and hashCode: two sets which are definitively equal (the same values are added in the same order) equal have to have the same hash code") = forAll { sLongSet: Set[Long] =>
+    property("equals and hashCode: two sets which are definitively equal (the same values are added in the same order) equal have to have the same hash code") = forAll { (sLongSet: Set[Long]) =>
         val sLongListSet = sLongSet.toList
         val oLongSet1 = sLongListSet.foldLeft(empty())(_ + _)
         val oLongSet2 = sLongListSet.foldLeft(empty())(_ + _)
@@ -64,7 +64,7 @@ abstract class LongSetProperties(typeName: String) extends Properties(typeName) 
             (oLongSet1.hashCode == oLongSet2.hashCode) :| "hashCode"
     }
 
-    property("equals and hashCode: two sets which are definitively not equal should not be equal") = forAll { sLongSet: Set[Long] =>
+    property("equals and hashCode: two sets which are definitively not equal should not be equal") = forAll { (sLongSet: Set[Long]) =>
         sLongSet.nonEmpty ==> {
             val sLongListSet = sLongSet.toList
             val oLongSet1 = sLongListSet.foldLeft(empty())(_ + _)

--- a/OPAL/common/src/test/scala/org/opalj/collection/immutable/UIDSetTest.scala
+++ b/OPAL/common/src/test/scala/org/opalj/collection/immutable/UIDSetTest.scala
@@ -49,7 +49,7 @@ class UIDSetTest extends AnyFunSpec with Matchers with ScalaCheckDrivenPropertyC
         } yield (s, i)
 
         it("create singleton set") {
-            forAll { i: Int =>
+            forAll { (i: Int) =>
                 val s = SUID(i)
                 val fl1 = UIDSet[SUID](i)
                 val fl2 = (UIDSet.newBuilder[SUID] += i).result()
@@ -69,7 +69,7 @@ class UIDSetTest extends AnyFunSpec with Matchers with ScalaCheckDrivenPropertyC
         }
 
         it("create set(++)") {
-            forAll { orig: Set[Int] =>
+            forAll { (orig: Set[Int]) =>
                 val s = orig.map(SUID.apply)
                 val us = EmptyUIDSet ++ s
                 (s.size == us.size) :| "size" &&
@@ -91,7 +91,7 @@ class UIDSetTest extends AnyFunSpec with Matchers with ScalaCheckDrivenPropertyC
         }
 
         it("create set(+)") {
-            forAll { orig: Set[Int] =>
+            forAll { (orig: Set[Int]) =>
                 val s = orig.map(SUID(_))
                 var us = EmptyUIDSet
                 s.foreach {
@@ -103,7 +103,7 @@ class UIDSetTest extends AnyFunSpec with Matchers with ScalaCheckDrivenPropertyC
         }
 
         it("remove element (-)") {
-            forAll { orig: Set[Int] =>
+            forAll { (orig: Set[Int]) =>
                 val base = orig.map(SUID.apply)
                 var s = base
                 var us = EmptyUIDSet ++ s
@@ -151,7 +151,7 @@ class UIDSetTest extends AnyFunSpec with Matchers with ScalaCheckDrivenPropertyC
         }
 
         it("equals") {
-            forAll { l: Set[Int] =>
+            forAll { (l: Set[Int]) =>
                 l.size >= 3 ==> {
                     val p = l.toList.permutations
                     val us1 = UIDSet.empty[SUID] ++ p.next().map(SUID.apply)
@@ -164,7 +164,7 @@ class UIDSetTest extends AnyFunSpec with Matchers with ScalaCheckDrivenPropertyC
         }
 
         it("seq") {
-            forAll { l: List[Int] =>
+            forAll { (l: List[Int]) =>
                 val fl = toSUIDSet(l)
                 (fl.toSeq eq fl)
             }
@@ -407,7 +407,7 @@ class UIDSetTest extends AnyFunSpec with Matchers with ScalaCheckDrivenPropertyC
         // METHODS DEFINED BY UIDSet
 
         it("isSingletonSet") {
-            forAll { orig: Set[Int] =>
+            forAll { (orig: Set[Int]) =>
                 val s = orig.map(SUID(_))
                 val us = EmptyUIDSet ++ s
                 (s.size == 1) == us.isSingletonSet

--- a/OPAL/common/src/test/scala/org/opalj/collection/immutable/UIDTrieSetTest.scala
+++ b/OPAL/common/src/test/scala/org/opalj/collection/immutable/UIDTrieSetTest.scala
@@ -26,7 +26,7 @@ class UIDTrieSetTest extends AnyFunSpec with ScalaCheckDrivenPropertyChecks with
         }
 
         it("create set(+) and forall and contains(id)") {
-            forAll { intSet: Set[Int] =>
+            forAll { (intSet: Set[Int]) =>
                 val oUIDTrieSet = intSet.foldLeft(UIDTrieSet.empty[SUID])(_ add _)
 
                 val sUIDSet = intSet.map(SUID(_))
@@ -39,7 +39,7 @@ class UIDTrieSetTest extends AnyFunSpec with ScalaCheckDrivenPropertyChecks with
         }
 
         it("create set(+) and foreach") {
-            forAll { intSet: Set[Int] =>
+            forAll { (intSet: Set[Int]) =>
                 val oUIDTrieSet = intSet.foldLeft(UIDTrieSet.empty[SUID])(_ add _)
                 val sUIDSet = intSet.map(SUID(_))
                 var newSUIDSet = Set.empty[SUID]
@@ -49,7 +49,7 @@ class UIDTrieSetTest extends AnyFunSpec with ScalaCheckDrivenPropertyChecks with
         }
 
         it("create set(+) and iterator") {
-            forAll { intSet: Set[Int] =>
+            forAll { (intSet: Set[Int]) =>
                 val oUIDTrieSet = intSet.foldLeft(UIDTrieSet.empty[SUID])(_ add _)
                 val sUIDSet = intSet.map(SUID(_))
                 var newSUIDSet = Set.empty[SUID]
@@ -59,7 +59,7 @@ class UIDTrieSetTest extends AnyFunSpec with ScalaCheckDrivenPropertyChecks with
         }
 
         it("equals and hashCode (if the sets are equal)") {
-            forAll { intSet: Set[Int] =>
+            forAll { (intSet: Set[Int]) =>
                 val p = intSet.toList.permutations
                 val initialUIDTrieSet = toSUIDSet(p.next())
                 p.take(100).forall { p =>
@@ -71,7 +71,7 @@ class UIDTrieSetTest extends AnyFunSpec with ScalaCheckDrivenPropertyChecks with
         }
 
         it("equals (if the sets are not equal)") {
-            forAll { intSet: Set[Int] =>
+            forAll { (intSet: Set[Int]) =>
                 intSet.nonEmpty ==> {
                     val oUIDTrieSet = toSUIDSet(intSet)
                     oUIDTrieSet.iterator.toList.tail.tails.forall { tailUIDTrieSet =>

--- a/OPAL/common/src/test/scala/org/opalj/collection/mutable/FixedSizeBitSetProperties.scala
+++ b/OPAL/common/src/test/scala/org/opalj/collection/mutable/FixedSizeBitSetProperties.scala
@@ -89,7 +89,7 @@ object FixedSizeBitSetProperties extends Properties("FixedSizeBitSet") {
             (!isEmpty && (bs != ZeroLengthBitSet) && (ZeroLengthBitSet != bs))
     }
 
-    property("equals and hashCode of two arbitrary sets") = forAll { e1: (IntArraySet, Int) =>
+    property("equals and hashCode of two arbitrary sets") = forAll { (e1: (IntArraySet, Int)) =>
         val (ias1, e1max) = e1
         val (ias2, e2max) = Arbitrary.arbitrary[(IntArraySet, Int)].sample.get
         val iasAreEqual = ias1 == ias2
@@ -132,7 +132,7 @@ object FixedSizeBitSetProperties extends Properties("FixedSizeBitSet") {
                 (bs3 == bs2) :| "right to left"
         }
 
-    property("equals and hashCode with something else") = forAll { e: (IntArraySet, Int) =>
+    property("equals and hashCode with something else") = forAll { (e: (IntArraySet, Int)) =>
         val (ias, max) = e
         val bs = ias.foldLeft(FixedSizeBitSet.create(max))(_ += _)
         bs != new Object
@@ -152,7 +152,7 @@ object FixedSizeBitSetProperties extends Properties("FixedSizeBitSet") {
             !bs1It.hasNext
     }
 
-    property("toString") = forAll { e: (IntArraySet, Int) =>
+    property("toString") = forAll { (e: (IntArraySet, Int)) =>
         val (ias, max) = e
         val bs = ias.foldLeft(FixedSizeBitSet.create(max))(_ += _)
         val bsToString = bs.toString.substring(12)

--- a/OPAL/common/src/test/scala/org/opalj/concurrent/TasksTest.scala
+++ b/OPAL/common/src/test/scala/org/opalj/concurrent/TasksTest.scala
@@ -5,6 +5,8 @@ package concurrent
 import org.junit.runner.RunWith
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicIntegerArray
+
+import scala.concurrent.ExecutionContextExecutorService
 //import java.util.concurrent.ConcurrentLinkedQueue
 import org.scalatestplus.junit.JUnitRunner
 import org.scalatest.funspec.AnyFunSpec
@@ -21,7 +23,8 @@ import scala.concurrent.ExecutionContext
 class TasksTest extends AnyFunSpec with Matchers {
 
     final val ThreadPool = BoundedThreadPool("tasks test", 128)
-    implicit final val TestExecutionContext = ExecutionContext.fromExecutorService(ThreadPool)
+    implicit final val TestExecutionContext: ExecutionContextExecutorService =
+        ExecutionContext.fromExecutorService(ThreadPool)
 
     describe("the Tasks control abstraction") {
 

--- a/OPAL/common/src/test/scala/org/opalj/graphs/DominanceFrontiersTest.scala
+++ b/OPAL/common/src/test/scala/org/opalj/graphs/DominanceFrontiersTest.scala
@@ -53,10 +53,10 @@ class DominanceFrontiersTest extends AnyFlatSpec with Matchers {
         val dominatorTree =
             DominatorTree(
                 startNode, startNodeHasPredecessors,
-                (n: Int) => { f: (Int => Unit) =>
+                (n: Int) => { (f: (Int => Unit)) =>
                     g.successors.getOrElse(n, List.empty).foreach[Unit](e => f(e))
                 },
-                (n: Int) => { f: (Int => Unit) =>
+                (n: Int) => { (f: (Int => Unit)) =>
                     g.predecessors.getOrElse(n, List.empty).foreach[Unit](e => f(e))
                 },
                 maxNode

--- a/OPAL/common/src/test/scala/org/opalj/graphs/DominatorTreeTest.scala
+++ b/OPAL/common/src/test/scala/org/opalj/graphs/DominatorTreeTest.scala
@@ -21,10 +21,10 @@ class DominatorTreeTest extends AnyFlatSpec with Matchers {
     "a graph with just one node" should "result in a dominator tree with a single node" in {
         val g = Graph.empty[Int] addVertice 0
         val foreachSuccessorOf: Int => ((Int => Unit) => Unit) = (n: Int) => {
-            f: (Int => Unit) => g.successors.getOrElse(n, Nil).foreach(e => f(e))
+            (f: (Int => Unit)) => g.successors.getOrElse(n, Nil).foreach(e => f(e))
         }
         val foreachPredecessorOf: Int => ((Int => Unit) => Unit) = (n: Int) => {
-            f: (Int => Unit) => g.predecessors.getOrElse(n, Nil).foreach(e => f(e))
+            (f: (Int => Unit)) => g.predecessors.getOrElse(n, Nil).foreach(e => f(e))
         }
 
         val dt = time {
@@ -46,10 +46,10 @@ class DominatorTreeTest extends AnyFlatSpec with Matchers {
     "a graph with one custom node" should "result in a dominator tree with a single node" in {
         val g = Graph.empty[Int] addVertice 7
         val foreachSuccessorOf: Int => ((Int => Unit) => Unit) = (n: Int) => {
-            f: (Int => Unit) => g.successors.getOrElse(n, Nil).foreach(e => f(e))
+            (f: (Int => Unit)) => g.successors.getOrElse(n, Nil).foreach(e => f(e))
         }
         val foreachPredecessorOf: Int => ((Int => Unit) => Unit) = (n: Int) => {
-            f: (Int => Unit) => g.predecessors.getOrElse(n, Nil).foreach(e => f(e))
+            (f: (Int => Unit)) => g.predecessors.getOrElse(n, Nil).foreach(e => f(e))
         }
 
         val dt = time {
@@ -71,10 +71,10 @@ class DominatorTreeTest extends AnyFlatSpec with Matchers {
     "a graph with two connected nodes" should "yield one node dominating the other" in {
         val g = Graph.empty[Int] addEdge (0 -> 1)
         val foreachSuccessorOf: Int => ((Int => Unit) => Unit) = (n: Int) => {
-            f: (Int => Unit) => g.successors.getOrElse(n, Nil).foreach(e => f(e))
+            (f: (Int => Unit)) => g.successors.getOrElse(n, Nil).foreach(e => f(e))
         }
         val foreachPredecessorOf: Int => ((Int => Unit) => Unit) = (n: Int) => {
-            f: (Int => Unit) => g.predecessors.getOrElse(n, Nil).foreach(e => f(e))
+            (f: (Int => Unit)) => g.predecessors.getOrElse(n, Nil).foreach(e => f(e))
         }
         val dt = time {
             DominatorTree(0, false, foreachSuccessorOf, foreachPredecessorOf, 4)
@@ -88,10 +88,10 @@ class DominatorTreeTest extends AnyFlatSpec with Matchers {
     "a simple tree" should "result in a corresponding dominator tree" in {
         val g = Graph.empty[Int] addEdge (0 -> 1) addEdge (1 -> 2) addEdge (1 -> 3) addEdge (1 -> 4)
         val foreachSuccessorOf: Int => ((Int => Unit) => Unit) = (n: Int) => {
-            f: (Int => Unit) => g.successors.getOrElse(n, Nil).foreach(e => f(e))
+            (f: (Int => Unit)) => g.successors.getOrElse(n, Nil).foreach(e => f(e))
         }
         val foreachPredecessorOf: Int => ((Int => Unit) => Unit) = (n: Int) => {
-            f: (Int => Unit) => g.predecessors.getOrElse(n, Nil).foreach(e => f(e))
+            (f: (Int => Unit)) => g.predecessors.getOrElse(n, Nil).foreach(e => f(e))
         }
         val dt = time {
             DominatorTree(0, false, foreachSuccessorOf, foreachPredecessorOf, 4)
@@ -107,10 +107,10 @@ class DominatorTreeTest extends AnyFlatSpec with Matchers {
     "a tree with a custom start node" should "result in a corresponding dominator tree" in {
         val g = Graph.empty[Int] addEdge (5 -> 0) addEdge (0 -> 1) addEdge (1 -> 2) addEdge (1 -> 3) addEdge (2 -> 4)
         val foreachSuccessorOf: Int => ((Int => Unit) => Unit) = (n: Int) => {
-            f: (Int => Unit) => g.successors.getOrElse(n, Nil).foreach(e => f(e))
+            (f: (Int => Unit)) => g.successors.getOrElse(n, Nil).foreach(e => f(e))
         }
         val foreachPredecessorOf: Int => ((Int => Unit) => Unit) = (n: Int) => {
-            f: (Int => Unit) => g.predecessors.getOrElse(n, Nil).foreach(e => f(e))
+            (f: (Int => Unit)) => g.predecessors.getOrElse(n, Nil).foreach(e => f(e))
         }
         val dt = time {
             DominatorTree(5, false, foreachSuccessorOf, foreachPredecessorOf, 5)
@@ -131,10 +131,10 @@ class DominatorTreeTest extends AnyFlatSpec with Matchers {
     "a graph with a cycle" should "correctly be resolved" in {
         val g = Graph.empty[Int] addEdge (0 -> 1) addEdge (1 -> 2) addEdge (1 -> 3) addEdge (0 -> 4) addEdge (2 -> 1)
         val foreachSuccessorOf: Int => ((Int => Unit) => Unit) = (n: Int) => {
-            f: (Int => Unit) => g.successors.getOrElse(n, Nil).foreach(e => f(e))
+            (f: (Int => Unit)) => g.successors.getOrElse(n, Nil).foreach(e => f(e))
         }
         val foreachPredecessorOf: Int => ((Int => Unit) => Unit) = (n: Int) => {
-            f: (Int => Unit) => g.predecessors.getOrElse(n, Nil).foreach(e => f(e))
+            (f: (Int => Unit)) => g.predecessors.getOrElse(n, Nil).foreach(e => f(e))
         }
         val dt = time {
             DominatorTree(0, false, foreachSuccessorOf, foreachPredecessorOf, 4)
@@ -151,10 +151,10 @@ class DominatorTreeTest extends AnyFlatSpec with Matchers {
     "a graph with a cycle and custom start node" should "correctly be resolved" in {
         val g = Graph.empty[Int] addEdge (5 -> 1) addEdge (1 -> 2) addEdge (1 -> 3) addEdge (5 -> 4) addEdge (2 -> 1)
         val foreachSuccessorOf: Int => ((Int => Unit) => Unit) = (n: Int) => {
-            f: (Int => Unit) => g.successors.getOrElse(n, Nil).foreach(e => f(e))
+            (f: (Int => Unit)) => g.successors.getOrElse(n, Nil).foreach(e => f(e))
         }
         val foreachPredecessorOf: Int => ((Int => Unit) => Unit) = (n: Int) => {
-            f: (Int => Unit) => g.predecessors.getOrElse(n, Nil).foreach(e => f(e))
+            (f: (Int => Unit)) => g.predecessors.getOrElse(n, Nil).foreach(e => f(e))
         }
         val dt = time {
             DominatorTree(5, false, foreachSuccessorOf, foreachPredecessorOf, 5)
@@ -171,10 +171,10 @@ class DominatorTreeTest extends AnyFlatSpec with Matchers {
     "a graph with a cycle related to the root node" should "correctly be resolved" in {
         val g = Graph.empty[Int] addEdge (0 -> 1) addEdge (1 -> 0)
         val foreachSuccessorOf: Int => ((Int => Unit) => Unit) = (n: Int) => {
-            f: (Int => Unit) => g.successors.getOrElse(n, Nil).foreach(e => f(e))
+            (f: (Int => Unit)) => g.successors.getOrElse(n, Nil).foreach(e => f(e))
         }
         val foreachPredecessorOf: Int => ((Int => Unit) => Unit) = (n: Int) => {
-            f: (Int => Unit) => g.predecessors.getOrElse(n, Nil).foreach(e => f(e))
+            (f: (Int => Unit)) => g.predecessors.getOrElse(n, Nil).foreach(e => f(e))
         }
         val dt = time {
             DominatorTree(0, true, foreachSuccessorOf, foreachPredecessorOf, 4)
@@ -188,10 +188,10 @@ class DominatorTreeTest extends AnyFlatSpec with Matchers {
     "a graph with a cycle related to a custom root node" should "correctly be resolved" in {
         val g = Graph.empty[Int] addEdge (2 -> 1) addEdge (1 -> 2)
         val foreachSuccessorOf: Int => ((Int => Unit) => Unit) = (n: Int) => {
-            f: (Int => Unit) => g.successors.getOrElse(n, Nil).foreach(e => f(e))
+            (f: (Int => Unit)) => g.successors.getOrElse(n, Nil).foreach(e => f(e))
         }
         val foreachPredecessorOf: Int => ((Int => Unit) => Unit) = (n: Int) => {
-            f: (Int => Unit) => g.predecessors.getOrElse(n, Nil).foreach(e => f(e))
+            (f: (Int => Unit)) => g.predecessors.getOrElse(n, Nil).foreach(e => f(e))
         }
         val dt = time {
             DominatorTree(2, true, foreachSuccessorOf, foreachPredecessorOf, 2)
@@ -205,10 +205,10 @@ class DominatorTreeTest extends AnyFlatSpec with Matchers {
     "a sparse cyclic graph" should "result in a compact dominator tree" in {
         val g = Graph.empty[Int] addEdge (0 -> 8) addEdge (8 -> 20) addEdge (8 -> 3) addEdge (0 -> 4) addEdge (20 -> 8)
         val foreachSuccessorOf: Int => ((Int => Unit) => Unit) = (n: Int) => {
-            f: (Int => Unit) => g.successors.getOrElse(n, Nil).foreach(e => f(e))
+            (f: (Int => Unit)) => g.successors.getOrElse(n, Nil).foreach(e => f(e))
         }
         val foreachPredecessorOf: Int => ((Int => Unit) => Unit) = (n: Int) => {
-            f: (Int => Unit) => g.predecessors.getOrElse(n, Nil).foreach(e => f(e))
+            (f: (Int => Unit)) => g.predecessors.getOrElse(n, Nil).foreach(e => f(e))
         }
         val dt = time {
             DominatorTree(0, false, foreachSuccessorOf, foreachPredecessorOf, 20)
@@ -231,10 +231,10 @@ class DominatorTreeTest extends AnyFlatSpec with Matchers {
         implicit def stringToInt(s: String): Int = s.charAt(0).toInt
         val g = Graph.empty[Int] addEdge (0, "b") addEdge ("b", "c") addEdge ("b", "d") addEdge (0, "e") addEdge ("d", "f") addEdge ("f", "b")
         val foreachSuccessorOf: Int => ((Int => Unit) => Unit) = (n: Int) => {
-            f: (Int => Unit) => g.successors.getOrElse(n, Nil).foreach(e => f(e))
+            (f: (Int => Unit)) => g.successors.getOrElse(n, Nil).foreach(e => f(e))
         }
         val foreachPredecessorOf: Int => ((Int => Unit) => Unit) = (n: Int) => {
-            f: (Int => Unit) => g.predecessors.getOrElse(n, Nil).foreach(e => f(e))
+            (f: (Int => Unit)) => g.predecessors.getOrElse(n, Nil).foreach(e => f(e))
         }
         val dt = time {
             DominatorTree(0, false, foreachSuccessorOf, foreachPredecessorOf, 128)
@@ -250,10 +250,10 @@ class DominatorTreeTest extends AnyFlatSpec with Matchers {
     "a very large, degenerated graph (path)" should "be computed in due time and should not raise an exception (e.g. StackOverflowError)" in {
         val g = Graph.empty[Int]
         val foreachSuccessorOf: Int => ((Int => Unit) => Unit) = (n: Int) => {
-            f: (Int => Unit) => g.successors.getOrElse(n, Nil).foreach(e => f(e))
+            (f: (Int => Unit)) => g.successors.getOrElse(n, Nil).foreach(e => f(e))
         }
         val foreachPredecessorOf: Int => ((Int => Unit) => Unit) = (n: Int) => {
-            f: (Int => Unit) => g.predecessors.getOrElse(n, Nil).foreach(e => f(e))
+            (f: (Int => Unit)) => g.predecessors.getOrElse(n, Nil).foreach(e => f(e))
         }
         var lastI = 0
         for (i <- 1 to 65000) {

--- a/OPAL/common/src/test/scala/org/opalj/graphs/PostDominatorTreeTest.scala
+++ b/OPAL/common/src/test/scala/org/opalj/graphs/PostDominatorTreeTest.scala
@@ -22,10 +22,10 @@ class PostDominatorTreeTest extends AnyFlatSpec with Matchers {
     "a graph with just one node" should "result in a post dominator tree with a single node" in {
         val g = Graph.empty[Int] addVertice 0
         val foreachSuccessorOf: Int => ((Int => Unit) => Unit) = (n: Int) => {
-            f: (Int => Unit) => g.successors.getOrElse(n, Nil).foreach(e => f(e))
+            (f: (Int => Unit)) => g.successors.getOrElse(n, Nil).foreach(e => f(e))
         }
         val foreachPredecessorOf: Int => ((Int => Unit) => Unit) = (n: Int) => {
-            f: (Int => Unit) => g.predecessors.getOrElse(n, Nil).foreach(e => f(e))
+            (f: (Int => Unit)) => g.predecessors.getOrElse(n, Nil).foreach(e => f(e))
         }
         val existNodes = Set(0)
         val dt = time {
@@ -54,10 +54,10 @@ class PostDominatorTreeTest extends AnyFlatSpec with Matchers {
     "a simple tree with multiple exits" should "result in a corresponding postdominator tree" in {
         val g = Graph.empty[Int] addEdge (0 -> 1) addEdge (1 -> 2) addEdge (1 -> 3) addEdge (2 -> 4)
         val foreachSuccessorOf: Int => ((Int => Unit) => Unit) = (n: Int) => {
-            f: (Int => Unit) => g.successors.getOrElse(n, Nil).foreach(e => f(e))
+            (f: (Int => Unit)) => g.successors.getOrElse(n, Nil).foreach(e => f(e))
         }
         val foreachPredecessorOf: Int => ((Int => Unit) => Unit) = (n: Int) => {
-            f: (Int => Unit) => g.predecessors.getOrElse(n, Nil).foreach(e => f(e))
+            (f: (Int => Unit)) => g.predecessors.getOrElse(n, Nil).foreach(e => f(e))
         }
         val existNodes = Set(3, 4)
         val dt = time {
@@ -92,10 +92,10 @@ class PostDominatorTreeTest extends AnyFlatSpec with Matchers {
     "a graph with a cycle" should "yield the correct postdominators" in {
         val g = Graph.empty[Int] addEdge (0 -> 1) addEdge (1 -> 2) addEdge (1 -> 3) addEdge (0 -> 4) addEdge (2 -> 1)
         val foreachSuccessorOf: Int => ((Int => Unit) => Unit) = (n: Int) => {
-            f: (Int => Unit) => g.successors.getOrElse(n, Nil).foreach(e => f(e))
+            (f: (Int => Unit)) => g.successors.getOrElse(n, Nil).foreach(e => f(e))
         }
         val foreachPredecessorOf: Int => ((Int => Unit) => Unit) = (n: Int) => {
-            f: (Int => Unit) => g.predecessors.getOrElse(n, Nil).foreach(e => f(e))
+            (f: (Int => Unit)) => g.predecessors.getOrElse(n, Nil).foreach(e => f(e))
         }
         val existNodes = Set(3, 4)
         val dt = time {
@@ -138,10 +138,10 @@ class PostDominatorTreeTest extends AnyFlatSpec with Matchers {
     "a path with multiple artificial exit points" should "yield the correct postdominators" in {
         val g = Graph.empty[Int] addEdge (0 -> 1) addEdge (1 -> 2)
         val foreachSuccessorOf: Int => ((Int => Unit) => Unit) = (n: Int) => {
-            f: (Int => Unit) => g.successors.getOrElse(n, Nil).foreach(e => f(e))
+            (f: (Int => Unit)) => g.successors.getOrElse(n, Nil).foreach(e => f(e))
         }
         val foreachPredecessorOf: Int => ((Int => Unit) => Unit) = (n: Int) => {
-            f: (Int => Unit) => g.predecessors.getOrElse(n, Nil).foreach(e => f(e))
+            (f: (Int => Unit)) => g.predecessors.getOrElse(n, Nil).foreach(e => f(e))
         }
         val existNodes = Set(1, 2)
         val dt = time {

--- a/OPAL/da/src/main/scala/org/opalj/da/ClassFile.scala
+++ b/OPAL/da/src/main/scala/org/opalj/da/ClassFile.scala
@@ -69,7 +69,7 @@ case class ClassFile(
 
     def jdkVersion: String = org.opalj.bi.jdkVersion(major_version)
 
-    private[this] implicit val cp = constant_pool
+    private[this] implicit val cp: Constant_Pool = constant_pool
 
     /**
      * The fully qualified name of this class in Java notation (i.e., using dots

--- a/OPAL/si/src/main/scala/org/opalj/fpcf/par/PKECPropertyStore.scala
+++ b/OPAL/si/src/main/scala/org/opalj/fpcf/par/PKECPropertyStore.scala
@@ -92,9 +92,10 @@ class PKECPropertyStore(
         if (printProperties) {
             val properties = for (pkId <- 0 to PropertyKey.maxId) yield {
                 var entities: List[String] = List.empty
-                ps(pkId).forEachValue(Long.MaxValue, { state: EPKState =>
-                    entities ::= state.eOptP.toString.replace("\n", "\n\t")
-                })
+                ps(pkId).forEachValue(
+                    Long.MaxValue,
+                    (state: EPKState) => entities ::= state.eOptP.toString.replace("\n", "\n\t")
+                )
                 entities.sorted.mkString(s"Entities for property key $pkId:\n\t", "\n\t", "\n")
             }
             properties.mkString("PropertyStore(\n\t", "\n\t", "\n)")
@@ -106,17 +107,18 @@ class PKECPropertyStore(
     override def entities(propertyFilter: SomeEPS => Boolean): Iterator[Entity] = {
         ps.iterator.flatMap { propertiesPerKind =>
             val result: ListBuffer[Entity] = ListBuffer.empty
-            propertiesPerKind.forEachValue(Long.MaxValue, {
-                state: EPKState => if (propertyFilter(state.eOptP.asEPS)) result.append(state.eOptP.e)
-            })
+            propertiesPerKind.forEachValue(
+                Long.MaxValue,
+                (state: EPKState) => if (propertyFilter(state.eOptP.asEPS)) result.append(state.eOptP.e)
+            )
             result
         }
     }
 
     override def entities[P <: Property](pk: PropertyKey[P]): Iterator[EPS[Entity, P]] = {
         val result: ListBuffer[EPS[Entity, P]] = ListBuffer.empty
-        ps(pk.id).forEachValue(Long.MaxValue, {
-            state: EPKState => result.append(state.eOptP.asInstanceOf[EPS[Entity, P]])
+        ps(pk.id).forEachValue(Long.MaxValue, { (state: EPKState) =>
+            result.append(state.eOptP.asInstanceOf[EPS[Entity, P]])
         })
         result.iterator
     }
@@ -322,7 +324,7 @@ class PKECPropertyStore(
                 val epk = EPK(e, AnalysisKey)
 
                 val epkState = EPKState(epk, null, dependees)
-                epkState.c = { dependee: SomeEPS =>
+                epkState.c = { (dependee: SomeEPS) =>
                     val result = c(dependee)
 
                     val state = ps(AnalysisKeyId).remove(e)
@@ -623,7 +625,7 @@ class PKECPropertyStore(
             var pkId = 0
             while (pkId <= PropertyKey.maxId) {
                 if (propertyKindsComputedInThisPhase(pkId) && (lazyComputations(pkId) eq null)) {
-                    ps(pkId).forEachValue(Long.MaxValue, { epkState: EPKState =>
+                    ps(pkId).forEachValue(Long.MaxValue, { (epkState: EPKState) =>
                         if (epkState.eOptP.isEPK && ((epkState.dependees eq null) || epkState.dependees.isEmpty)) {
                             val e = epkState.eOptP.e
                             if (getResponsibleTId(e) == ownTId) {
@@ -648,7 +650,7 @@ class PKECPropertyStore(
             var pkId = 0
             while (pkId <= PropertyKey.maxId) {
                 if (propertyKindsComputedInThisPhase(pkId)) {
-                    ps(pkId).forEachValue(Long.MaxValue, { epkState: EPKState =>
+                    ps(pkId).forEachValue(Long.MaxValue, { (epkState: EPKState) =>
                         val eOptP = epkState.eOptP
                         if (eOptP.isRefinable && getResponsibleTId(eOptP.e) == ownTId) {
                             localInterimStates.append(epkState)
@@ -679,7 +681,7 @@ class PKECPropertyStore(
 
             pksToFinalize foreach { pk =>
                 val pkId = pk.id
-                ps(pkId).forEachValue(Long.MaxValue, { epkState: EPKState =>
+                ps(pkId).forEachValue(Long.MaxValue, { (epkState: EPKState) =>
                     val eOptP = epkState.eOptP
                     if (getResponsibleTId(eOptP.e) == ownTId && eOptP.isRefinable && !eOptP.isEPK) //TODO Won't be required once subPhaseFinalizationOrder is reliably only the partial properties
                         handleFinalResult(eOptP.toFinalEP, pksToFinalize)

--- a/OPAL/si/src/test/scala/org/opalj/fpcf/EOptionPSetTest.scala
+++ b/OPAL/si/src/test/scala/org/opalj/fpcf/EOptionPSetTest.scala
@@ -38,7 +38,7 @@ class EOptionPSetTest extends AnyFunSuite {
         val fep2Marker = FinalEP(e2, Marker.IsMarked)
         val fe2Pal = FinalEP(e2, Palindromes.Palindrome)
 
-        implicit val ps = new InitializedPropertyStore(IntMap(
+        implicit val ps: InitializedPropertyStore = new InitializedPropertyStore(IntMap(
             Marker.Key.id -> Map(
                 e1 -> mutable.Queue(ie1Marker, fep1Marker, fep1Marker),
                 e2 -> mutable.Queue(ie2Marker, fep2Marker)
@@ -72,7 +72,7 @@ class EOptionPSetTest extends AnyFunSuite {
         val fep1Marker = FinalEP(e1, Marker.IsMarked)
         val fe2Pal = FinalEP(e2, Palindromes.Palindrome)
 
-        implicit val ps = new InitializedPropertyStore(IntMap(
+        implicit val ps: InitializedPropertyStore = new InitializedPropertyStore(IntMap(
             Marker.Key.id -> Map(
                 e1 -> mutable.Queue(ie1Marker, fep1Marker),
                 e2 -> mutable.Queue(ie2Marker)
@@ -101,7 +101,7 @@ class EOptionPSetTest extends AnyFunSuite {
         val e2 = new Object
         val ieupb1 = InterimEUBP(e1, Marker.NotMarked)
         val ieupb2 = InterimEUBP(e2, Marker.NotMarked)
-        implicit val ps = new InitializedPropertyStore(IntMap(
+        implicit val ps: InitializedPropertyStore = new InitializedPropertyStore(IntMap(
             Marker.Key.id ->
                 Map(
                     e1 -> mutable.Queue(ieupb1),
@@ -144,7 +144,7 @@ class EOptionPSetTest extends AnyFunSuite {
         val ie2Marker = InterimEUBP(e2, Marker.NotMarked)
         val ie2Pal = InterimEUBP(e2, Palindromes.NoPalindrome)
 
-        implicit val ps = new InitializedPropertyStore(IntMap(
+        implicit val ps: InitializedPropertyStore = new InitializedPropertyStore(IntMap(
             Marker.Key.id -> Map(
                 e1 -> mutable.Queue(ie1Marker),
                 e2 -> mutable.Queue(ie2Marker)
@@ -174,7 +174,7 @@ class EOptionPSetTest extends AnyFunSuite {
         val ie2Marker = InterimEUBP(e2, Marker.NotMarked)
         val ie2Pal = InterimEUBP(e2, Palindromes.NoPalindrome)
 
-        implicit val ps = new InitializedPropertyStore(IntMap(
+        implicit val ps: InitializedPropertyStore = new InitializedPropertyStore(IntMap(
             Marker.Key.id -> Map(
                 e1 -> mutable.Queue(ie1Marker),
                 e2 -> mutable.Queue(ie2Marker)
@@ -205,7 +205,7 @@ class EOptionPSetTest extends AnyFunSuite {
         val ie2Marker = InterimEUBP(e2, Marker.NotMarked)
         val ie2Pal = InterimEUBP(e2, Palindromes.NoPalindrome)
 
-        implicit val ps = new InitializedPropertyStore(IntMap(
+        implicit val ps: InitializedPropertyStore = new InitializedPropertyStore(IntMap(
             Marker.Key.id -> Map(
                 e1 -> mutable.Queue(ie1Marker),
                 e2 -> mutable.Queue(ie2Marker)
@@ -222,12 +222,12 @@ class EOptionPSetTest extends AnyFunSuite {
 
         val newSet = set.filter(_.e == e1)
         assert(newSet.size == 1)
-        assert(!newSet.isEmpty)
+        assert(newSet.nonEmpty)
         assert(set.getOrQueryAndUpdate(e1, Marker.Key) == ie1Marker)
         assert(newSet.size == 1)
 
         val newSet2 = newSet.filter(_.e == e2)
-        assert(newSet2.size == 0)
+        assert(newSet2.isEmpty)
         assert(newSet2.isEmpty)
 
         // old sets are unchanged...:

--- a/OPAL/si/src/test/scala/org/opalj/fpcf/PropertyStoreTest.scala
+++ b/OPAL/si/src/test/scala/org/opalj/fpcf/PropertyStoreTest.scala
@@ -586,7 +586,7 @@ sealed abstract class PropertyStoreTest[PS <: PropertyStore]
                             )
                         }
                     )
-                    ps.scheduleEagerComputationForEntity("e") { e: String =>
+                    ps.scheduleEagerComputationForEntity("e") { (e: String) =>
                         val initialSomeEOptionP = ps("e", SuperPalindromeKey)
                         initialSomeEOptionP should be(EPK("e", SuperPalindromeKey))
                         InterimResult(
@@ -1722,7 +1722,7 @@ sealed abstract class PropertyStoreTest[PS <: PropertyStore]
                     Result(e, p)
                 }
             )
-            ps.scheduleEagerComputationForEntity("aaa") { s: String =>
+            ps.scheduleEagerComputationForEntity("aaa") { (s: String) =>
                 ps("a", ppk) match {
                     case epk: EPK[_, _] =>
                         InterimResult(

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/escape/AbstractEscapeAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/escape/AbstractEscapeAnalysis.scala
@@ -25,7 +25,6 @@ import org.opalj.br.fpcf.FPCFAnalysis
 import org.opalj.br.fpcf.properties.Context
 import org.opalj.br.fpcf.properties.GlobalEscape
 import org.opalj.br.fpcf.properties.NoEscape
-import org.opalj.ai.ValueOrigin
 import org.opalj.tac.cg.TypeIteratorKey
 import org.opalj.tac.common.DefinitionSiteLike
 import org.opalj.tac.fpcf.analyses.cg.TypeIterator
@@ -425,7 +424,7 @@ trait AbstractEscapeAnalysis extends FPCFAnalysis {
     protected[this] def determineEscapeOfDS(
         dsl: (Context, DefinitionSiteLike)
     ): ProperPropertyComputationResult = {
-        val ctx = createContext(dsl, dsl._2.pc, dsl._2.method)
+        val ctx = createContext(dsl, dsl._2.method)
         doDetermineEscape(ctx, createState)
     }
 
@@ -444,7 +443,6 @@ trait AbstractEscapeAnalysis extends FPCFAnalysis {
 
     protected[this] def createContext(
         entity:       (Context, Entity),
-        defSitePC:    ValueOrigin,
         targetMethod: Method
     ): AnalysisContext
 }

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/escape/SimpleEscapeAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/escape/SimpleEscapeAnalysis.scala
@@ -28,14 +28,12 @@ import org.opalj.br.fpcf.FPCFAnalysis
 import org.opalj.br.fpcf.FPCFAnalysisScheduler
 import org.opalj.br.fpcf.properties.Context
 import org.opalj.br.fpcf.properties.SimpleContextsKey
-import org.opalj.ai.ValueOrigin
 import org.opalj.tac.cg.TypeIteratorKey
 import org.opalj.tac.common.DefinitionSitesKey
 import org.opalj.tac.fpcf.properties.TACAI
 
 class SimpleEscapeAnalysisContext(
         val entity:                  (Context, Entity),
-        val defSitePC:               ValueOrigin,
         val targetMethod:            Method,
         val declaredMethods:         DeclaredMethods,
         val virtualFormalParameters: VirtualFormalParameters,
@@ -71,7 +69,7 @@ class SimpleEscapeAnalysis( final val project: SomeProject)
             case VirtualFormalParameter(dm: DefinedMethod, _) if dm.definedMethod.body.isEmpty =>
                 Result(fp, AtMost(NoEscape))
             case VirtualFormalParameter(dm: DefinedMethod, -1) if dm.definedMethod.isInitializer =>
-                val ctx = createContext(fp, -1, dm.definedMethod)
+                val ctx = createContext(fp, dm.definedMethod)
                 doDetermineEscape(ctx, createState)
             case VirtualFormalParameter(_, _) =>
                 Result(fp, AtMost(NoEscape))
@@ -80,11 +78,9 @@ class SimpleEscapeAnalysis( final val project: SomeProject)
 
     override def createContext(
         entity:       (Context, Entity),
-        defSite:      ValueOrigin,
         targetMethod: Method
     ): SimpleEscapeAnalysisContext = new SimpleEscapeAnalysisContext(
         entity,
-        defSite,
         targetMethod,
         declaredMethods,
         virtualFormalParameters,

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/fieldassignability/AbstractFieldAssignabilityAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/fieldassignability/AbstractFieldAssignabilityAnalysis.scala
@@ -115,7 +115,7 @@ trait AbstractFieldAssignabilityAnalysis extends FPCFAnalysis {
         field: Field
     ): ProperPropertyComputationResult = {
 
-        implicit val state = createState(field)
+        implicit val state: AnalysisState = createState(field)
 
         if (field.isFinal)
             return Result(field, NonAssignable);

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/ConfiguredMethodsPointsToAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/ConfiguredMethodsPointsToAnalysis.scala
@@ -263,9 +263,7 @@ abstract class ConfiguredMethodsPointsToAnalysis private[analyses] (
             case md: MethodDescription =>
                 val method = md.method(declaredMethods)
                 val returnType = method.descriptor.returnType.asReferenceType
-                val filter = { t: ReferenceType =>
-                    classHierarchy.isSubtypeOf(t, returnType)
-                }
+                val filter = (t: ReferenceType) => classHierarchy.isSubtypeOf(t, returnType)
                 val entity = state.callContext
                 state.includeSharedPointsToSet(
                     entity,

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/PointsToAnalysisBase.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/PointsToAnalysisBase.scala
@@ -104,7 +104,7 @@ trait PointsToAnalysisBase extends AbstractPointsToBasedAnalysis with TypeConsum
         val declClassType = targetMethod.declaringClassType
         val tgtMethod = targetMethod.definedMethod
         val filter = if (isNonVirtualCall) {
-            t: ReferenceType => classHierarchy.isSubtypeOf(t, declClassType)
+            (t: ReferenceType) => classHierarchy.isSubtypeOf(t, declClassType)
         } else {
             val overrides =
                 if (project.overridingMethods.contains(tgtMethod))
@@ -113,7 +113,7 @@ trait PointsToAnalysisBase extends AbstractPointsToBasedAnalysis with TypeConsum
                 else
                     Set.empty
             // TODO this might not be 100% correct in some corner cases
-            t: ReferenceType =>
+            (t: ReferenceType) =>
                 classHierarchy.isSubtypeOf(t, declClassType) &&
                     !overrides.exists(st => classHierarchy.isSubtypeOf(t, st))
         }
@@ -145,9 +145,7 @@ trait PointsToAnalysisBase extends AbstractPointsToBasedAnalysis with TypeConsum
         val paramType = target.method.descriptor.parameterType(paramIndex)
         if (paramType.isReferenceType) {
             val fp = getFormalParameter(paramIndex + 1, fps, target)
-            val filter = { t: ReferenceType =>
-                classHierarchy.isSubtypeOf(t, paramType.asReferenceType)
-            }
+            val filter = (t: ReferenceType) => classHierarchy.isSubtypeOf(t, paramType.asReferenceType)
             state.includeSharedPointsToSets(
                 fp,
                 currentPointsToOfDefSites(fp, paramDefSites, filter),
@@ -165,7 +163,7 @@ trait PointsToAnalysisBase extends AbstractPointsToBasedAnalysis with TypeConsum
             val nextStmt = tac.stmts(index + 1)
             nextStmt match {
                 case Checkcast(_, value, cmpTpe) if value.asVar.definedBy.contains(index) =>
-                    t: ReferenceType => classHierarchy.isSubtypeOf(t, cmpTpe)
+                    (t: ReferenceType) => classHierarchy.isSubtypeOf(t, cmpTpe)
                 case _ =>
                     PointsToSetLike.noFilter
             }
@@ -243,9 +241,9 @@ trait PointsToAnalysisBase extends AbstractPointsToBasedAnalysis with TypeConsum
         val fakeEntity = (rhsDefSites, fieldOpt)
         state.addPutFieldEntity(fakeEntity)
 
-        val filter = if (fieldOpt.isDefined) { t: ReferenceType =>
-            classHierarchy.isSubtypeOf(t, fieldOpt.get.fieldType.asReferenceType)
-        } else
+        val filter = if (fieldOpt.isDefined)
+            (t: ReferenceType) => classHierarchy.isSubtypeOf(t, fieldOpt.get.fieldType.asReferenceType)
+        else
             PointsToSetLike.noFilter
 
         currentPointsToOfDefSites(fakeEntity, objRefDefSites).foreach { pts =>
@@ -268,9 +266,7 @@ trait PointsToAnalysisBase extends AbstractPointsToBasedAnalysis with TypeConsum
     }
 
     protected[this] def handlePutStatic(field: Field, rhsDefSites: IntTrieSet)(implicit state: State): Unit = {
-        val filter = { t: ReferenceType =>
-            classHierarchy.isSubtypeOf(t, field.fieldType.asReferenceType)
-        }
+        val filter = (t: ReferenceType) => classHierarchy.isSubtypeOf(t, field.fieldType.asReferenceType)
         state.includeSharedPointsToSets(
             field,
             currentPointsToOfDefSites(field, rhsDefSites, filter),
@@ -291,9 +287,7 @@ trait PointsToAnalysisBase extends AbstractPointsToBasedAnalysis with TypeConsum
                     !isEmptyArray(as)) {
                     val arrayEntity = ArrayEntity(as)
                     val componentType = ArrayType.lookup(typeId).componentType.asReferenceType
-                    val filter = { t: ReferenceType =>
-                        classHierarchy.isSubtypeOf(t, componentType)
-                    }
+                    val filter = (t: ReferenceType) => classHierarchy.isSubtypeOf(t, componentType)
                     state.includeSharedPointsToSets(
                         arrayEntity,
                         currentPointsToOfDefSites(arrayEntity, rhsDefSites, filter),
@@ -373,9 +367,9 @@ trait PointsToAnalysisBase extends AbstractPointsToBasedAnalysis with TypeConsum
                     if (tpe.isObjectType && (fieldOpt.isEmpty ||
                         classHierarchy.isSubtypeOf(tpe, fieldOpt.get.classFile.thisType))) {
 
-                        val typeFilter = if (fieldOpt.isDefined) { t: ReferenceType =>
-                            classHierarchy.isSubtypeOf(t, fieldOpt.get.fieldType.asReferenceType)
-                        } else
+                        val typeFilter = if (fieldOpt.isDefined)
+                            (t: ReferenceType) => classHierarchy.isSubtypeOf(t, fieldOpt.get.fieldType.asReferenceType)
+                        else
                             PointsToSetLike.noFilter
 
                         val fieldEntities =
@@ -421,9 +415,7 @@ trait PointsToAnalysisBase extends AbstractPointsToBasedAnalysis with TypeConsum
                         classHierarchy.isSubtypeOf(ArrayType.lookup(typeId), arrayType) &&
                         !isEmptyArray(as)) {
                         val componentType = ArrayType.lookup(typeId).componentType.asReferenceType
-                        val typeFilter = { t: ReferenceType =>
-                            classHierarchy.isSubtypeOf(t, componentType)
-                        }
+                        val typeFilter = (t: ReferenceType) => classHierarchy.isSubtypeOf(t, componentType)
                         results = results ++ createPartialResults(
                             ArrayEntity(as),
                             knownPointsTo,

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/purity/DomainSpecificRater.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/purity/DomainSpecificRater.scala
@@ -11,6 +11,7 @@ import org.opalj.br.analyses.SomeProject
 import org.opalj.br.fpcf.properties.DPure
 import org.opalj.br.fpcf.properties.Pure
 import org.opalj.br.fpcf.properties.Purity
+import org.opalj.br.ClassHierarchy
 import org.opalj.br.MethodDescriptor
 
 /**
@@ -184,7 +185,7 @@ trait LoggingRater extends DomainSpecificRater {
         code:    Array[Stmt[V]]
     ): Option[Purity] = {
         val GetStatic(_, declaringClass, _, _) = expr
-        if (logLevels.exists(declaringClass == _))
+        if (logLevels.contains(declaringClass))
             Some(DPure)
         else super.handleGetStatic(expr)
     }
@@ -202,7 +203,7 @@ trait ExceptionRater extends DomainSpecificRater {
         project: SomeProject,
         code:    Array[Stmt[V]]
     ): Option[Purity] = {
-        implicit val classHierarchy = project.classHierarchy
+        implicit val classHierarchy: ClassHierarchy = project.classHierarchy
         val declClass = call.declaringClass
         if (declClass.isObjectType && call.name == "<init>" &&
             declClass.asObjectType.isSubtypeOf(ObjectType.Throwable) &&
@@ -249,7 +250,7 @@ trait AssertionExceptionRater extends DomainSpecificRater {
         implicit
         project: SomeProject, code: Array[Stmt[V]]
     ): Option[Purity] = {
-        implicit val classHierarchy = project.classHierarchy;
+        implicit val classHierarchy: ClassHierarchy = project.classHierarchy
         if (call.declaringClass.isObjectType && call.name == "<init>" &&
             exceptionTypes.exists(call.declaringClass.asObjectType.isSubtypeOf))
             Some(DPure)

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/properties/cg/Callers.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/properties/cg/Callers.scala
@@ -292,7 +292,7 @@ sealed trait CallersImplementation extends Callers {
             case (calleeContextId, callers) =>
                 val calleeContext = typeIterator.contextFromId(calleeContextId)
                 val seen = if (old eq null) 0 else old.callersForContextId(calleeContextId).size
-                callers.forFirstN(callers.size - seen) { encodedPair: Long =>
+                callers.forFirstN(callers.size - seen) { (encodedPair: Long) =>
                     val (callerContextId, pc, isDirect) = Callers.toContextPcAndIsDirect(encodedPair)
                     val callerContext = typeIterator.contextFromId(callerContextId)
                     handleContext(calleeContext, callerContext, pc, isDirect)

--- a/OPAL/tac/src/main/scala/org/opalj/tac/package.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/package.scala
@@ -39,7 +39,7 @@ package object tac {
         stmts: Array[Stmt[V]],
         cfg:   CFG[Stmt[V], TACStmts[V]]
     ): Iterable[Node] = {
-        val (_, allNodes) = cfg.toDot { bb: BasicBlock =>
+        val (_, allNodes) = cfg.toDot { (bb: BasicBlock) =>
             val pcRange = bb.startPC to bb.endPC
             val bbStmts = stmts.slice(bb.startPC, bb.endPC + 1).zip(pcRange)
             val txtStmts = bbStmts.map { stmtPC =>

--- a/TOOLS/bp/src/main/scala/org/opalj/bugpicker/core/analyses/BugPickerAnalysis.scala
+++ b/TOOLS/bp/src/main/scala/org/opalj/bugpicker/core/analyses/BugPickerAnalysis.scala
@@ -94,8 +94,8 @@ class BugPickerAnalysis extends Analysis[URL, BugPickerResults] {
 
         import theProject.config
 
-        implicit val project = theProject
-        implicit val logContext = theProject.logContext
+        implicit val project: Project[URL] = theProject
+        implicit val logContext: LogContext = theProject.logContext
 
         // related to managing the analysis progress
         val classFilesCount = theProject.projectClassFilesCount

--- a/TOOLS/bp/src/main/scala/org/opalj/bugpicker/core/analyses/DeadEdgesAnalysis.scala
+++ b/TOOLS/bp/src/main/scala/org/opalj/bugpicker/core/analyses/DeadEdgesAnalysis.scala
@@ -60,7 +60,7 @@ object DeadEdgesAnalysis {
         import result.operandsArray
         import result.localsArray
         val evaluatedInstructions = result.evaluatedInstructions
-        implicit val body = result.code
+        implicit val body: Code = result.code
         val instructions = body.instructions
         import result.cfJoins
         import result.domain.regularSuccessorsOf

--- a/TOOLS/hermes/src/main/scala/org/opalj/hermes/queries/FanInFanOut.scala
+++ b/TOOLS/hermes/src/main/scala/org/opalj/hermes/queries/FanInFanOut.scala
@@ -72,7 +72,7 @@ class FanInFanOut(implicit hermes: HermesConfig) extends FeatureQuery {
             categorySizeDefault: Double,
             offset:              Int
         ): FeatureConfiguration = {
-            implicit val config = hermes.Config.getConfig(FanInFanOutConfigPrefix)
+            implicit val config: Config = hermes.Config.getConfig(FanInFanOutConfigPrefix)
             val numCategories = parseNumCategories(categoriesKey).getOrElse(categoriesDefault)
             val categorySize = parseCategorySize(categorySizeKey).getOrElse(categorySizeDefault)
 
@@ -213,7 +213,7 @@ class FanInFanOut(implicit hermes: HermesConfig) extends FeatureQuery {
             objectTypeId = ObjectType(classFileType).id
             location = ClassFileLocation(Some(source), classFileType)
         } {
-            implicit val constantPool = classFile.constant_pool
+            implicit val constantPool: Constant_Pool = classFile.constant_pool
             val cpEntryPredicate: PartialFunction[Constant_Pool_Entry, Constant_Pool_Entry] = {
                 case CONSTANT_Fieldref_info(_, name_and_type_index) => constantPool(name_and_type_index)
                 case CONSTANT_NameAndType_info(_, descriptor_index) => constantPool(descriptor_index)

--- a/TOOLS/hermes/src/main/scala/org/opalj/hermes/queries/MicroPatterns.scala
+++ b/TOOLS/hermes/src/main/scala/org/opalj/hermes/queries/MicroPatterns.scala
@@ -72,7 +72,7 @@ class MicroPatterns(implicit hermes: HermesConfig) extends FeatureQuery {
         project:              Project[S],
         rawClassFiles:        Iterable[(org.opalj.da.ClassFile, S)]
     ): IterableOnce[Feature[S]] = {
-        implicit val theProject = project
+        implicit val theProject: Project[S] = project
 
         val fa = project.get(FieldAccessInformationKey)
 

--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ ThisBuild / licenses := Seq("BSD-2-Clause" -> url("https://opensource.org/licens
 
 usePgpKeyHex("80B9D3FB5A8508F6B4774932E71AFF01E234090C")
 
-ThisBuild / scalaVersion := "2.13.10"
+ThisBuild / scalaVersion := "2.13.11"
 
 ScalacConfiguration.globalScalacOptions
 


### PR DESCRIPTION
Scala 2.13.11 changed some syntax for better source compatibility with Scala 3, improves the performance of some collections and improves support for the latest JDK versions: https://github.com/scala/scala/releases/tag/v2.13.11