### PR TITLE
Improve l2.SharedValuesDomain

### DIFF
--- a/OPAL/ai/src/main/scala/org/opalj/ai/domain/l2/SharedValuesDomain.scala
+++ b/OPAL/ai/src/main/scala/org/opalj/ai/domain/l2/SharedValuesDomain.scala
@@ -39,8 +39,8 @@ class SharedDefaultDomain[Source](
         val method:  Method
 ) extends TheMethod
     with ThrowAllPotentialExceptionsConfiguration
-    with DefaultHandlingOfMethodResults
     with IgnoreSynchronization
+    with l0.DefaultTypeLevelHandlingOfMethodResults
     with l0.TypeLevelFieldAccessInstructions
     with l0.TypeLevelInvokeInstructions
     with l0.TypeLevelDynamicLoads

--- a/OPAL/tac/src/test/resources/org/opalj/tac/ai-complete-ai.domain.StringValues-build-l2.DefaultPerformInvocationsDomainWithCFGAndDefUse.tac.txt
+++ b/OPAL/tac/src/test/resources/org/opalj/tac/ai-complete-ai.domain.StringValues-build-l2.DefaultPerformInvocationsDomainWithCFGAndDefUse.tac.txt
@@ -19,4 +19,3 @@
 
 // 6 ->
 7:/*pc=24:*/ return {lv6}
-// ⚡️ <uncaught exception => abnormal return>

--- a/OPAL/tac/src/test/resources/org/opalj/tac/ai-complete-ai.domain.StringValues-sb-l2.DefaultPerformInvocationsDomainWithCFGAndDefUse.tac.txt
+++ b/OPAL/tac/src/test/resources/org/opalj/tac/ai-complete-ai.domain.StringValues-sb-l2.DefaultPerformInvocationsDomainWithCFGAndDefUse.tac.txt
@@ -31,4 +31,3 @@
 
 // 7 ->
 8:/*pc=37:*/ return {lv7}
-// ⚡️ <uncaught exception => abnormal return>


### PR DESCRIPTION
Use a domain that actually checks whether monitor instructions are used instead of declaring every method as capable of producing IllegalMonitorStateExceptions.