### PR TITLE
Clean up CallGraphKey

### DIFF
--- a/DEVELOPING_OPAL/validate/src/test/scala/org/opalj/fpcf/FieldLocalityTests.scala
+++ b/DEVELOPING_OPAL/validate/src/test/scala/org/opalj/fpcf/FieldLocalityTests.scala
@@ -6,8 +6,6 @@ import java.net.URL
 
 import org.opalj.br.analyses.Project
 import org.opalj.br.fpcf.FPCFAnalysisScheduler
-import org.opalj.ai.domain.l1.DefaultDomainWithCFGAndDefUse
-import org.opalj.ai.fpcf.properties.AIDomainFactoryKey
 import org.opalj.tac.cg.RTACallGraphKey
 import org.opalj.tac.fpcf.analyses.EagerFieldLocalityAnalysis
 import org.opalj.tac.fpcf.analyses.escape.LazyInterProceduralEscapeAnalysis
@@ -26,9 +24,6 @@ class FieldLocalityTests extends PropertiesTest {
     }
 
     override def init(p: Project[URL]): Unit = {
-        p.updateProjectInformationKeyInitializationData(AIDomainFactoryKey) {
-            _ => Set(classOf[DefaultDomainWithCFGAndDefUse[URL]])
-        }
         p.get(RTACallGraphKey)
     }
 

--- a/OPAL/tac/src/main/scala/org/opalj/tac/cg/CallGraphKey.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/cg/CallGraphKey.scala
@@ -111,7 +111,7 @@ trait CallGraphKey extends ProjectInformationKey[CallGraph, Nothing] {
             implicit val logContext: LogContext = project.logContext
             OPALLogger.error(
                 "analysis configuration",
-                s"call graph was already computed, computing new call graph"
+                s"must not compute multiple call graphs"
             )
             throw new IllegalArgumentException()
         }

--- a/OPAL/tac/src/main/scala/org/opalj/tac/cg/CallGraphKey.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/cg/CallGraphKey.scala
@@ -111,7 +111,7 @@ trait CallGraphKey extends ProjectInformationKey[CallGraph, Nothing] {
             implicit val logContext: LogContext = project.logContext
             OPALLogger.error(
                 "analysis configuration",
-                s"call graphs was already computed, computing new call graph"
+                s"call graph was already computed, computing new call graph"
             )
             throw new IllegalArgumentException()
         }


### PR DESCRIPTION
Collect the analyses in a single place to remove code duplication and prevent inconsistencies

Free up the initialization data of the key for something more sensible