### PR TITLE
Add a CallGraphKey that doesn't compute a CG

### DIFF
--- a/OPAL/tac/src/main/scala/org/opalj/tac/cg/CallGraphKey.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/cg/CallGraphKey.scala
@@ -120,15 +120,18 @@ trait CallGraphKey extends ProjectInformationKey[CallGraph, Nothing] {
         implicit val typeIterator: TypeIterator = project.get(TypeIteratorKey)
         implicit val ps: PropertyStore = project.get(PropertyStoreKey)
 
-        val manager = project.get(FPCFAnalysesManagerKey)
-
-        manager.runAll(allCallGraphAnalyses(project))
+        runAnalyses(project, ps)
 
         val cg = new CallGraph()
 
         CallGraphKey.cg = Some(cg)
 
         cg
+    }
+
+    protected[this] def runAnalyses(project: SomeProject, ps: PropertyStore): Unit = {
+        val manager = project.get(FPCFAnalysesManagerKey)
+        manager.runAll(allCallGraphAnalyses(project))
     }
 
     private[this] def resolveAnalysisRunner(

--- a/OPAL/tac/src/main/scala/org/opalj/tac/cg/NoCallGraphKey.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/cg/NoCallGraphKey.scala
@@ -1,0 +1,41 @@
+/* BSD 2-Clause License - see OPAL/LICENSE for details. */
+package org.opalj
+package tac
+package cg
+
+import org.opalj.fpcf.PropertyStore
+import org.opalj.br.analyses.ProjectInformationKeys
+import org.opalj.br.analyses.SomeProject
+import org.opalj.br.fpcf.PropertyStoreKey
+import org.opalj.br.fpcf.properties.SimpleContextsKey
+import org.opalj.br.fpcf.FPCFAnalysesManagerKey
+import org.opalj.br.fpcf.FPCFAnalysisScheduler
+import org.opalj.tac.fpcf.analyses.cg.CHATypeIterator
+import org.opalj.tac.fpcf.properties.cg.OnlyCallersWithUnknownContext
+
+/**
+ * Pseudo CallGraphKey that can be used to declare methods reachable without computing a call graph.
+ * This will NOT provide any Callee properties!
+ *
+ * Methods deemed reachable are set via this key's initialization data. If not set, all methods of the project are used.
+ *
+ * Types are resolved using the CHATypeIterator, i.e., on the fly with CHA precision.
+ */
+object NoCallGraphKey extends CallGraphKey {
+
+    override def requirements(project: SomeProject): ProjectInformationKeys = {
+        Seq(PropertyStoreKey, FPCFAnalysesManagerKey, SimpleContextsKey)
+    }
+
+    override protected def callGraphSchedulers(project: SomeProject): Iterable[FPCFAnalysisScheduler] = List.empty
+
+    override def getTypeIterator(project: SomeProject) = new CHATypeIterator(project)
+
+    override protected def runAnalyses(project: SomeProject, ps: PropertyStore): Unit = {
+        val methods = project.getProjectInformationKeyInitializationData(this).getOrElse(project.allMethods)
+
+        methods.foreach { method =>
+            ps.set(method, OnlyCallersWithUnknownContext)
+        }
+    }
+}


### PR DESCRIPTION
This can be handy if an analysis depends on the reachable methods, but one does not need a full call graph.