### PR TITLE
Split context functions from TypeIterator

### DIFF
--- a/DEVELOPING_OPAL/demos/src/main/scala/org/opalj/tac/fpcf/analyses/taint/BackwardClassForNameTaintAnalysisScheduler.scala
+++ b/DEVELOPING_OPAL/demos/src/main/scala/org/opalj/tac/fpcf/analyses/taint/BackwardClassForNameTaintAnalysisScheduler.scala
@@ -11,6 +11,7 @@ import org.opalj.br.analyses.DeclaredMethodsKey
 import org.opalj.br.analyses.ProjectInformationKeys
 import org.opalj.br.analyses.SomeProject
 import org.opalj.br.fpcf.PropertyStoreKey
+import org.opalj.br.fpcf.properties.cg.Callers
 import org.opalj.fpcf.EPS
 import org.opalj.fpcf.FinalEP
 import org.opalj.fpcf.PropertyBounds
@@ -31,7 +32,6 @@ import org.opalj.tac.fpcf.analyses.ifds.taint.TaintFact
 import org.opalj.tac.fpcf.analyses.ifds.taint.Variable
 import org.opalj.tac.fpcf.analyses.ifds.taint.ArrayElement
 import org.opalj.tac.fpcf.analyses.ifds.taint.InstanceField
-import org.opalj.tac.fpcf.properties.cg.Callers
 import org.opalj.tac.fpcf.properties.TACAI
 import org.opalj.tac.fpcf.properties.Taint
 

--- a/DEVELOPING_OPAL/demos/src/main/scala/org/opalj/tac/fpcf/analyses/taint/ForwardClassForNameTaintAnalysisScheduler.scala
+++ b/DEVELOPING_OPAL/demos/src/main/scala/org/opalj/tac/fpcf/analyses/taint/ForwardClassForNameTaintAnalysisScheduler.scala
@@ -5,21 +5,18 @@ package fpcf
 package analyses
 package taint
 
+import java.io.File
+
+import org.opalj.fpcf.PropertyBounds
+import org.opalj.fpcf.PropertyStore
 import org.opalj.br.analyses.DeclaredMethodsKey
 import org.opalj.br.analyses.ProjectInformationKeys
 import org.opalj.br.analyses.SomeProject
 import org.opalj.br.fpcf.PropertyStoreKey
+import org.opalj.br.fpcf.properties.cg.Callers
 import org.opalj.br.DeclaredMethod
 import org.opalj.br.Method
 import org.opalj.br.ObjectType
-import org.opalj.fpcf.PropertyBounds
-import org.opalj.fpcf.PropertyStore
-import org.opalj.ifds.Callable
-import org.opalj.ifds.IFDSAnalysis
-import org.opalj.ifds.IFDSAnalysisScheduler
-import org.opalj.ifds.IFDSFact
-import org.opalj.ifds.IFDSProperty
-import org.opalj.ifds.IFDSPropertyMetaInformation
 import org.opalj.tac.cg.RTACallGraphKey
 import org.opalj.tac.cg.TypeIteratorKey
 import org.opalj.tac.fpcf.analyses.ifds.IFDSEvaluationRunner
@@ -30,11 +27,14 @@ import org.opalj.tac.fpcf.analyses.ifds.taint.FlowFact
 import org.opalj.tac.fpcf.analyses.ifds.taint.TaintFact
 import org.opalj.tac.fpcf.analyses.ifds.taint.TaintProblem
 import org.opalj.tac.fpcf.analyses.ifds.taint.Variable
-import org.opalj.tac.fpcf.properties.cg.Callers
 import org.opalj.tac.fpcf.properties.TACAI
 import org.opalj.tac.fpcf.properties.Taint
-
-import java.io.File
+import org.opalj.ifds.Callable
+import org.opalj.ifds.IFDSAnalysis
+import org.opalj.ifds.IFDSAnalysisScheduler
+import org.opalj.ifds.IFDSFact
+import org.opalj.ifds.IFDSProperty
+import org.opalj.ifds.IFDSPropertyMetaInformation
 
 /**
  * A forward IFDS taint analysis which tracks the String parameters of all methods of the rt.jar

--- a/DEVELOPING_OPAL/tools/src/main/scala/org/opalj/support/info/CallGraph.scala
+++ b/DEVELOPING_OPAL/tools/src/main/scala/org/opalj/support/info/CallGraph.scala
@@ -26,8 +26,6 @@ import org.opalj.br.analyses.Project
 import org.opalj.br.analyses.ProjectAnalysisApplication
 import org.opalj.br.analyses.VirtualFormalParameter
 import org.opalj.br.fpcf.PropertyStoreKey
-import org.opalj.tac.fpcf.properties.cg.Callees
-import org.opalj.tac.fpcf.properties.cg.Callers
 import org.opalj.br.fpcf.properties.pointsto.AllocationSitePointsToSet
 import org.opalj.br.Field
 import org.opalj.br.analyses.cg.InitialEntryPointsKey
@@ -37,6 +35,10 @@ import org.opalj.ai.fpcf.properties.AIDomainFactoryKey
 import org.opalj.ai.Domain
 import org.opalj.ai.domain.RecordDefUse
 import org.opalj.fpcf.seq.PKESequentialPropertyStore
+import org.opalj.br.fpcf.analyses.ContextProvider
+import org.opalj.br.fpcf.properties.cg.Callees
+import org.opalj.br.fpcf.properties.cg.Callers
+import org.opalj.br.fpcf.ContextProviderKey
 import org.opalj.tac.cg.AllocationSiteBasedPointsToCallGraphKey
 import org.opalj.tac.cg.CallGraphSerializer
 import org.opalj.tac.cg.CFA_1_0_CallGraphKey
@@ -47,10 +49,8 @@ import org.opalj.tac.cg.FTACallGraphKey
 import org.opalj.tac.cg.MTACallGraphKey
 import org.opalj.tac.cg.RTACallGraphKey
 import org.opalj.tac.cg.TypeBasedPointsToCallGraphKey
-import org.opalj.tac.cg.TypeIteratorKey
 import org.opalj.tac.cg.XTACallGraphKey
 import org.opalj.tac.common.DefinitionSite
-import org.opalj.tac.fpcf.analyses.cg.TypeIterator
 import org.opalj.tac.fpcf.analyses.pointsto.ArrayEntity
 import org.opalj.tac.fpcf.analyses.pointsto.CallExceptions
 import org.opalj.tac.fpcf.analyses.pointsto.MethodExceptions
@@ -242,7 +242,7 @@ object CallGraph extends ProjectAnalysisApplication {
         println(calleesSigs.mkString("\n"))
         println(callersSigs.mkString("\n"))
 
-        implicit val typeIterator: TypeIterator = project.get(TypeIteratorKey)
+        implicit val contextProvider: ContextProvider = project.get(ContextProviderKey)
 
         for (m <- allMethods) {
             val mSig = m.descriptor.toJava(m.name)

--- a/DEVELOPING_OPAL/tools/src/main/scala/org/opalj/support/info/Purity.scala
+++ b/DEVELOPING_OPAL/tools/src/main/scala/org/opalj/support/info/Purity.scala
@@ -44,8 +44,6 @@ import org.opalj.br.DefinedMethod
 import org.opalj.br.analyses.DeclaredMethodsKey
 import org.opalj.br.analyses.Project
 import org.opalj.br.analyses.Project.JavaClassFileReader
-import org.opalj.tac.fpcf.properties.cg.Callers
-import org.opalj.tac.fpcf.properties.cg.NoCallers
 import org.opalj.ai.Domain
 import org.opalj.ai.domain
 import org.opalj.ai.domain.RecordDefUse
@@ -58,11 +56,13 @@ import org.opalj.fpcf.PropertyStoreContext
 import org.opalj.fpcf.seq.PKESequentialPropertyStore
 import org.opalj.log.LogContext
 import org.opalj.br.fpcf.properties.Context
+import org.opalj.br.fpcf.ContextProviderKey
+import org.opalj.br.fpcf.properties.cg.Callers
+import org.opalj.br.fpcf.properties.cg.NoCallers
 import org.opalj.tac.cg.CallGraphKey
 import org.opalj.tac.cg.AllocationSiteBasedPointsToCallGraphKey
 import org.opalj.tac.cg.CHACallGraphKey
 import org.opalj.tac.cg.RTACallGraphKey
-import org.opalj.tac.cg.TypeIteratorKey
 import org.opalj.tac.fpcf.analyses.LazyFieldImmutabilityAnalysis
 import org.opalj.tac.fpcf.analyses.LazyFieldLocalityAnalysis
 import org.opalj.tac.fpcf.analyses.escape.LazyInterProceduralEscapeAnalysis
@@ -246,8 +246,8 @@ object Purity {
                 case FinalEP(m: DeclaredMethod, c: Callers) if c ne NoCallers => m
             }.toSet
 
-        val typeIterator = project.get(TypeIteratorKey)
-        val analyzedContexts = projMethods.filter(reachableMethods.contains).map(typeIterator.newContext(_))
+        val contextProvider = project.get(ContextProviderKey)
+        val analyzedContexts = projMethods.filter(reachableMethods.contains).map(contextProvider.newContext(_))
 
         time {
             val analyses = analysis :: support

--- a/DEVELOPING_OPAL/validate/src/it/scala/org/opalj/tac/fpcf/analyses/cg/CallGraphIntegrationTest.scala
+++ b/DEVELOPING_OPAL/validate/src/it/scala/org/opalj/tac/fpcf/analyses/cg/CallGraphIntegrationTest.scala
@@ -18,21 +18,22 @@ import org.opalj.fpcf.FinalP
 import org.opalj.fpcf.PropertyStore
 import org.opalj.br.DeclaredMethod
 import org.opalj.br.analyses.DeclaredMethodsKey
-import org.opalj.tac.fpcf.properties.cg.Callees
-import org.opalj.tac.fpcf.properties.cg.Callers
 import org.opalj.br.TestSupport.allBIProjects
 import org.opalj.br.analyses.cg.ClassExtensibilityKey
 import org.opalj.br.analyses.cg.ClosedPackagesKey
 import org.opalj.br.analyses.cg.IsOverridableMethodKey
 import org.opalj.br.analyses.cg.TypeExtensibilityKey
 import org.opalj.br.analyses.Project
-import org.opalj.tac.fpcf.properties.cg.NoCallers
 import org.opalj.br.fpcf.PropertyStoreKey
+import org.opalj.br.fpcf.analyses.ContextProvider
+import org.opalj.br.fpcf.properties.cg.Callees
+import org.opalj.br.fpcf.properties.cg.Callers
+import org.opalj.br.fpcf.properties.cg.NoCallers
+import org.opalj.br.fpcf.ContextProviderKey
 import org.opalj.tac.cg.CallGraph
 import org.opalj.tac.cg.CHACallGraphKey
 import org.opalj.tac.cg.RTACallGraphKey
 import org.opalj.tac.cg.TypeBasedPointsToCallGraphKey
-import org.opalj.tac.cg.TypeIteratorKey
 
 @RunWith(classOf[JUnitRunner]) // TODO: We should use JCG for some basic tests
 class CallGraphIntegrationTest extends AnyFlatSpec with Matchers {
@@ -70,7 +71,7 @@ class CallGraphIntegrationTest extends AnyFlatSpec with Matchers {
             chaPS = project.get(PropertyStoreKey)
             cha = project.get(CHACallGraphKey)
 
-            checkBidirectionCallerCallee(chaPS)(project.get(TypeIteratorKey))
+            checkBidirectionCallerCallee(chaPS)(project.get(ContextProviderKey))
         }
 
         it should s"have matching callers and callees for RTA" in {
@@ -83,13 +84,13 @@ class CallGraphIntegrationTest extends AnyFlatSpec with Matchers {
             rtaPS = rtaProject.get(PropertyStoreKey)
             rta = rtaProject.get(RTACallGraphKey)
 
-            checkBidirectionCallerCallee(rtaPS)(rtaProject.get(TypeIteratorKey))
+            checkBidirectionCallerCallee(rtaPS)(rtaProject.get(ContextProviderKey))
         }
 
         it should s"have RTA more precise than CHA" in {
-            val lessPrecisetypeIterator = project.get(TypeIteratorKey)
-            val morePrecisetypeIterator = rtaProject.get(TypeIteratorKey)
-            checkMorePrecise(cha, rta, chaPS, morePrecisetypeIterator, lessPrecisetypeIterator)
+            val lessPreciseContextProvider = project.get(ContextProviderKey)
+            val morePreciseContextProvider = rtaProject.get(ContextProviderKey)
+            checkMorePrecise(cha, rta, chaPS, morePreciseContextProvider, lessPreciseContextProvider)
         }
 
         project = null
@@ -106,22 +107,22 @@ class CallGraphIntegrationTest extends AnyFlatSpec with Matchers {
             val pointsToPS = pointsToProject.get(PropertyStoreKey)
             pointsTo = pointsToProject.get(TypeBasedPointsToCallGraphKey)
 
-            checkBidirectionCallerCallee(pointsToPS)(pointsToProject.get(TypeIteratorKey))
+            checkBidirectionCallerCallee(pointsToPS)(pointsToProject.get(ContextProviderKey))
         }
 
         it should s"have PointsTo more precise than RTA" in {
-            val lessPrecisetypeIterator = rtaProject.get(TypeIteratorKey)
-            val morePrecisetypeIterator = pointsToProject.get(TypeIteratorKey)
-            checkMorePrecise(rta, pointsTo, rtaPS, morePrecisetypeIterator, lessPrecisetypeIterator)
+            val lessPreciseContextProvider = rtaProject.get(ContextProviderKey)
+            val morePreciseContextProvider = pointsToProject.get(ContextProviderKey)
+            checkMorePrecise(rta, pointsTo, rtaPS, morePreciseContextProvider, lessPreciseContextProvider)
         }
     }
 
     def checkMorePrecise(
-        lessPreciseCG:           CallGraph,
-        morePreciseCG:           CallGraph,
-        lessPreciseCGPS:         PropertyStore,
-        morePrecisetypeIterator: TypeIterator,
-        lessPrecisetypeIterator: TypeIterator
+        lessPreciseCG:              CallGraph,
+        morePreciseCG:              CallGraph,
+        lessPreciseCGPS:            PropertyStore,
+        morePreciseContextProvider: ContextProvider,
+        lessPreciseContextProvider: ContextProvider
     ): Unit = {
         var unexpectedCalls: List[UnexpectedCallTarget] = Nil
         morePreciseCG.reachableMethods().foreach { context =>
@@ -129,7 +130,7 @@ class CallGraphIntegrationTest extends AnyFlatSpec with Matchers {
             val callersLPCG = lessPreciseCG.callersPropertyOf(method)
             val callersMPCG = morePreciseCG.callersPropertyOf(method)
             if ((callersLPCG eq NoCallers) &&
-                !callersMPCG.callers(method)(morePrecisetypeIterator).iterator.forall {
+                !callersMPCG.callers(method)(morePreciseContextProvider).iterator.forall {
                     callSite =>
                         val callees = lessPreciseCG.calleesPropertyOf(callSite._1)
                         !callSite._3 &&
@@ -144,7 +145,7 @@ class CallGraphIntegrationTest extends AnyFlatSpec with Matchers {
                 (pc, calleesMPCG) <- allCalleesMPCG
                 calleesLPCG = lessPreciseCG.calleesPropertyOf(method)
                 if !calleesLPCG.isIncompleteCallSite(context, pc)(lessPreciseCGPS)
-                allCalleesLPCG = calleesLPCG.callees(context, pc)(lessPreciseCGPS, lessPrecisetypeIterator).toSet
+                allCalleesLPCG = calleesLPCG.callees(context, pc)(lessPreciseCGPS, lessPreciseContextProvider).toSet
                 calleeMPCG <- calleesMPCG
                 if !allCalleesLPCG(calleeMPCG)
             } {
@@ -160,7 +161,7 @@ class CallGraphIntegrationTest extends AnyFlatSpec with Matchers {
 
     def checkBidirectionCallerCallee(
         propertyStore: PropertyStore
-    )(implicit typeIterator: TypeIterator): Unit = {
+    )(implicit contextProvider: ContextProvider): Unit = {
         implicit val ps: PropertyStore = propertyStore
         for {
             FinalEP(dm: DeclaredMethod, callees) <- propertyStore.entities(Callees.key).map(_.asFinal)

--- a/DEVELOPING_OPAL/validate/src/test/scala/org/opalj/fpcf/CallGraphTests.scala
+++ b/DEVELOPING_OPAL/validate/src/test/scala/org/opalj/fpcf/CallGraphTests.scala
@@ -12,13 +12,13 @@ import org.opalj.br.analyses.cg.InitialInstantiatedTypesKey
 import org.opalj.br.fpcf.FPCFAnalysis
 import org.opalj.fpcf.properties.callgraph.TypePropagationVariant
 import org.opalj.br.analyses.Project
+import org.opalj.br.fpcf.ContextProviderKey
 import org.opalj.tac.cg.CallGraphKey
 import org.opalj.tac.cg.CHACallGraphKey
 import org.opalj.tac.cg.CTACallGraphKey
 import org.opalj.tac.cg.FTACallGraphKey
 import org.opalj.tac.cg.MTACallGraphKey
 import org.opalj.tac.cg.RTACallGraphKey
-import org.opalj.tac.cg.TypeIteratorKey
 import org.opalj.tac.cg.XTACallGraphKey
 import org.opalj.tac.fpcf.analyses.cg.reflection.ReflectionRelatedCallsAnalysisScheduler
 import org.opalj.tac.fpcf.analyses.cg.rta.InstantiatedTypesAnalysisScheduler
@@ -59,7 +59,7 @@ class CallGraphTests extends PropertiesTest {
     var cgKey: CallGraphKey = null
 
     override def init(p: Project[URL]): Unit = {
-        p.updateProjectInformationKeyInitializationData(TypeIteratorKey) {
+        p.updateProjectInformationKeyInitializationData(ContextProviderKey) {
             case Some(_) => throw new IllegalArgumentException()
             case None    => cgKey.getTypeIterator(p)
         }

--- a/DEVELOPING_OPAL/validate/src/test/scala/org/opalj/fpcf/CallGraphTests.scala
+++ b/DEVELOPING_OPAL/validate/src/test/scala/org/opalj/fpcf/CallGraphTests.scala
@@ -61,7 +61,7 @@ class CallGraphTests extends PropertiesTest {
     override def init(p: Project[URL]): Unit = {
         p.updateProjectInformationKeyInitializationData(TypeIteratorKey) {
             case Some(_) => throw new IllegalArgumentException()
-            case None    => () => cgKey.getTypeIterator(p)
+            case None    => cgKey.getTypeIterator(p)
         }
     }
 

--- a/DEVELOPING_OPAL/validate/src/test/scala/org/opalj/fpcf/ifds/IFDSBasedVariableTypeAnalysis.scala
+++ b/DEVELOPING_OPAL/validate/src/test/scala/org/opalj/fpcf/ifds/IFDSBasedVariableTypeAnalysis.scala
@@ -3,27 +3,27 @@ package org.opalj
 package fpcf
 package ifds
 
+import java.io.File
+import java.io.PrintWriter
+
+import org.opalj.fpcf.PropertyBounds
+import org.opalj.fpcf.PropertyKey
+import org.opalj.fpcf.PropertyStore
 import org.opalj.br.Method
 import org.opalj.br.analyses.DeclaredMethodsKey
 import org.opalj.br.analyses.ProjectInformationKeys
 import org.opalj.br.analyses.SomeProject
 import org.opalj.br.fpcf.PropertyStoreKey
-import org.opalj.fpcf.PropertyBounds
-import org.opalj.fpcf.PropertyKey
-import org.opalj.fpcf.PropertyStore
+import org.opalj.br.fpcf.properties.cg.Callers
+import org.opalj.br.fpcf.ContextProviderKey
+import org.opalj.tac.fpcf.analyses.ifds.IFDSEvaluationRunner
+import org.opalj.tac.fpcf.analyses.ifds.JavaStatement
+import org.opalj.tac.fpcf.properties.TACAI
 import org.opalj.ifds.IFDSAnalysis
 import org.opalj.ifds.IFDSAnalysisScheduler
 import org.opalj.ifds.IFDSProperty
 import org.opalj.ifds.IFDSPropertyMetaInformation
 import org.opalj.ifds.Statistics
-import org.opalj.tac.cg.TypeIteratorKey
-import org.opalj.tac.fpcf.analyses.ifds.IFDSEvaluationRunner
-import org.opalj.tac.fpcf.analyses.ifds.JavaStatement
-import org.opalj.tac.fpcf.properties.TACAI
-import org.opalj.tac.fpcf.properties.cg.Callers
-
-import java.io.File
-import java.io.PrintWriter
 
 /**
  * A variable type analysis implemented as an IFDS analysis.
@@ -32,6 +32,7 @@ import java.io.PrintWriter
  * The subsuming taint can be mixed in to enable subsuming.
  *
  * @param project The analyzed project.
+ *
  * @author Mario Trageser
  */
 class IFDSBasedVariableTypeAnalysis(project: SomeProject, subsumeFacts: Boolean = false)
@@ -41,7 +42,7 @@ class IFDSBasedVariableTypeAnalysisScheduler(subsumeFacts: Boolean = false) exte
     override def init(p: SomeProject, ps: PropertyStore) = new IFDSBasedVariableTypeAnalysis(p, subsumeFacts)
     override def property: IFDSPropertyMetaInformation[JavaStatement, VTAFact] = VTAResult
     override val uses: Set[PropertyBounds] = Set(PropertyBounds.finalP(TACAI), PropertyBounds.finalP(Callers))
-    override def requiredProjectInformation: ProjectInformationKeys = Seq(DeclaredMethodsKey, TypeIteratorKey, PropertyStoreKey)
+    override def requiredProjectInformation: ProjectInformationKeys = Seq(DeclaredMethodsKey, ContextProviderKey, PropertyStoreKey)
 }
 
 /**

--- a/DEVELOPING_OPAL/validate/src/test/scala/org/opalj/fpcf/ifds/VariableTypeProblem.scala
+++ b/DEVELOPING_OPAL/validate/src/test/scala/org/opalj/fpcf/ifds/VariableTypeProblem.scala
@@ -3,6 +3,12 @@ package org.opalj
 package fpcf
 package ifds
 
+import scala.annotation.tailrec
+
+import org.opalj.collection.immutable.EmptyIntTrieSet
+import org.opalj.fpcf.FinalEP
+import org.opalj.fpcf.PropertyStore
+import org.opalj.value.ValueInformation
 import org.opalj.br.ArrayType
 import org.opalj.br.ClassFile
 import org.opalj.br.FieldType
@@ -12,14 +18,7 @@ import org.opalj.br.analyses.DeclaredMethods
 import org.opalj.br.analyses.DeclaredMethodsKey
 import org.opalj.br.analyses.SomeProject
 import org.opalj.br.fpcf.PropertyStoreKey
-import org.opalj.collection.immutable.EmptyIntTrieSet
-import org.opalj.fpcf.FinalEP
-import org.opalj.fpcf.PropertyStore
-import org.opalj.ifds.AbstractIFDSFact
-import org.opalj.ifds.AbstractIFDSNullFact
-import org.opalj.ifds.Callable
-import org.opalj.ifds.Dependees.Getter
-import org.opalj.ifds.IFDSFact
+import org.opalj.br.fpcf.properties.cg.Callers
 import org.opalj.tac.ArrayLoad
 import org.opalj.tac.ArrayStore
 import org.opalj.tac.Assignment
@@ -33,10 +32,11 @@ import org.opalj.tac.Var
 import org.opalj.tac.fpcf.analyses.ifds.JavaForwardIFDSProblem
 import org.opalj.tac.fpcf.analyses.ifds.JavaIFDSProblem
 import org.opalj.tac.fpcf.analyses.ifds.JavaStatement
-import org.opalj.tac.fpcf.properties.cg.Callers
-import org.opalj.value.ValueInformation
-
-import scala.annotation.tailrec
+import org.opalj.ifds.AbstractIFDSFact
+import org.opalj.ifds.AbstractIFDSNullFact
+import org.opalj.ifds.Callable
+import org.opalj.ifds.Dependees.Getter
+import org.opalj.ifds.IFDSFact
 
 trait VTAFact extends AbstractIFDSFact
 case object VTANullFact extends VTAFact with AbstractIFDSNullFact

--- a/DEVELOPING_OPAL/validate/src/test/scala/org/opalj/fpcf/properties/callgraph/AvailableTypesMatcher.scala
+++ b/DEVELOPING_OPAL/validate/src/test/scala/org/opalj/fpcf/properties/callgraph/AvailableTypesMatcher.scala
@@ -10,7 +10,7 @@ import org.opalj.br.ObjectType
 import org.opalj.br.ReferenceType
 import org.opalj.br.analyses.Project
 import org.opalj.br.fpcf.PropertyStoreKey
-import org.opalj.tac.fpcf.properties.cg.InstantiatedTypes
+import org.opalj.br.fpcf.properties.cg.InstantiatedTypes
 import org.opalj.collection.immutable.UIDSet
 import org.opalj.log.LogContext
 import org.opalj.log.OPALLogger

--- a/DEVELOPING_OPAL/validate/src/test/scala/org/opalj/fpcf/properties/callgraph/DirectCallMatcher.scala
+++ b/DEVELOPING_OPAL/validate/src/test/scala/org/opalj/fpcf/properties/callgraph/DirectCallMatcher.scala
@@ -17,11 +17,11 @@ import org.opalj.br.StringValue
 import org.opalj.br.VoidType
 import org.opalj.br.analyses.Project
 import org.opalj.br.fpcf.PropertyStoreKey
-import org.opalj.tac.cg.TypeIteratorKey
-import org.opalj.tac.fpcf.analyses.cg.TypeIterator
-import org.opalj.tac.fpcf.properties.cg.Callees
-
+import org.opalj.br.fpcf.ContextProviderKey
+import org.opalj.br.fpcf.properties.cg.Callees
 import scala.collection.immutable.ArraySeq
+
+import org.opalj.br.fpcf.analyses.ContextProvider
 
 class DirectCallMatcher extends AbstractPropertyMatcher {
 
@@ -84,7 +84,7 @@ class DirectCallMatcher extends AbstractPropertyMatcher {
             return None;
 
         implicit val ps: PropertyStore = p.get(PropertyStoreKey)
-        implicit val typeIterator: TypeIterator = p.get(TypeIteratorKey)
+        implicit val contextProvider: ContextProvider = p.get(ContextProviderKey)
 
         val calleesP = {
             properties.find(_.isInstanceOf[Callees]) match {

--- a/OPAL/br/src/main/scala/org/opalj/br/fpcf/ContextProviderKey.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/fpcf/ContextProviderKey.scala
@@ -1,0 +1,37 @@
+/* BSD 2-Clause License - see OPAL/LICENSE for details. */
+package org.opalj
+package br
+package fpcf
+
+import org.opalj.log.LogContext
+import org.opalj.log.OPALLogger
+import org.opalj.br.analyses.ProjectInformationKey
+import org.opalj.br.analyses.ProjectInformationKeys
+import org.opalj.br.analyses.SomeProject
+import org.opalj.br.fpcf.analyses.ContextProvider
+import org.opalj.br.fpcf.analyses.SimpleContextProvider
+
+/**
+ *  An [[org.opalj.br.analyses.ProjectInformationKey]] to get the
+ *  [[org.opalj.br.fpcf.analyses.ContextProvider]] used to compute the current project's call graph.
+ *  This key is intended to be set up by a corresponding [[org.opalj.tac.cg.TypeIteratorKey]].
+ */
+object ContextProviderKey extends ProjectInformationKey[ContextProvider, ContextProvider] {
+
+    override def requirements(project: SomeProject): ProjectInformationKeys = Nil
+
+    override def compute(theProject: SomeProject): ContextProvider = {
+        theProject.getProjectInformationKeyInitializationData(this) match {
+            case Some(contextProvider: ContextProvider) => contextProvider
+            case None =>
+                implicit val logContext: LogContext = theProject.logContext
+                OPALLogger.warn(
+                    "analysis configuration",
+                    s"no context provider configured, using SimpleContextProvider as a fallback"
+                )
+                new SimpleContextProvider {
+                    override val project: SomeProject = theProject
+                }
+        }
+    }
+}

--- a/OPAL/br/src/main/scala/org/opalj/br/fpcf/analyses/ContextProvider.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/fpcf/analyses/ContextProvider.scala
@@ -36,8 +36,8 @@ trait SimpleContextProvider extends ContextProvider {
 
     override type ContextType = SimpleContext
 
-    protected[this] implicit val declaredMethods: DeclaredMethods = project.get(DeclaredMethodsKey)
-    private[this] val simpleContexts: SimpleContexts = project.get(SimpleContextsKey)
+    protected[this] implicit lazy val declaredMethods: DeclaredMethods = project.get(DeclaredMethodsKey)
+    private[this] lazy val simpleContexts: SimpleContexts = project.get(SimpleContextsKey)
 
     @inline def newContext(method: DeclaredMethod): SimpleContext = simpleContexts(method)
 
@@ -60,7 +60,7 @@ trait CallStringContextProvider extends ContextProvider {
 
     val k: Int
 
-    private[this] val callStringContexts: CallStringContexts = project.get(CallStringContextsKey)
+    private[this] lazy val callStringContexts: CallStringContexts = project.get(CallStringContextsKey)
 
     @inline def newContext(method: DeclaredMethod): CallStringContext =
         callStringContexts(method, Nil)

--- a/OPAL/br/src/main/scala/org/opalj/br/fpcf/analyses/ContextProvider.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/fpcf/analyses/ContextProvider.scala
@@ -1,0 +1,87 @@
+/* BSD 2-Clause License - see OPAL/LICENSE for details. */
+package org.opalj
+package br
+package fpcf
+package analyses
+
+import org.opalj.br.analyses.DeclaredMethods
+import org.opalj.br.analyses.DeclaredMethodsKey
+import org.opalj.br.analyses.SomeProject
+import org.opalj.br.fpcf.properties.CallStringContext
+import org.opalj.br.fpcf.properties.CallStringContexts
+import org.opalj.br.fpcf.properties.CallStringContextsKey
+import org.opalj.br.fpcf.properties.NoContext
+import org.opalj.br.fpcf.properties.SimpleContext
+import org.opalj.br.fpcf.properties.SimpleContexts
+import org.opalj.br.fpcf.properties.SimpleContextsKey
+import org.opalj.br.fpcf.properties.Context
+
+/**
+ * Provides analyses with [[Context]]s for method executions.
+ */
+trait ContextProvider {
+
+    type ContextType <: Context
+
+    val project: SomeProject
+
+    def newContext(method: DeclaredMethod): ContextType
+
+    def expandContext(oldContext: Context, method: DeclaredMethod, pc: Int): ContextType
+
+    def contextFromId(contextId: Int): Context
+}
+
+trait SimpleContextProvider extends ContextProvider {
+
+    override type ContextType = SimpleContext
+
+    protected[this] implicit val declaredMethods: DeclaredMethods = project.get(DeclaredMethodsKey)
+    private[this] val simpleContexts: SimpleContexts = project.get(SimpleContextsKey)
+
+    @inline def newContext(method: DeclaredMethod): SimpleContext = simpleContexts(method)
+
+    @inline def expandContext(
+        oldContext: Context,
+        method:     DeclaredMethod,
+        pc:         Int
+    ): SimpleContext =
+        simpleContexts(method)
+
+    @inline def contextFromId(contextId: Int): Context = {
+        if (contextId == -1) NoContext
+        else simpleContexts(declaredMethods(contextId))
+    }
+}
+
+trait CallStringContextProvider extends ContextProvider {
+
+    override type ContextType = CallStringContext
+
+    val k: Int
+
+    private[this] val callStringContexts: CallStringContexts = project.get(CallStringContextsKey)
+
+    @inline def newContext(method: DeclaredMethod): CallStringContext =
+        callStringContexts(method, Nil)
+
+    @inline override def expandContext(
+        oldContext: Context,
+        method:     DeclaredMethod,
+        pc:         Int
+    ): CallStringContext = {
+        oldContext match {
+            case csc: CallStringContext =>
+                callStringContexts(method, (oldContext.method, pc) :: csc.callString.take(k - 1))
+            case _ if oldContext.hasContext =>
+                callStringContexts(method, List((oldContext.method, pc)))
+            case _ =>
+                callStringContexts(method, Nil)
+        }
+    }
+
+    @inline override def contextFromId(contextId: Int): Context = {
+        if (contextId == -1) NoContext
+        else callStringContexts(contextId)
+    }
+}

--- a/OPAL/br/src/main/scala/org/opalj/br/fpcf/properties/cg/ForNameClasses.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/fpcf/properties/cg/ForNameClasses.scala
@@ -1,6 +1,6 @@
 /* BSD 2-Clause License - see OPAL/LICENSE for details. */
 package org.opalj
-package tac
+package br
 package fpcf
 package properties
 package cg
@@ -14,32 +14,30 @@ import org.opalj.fpcf.PropertyIsNotDerivedByPreviouslyExecutedAnalysis
 import org.opalj.fpcf.PropertyKey
 import org.opalj.fpcf.PropertyMetaInformation
 import org.opalj.fpcf.PropertyStore
-import org.opalj.br.ObjectType
 
-sealed trait LoadedClassesMetaInformation extends PropertyMetaInformation {
-    final type Self = LoadedClasses
+sealed trait ForNameClassesMetaInformation extends PropertyMetaInformation {
+    final type Self = ForNameClasses
 }
 
 /**
- * Represent the set of types (classes) that were loaded by the VM during execution of the
- * respective [[org.opalj.br.analyses.Project]] (which is the entity for this property).
+ * Represent the set of types (classes) that were loaded via a particular call to Class.forName.
  *
- * @author Florian Kuebler
+ * @author Dominik Helm
  */
-sealed class LoadedClasses private[properties] (
-        final val orderedClasses: List[ObjectType],
-        final val classes:        UIDSet[ObjectType]
-) extends OrderedProperty with LoadedClassesMetaInformation {
+sealed class ForNameClasses private[properties] (
+        final val orderedClasses: List[ReferenceType],
+        final val classes:        UIDSet[ReferenceType]
+) extends OrderedProperty with ForNameClassesMetaInformation {
 
     assert(orderedClasses == null || orderedClasses.size == classes.size)
 
-    override def checkIsEqualOrBetterThan(e: Entity, other: LoadedClasses): Unit = {
+    override def checkIsEqualOrBetterThan(e: Entity, other: ForNameClasses): Unit = {
         if (other.classes != null && !classes.subsetOf(other.classes)) {
             throw new IllegalArgumentException(s"$e: illegal refinement of $other to $this")
         }
     }
 
-    def updated(newClasses: IterableOnce[ObjectType]): LoadedClasses = {
+    def updated(newClasses: IterableOnce[ReferenceType]): ForNameClasses = {
         var updatedOrderedClasses = orderedClasses
         var updatedClasses = classes
         for { c <- newClasses.iterator } {
@@ -49,39 +47,39 @@ sealed class LoadedClasses private[properties] (
                 updatedClasses = nextUpdatedClasses
             }
         }
-        new LoadedClasses(updatedOrderedClasses, updatedClasses)
+        new ForNameClasses(updatedOrderedClasses, updatedClasses)
     }
 
     /**
      * Will return the loaded classes added most recently, dropping the `num` oldest ones.
      */
-    def dropOldest(num: Int): Iterator[ObjectType] = {
+    def dropOldest(num: Int): Iterator[ReferenceType] = {
         orderedClasses.iterator.take(classes.size - num)
     }
 
     def size: Int = classes.size
 
-    override def key: PropertyKey[LoadedClasses] = LoadedClasses.key
+    override def key: PropertyKey[ForNameClasses] = ForNameClasses.key
 
-    override def toString: String = s"LoadedClasses(${classes.size})"
+    override def toString: String = s"ForNameClasses(${classes.size})"
 }
 
-object NoLoadedClasses extends LoadedClasses(classes = UIDSet.empty, orderedClasses = List.empty)
+object NoForNameClasses extends ForNameClasses(classes = UIDSet.empty, orderedClasses = List.empty)
 
-object LoadedClasses extends LoadedClassesMetaInformation {
+object ForNameClasses extends ForNameClassesMetaInformation {
 
-    def apply(classes: UIDSet[ObjectType]): LoadedClasses = {
-        new LoadedClasses(classes.toList, classes)
+    def apply(classes: UIDSet[ReferenceType]): ForNameClasses = {
+        new ForNameClasses(classes.toList, classes)
     }
 
-    final val key: PropertyKey[LoadedClasses] = {
-        val name = "opalj.LoadedClasses"
+    final val key: PropertyKey[ForNameClasses] = {
+        val name = "opalj.ForNameClasses"
         PropertyKey.create(
             name,
             (ps: PropertyStore, reason: FallbackReason, _: Entity) => reason match {
                 case PropertyIsNotDerivedByPreviouslyExecutedAnalysis =>
-                    OPALLogger.error("call graph analysis", "there was no class loaded")(ps.logContext)
-                    NoLoadedClasses
+                    OPALLogger.error("call graph analysis", "no analysis executed for Class.forName")(ps.logContext)
+                    NoForNameClasses
                 case _ =>
                     throw new IllegalStateException(s"analysis required for property: $name")
             }

--- a/OPAL/br/src/main/scala/org/opalj/br/fpcf/properties/cg/InstantiatedTypes.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/fpcf/properties/cg/InstantiatedTypes.scala
@@ -1,14 +1,14 @@
 /* BSD 2-Clause License - see OPAL/LICENSE for details. */
 package org.opalj
-package tac
+package br
 package fpcf
 package properties
 package cg
 
 import org.opalj.collection.immutable.UIDSet
+import org.opalj.fpcf.Entity
 import org.opalj.fpcf.EOptionP
 import org.opalj.fpcf.EPK
-import org.opalj.fpcf.Entity
 import org.opalj.fpcf.FallbackReason
 import org.opalj.fpcf.InterimEP
 import org.opalj.fpcf.InterimEUBP
@@ -18,7 +18,6 @@ import org.opalj.fpcf.PropertyIsNotDerivedByPreviouslyExecutedAnalysis
 import org.opalj.fpcf.PropertyKey
 import org.opalj.fpcf.PropertyMetaInformation
 import org.opalj.fpcf.PropertyStore
-import org.opalj.br.ReferenceType
 
 /**
  * Represent the set of types that have allocations reachable from the respective entry points.

--- a/OPAL/br/src/main/scala/org/opalj/br/fpcf/properties/pointsto/package.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/fpcf/properties/pointsto/package.scala
@@ -4,6 +4,8 @@ package br
 package fpcf
 package properties
 
+import org.opalj.br.fpcf.analyses.ContextProvider
+
 package object pointsto {
     // we encode allocation sites (method, pc, emptyArray, typeid tuples) as longs
     // MSB 20 bit TypeID | 1 bit is empty array | 16 bit PC | 27 bit ContextID LSB
@@ -30,5 +32,20 @@ package object pointsto {
 
     @inline def isEmptyArrayAllocationSite(encodedAllocationSite: AllocationSite): Boolean = {
         (encodedAllocationSite >> 43) % 2 == -1
+    }
+
+    @inline def longToAllocationSite(
+        encodedAllocationSite: AllocationSite
+    )(
+        implicit
+        contextProvider: ContextProvider
+    ): (Context, PC, Int) /* method, pc, typeid */ = {
+        val contextID = encodedAllocationSite.toInt & 0x3FFFFFF
+        val pc = (encodedAllocationSite >> 26).toInt & 0x1FFFF
+        (
+            contextProvider.contextFromId(if (contextID == 0x3FFFFFF) -1 else contextID),
+            if (pc > 0xFFFF) pc | 0xFFFF0000 else pc,
+            (encodedAllocationSite >> 44).toInt
+        )
     }
 }

--- a/OPAL/tac/src/main/scala/org/opalj/tac/cg/CFA_1_0_CallGraphKey.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/cg/CFA_1_0_CallGraphKey.scala
@@ -6,7 +6,7 @@ package cg
 import org.opalj.br.analyses.ProjectInformationKeys
 import org.opalj.br.analyses.SomeProject
 import org.opalj.br.fpcf.FPCFAnalysisScheduler
-import org.opalj.tac.fpcf.analyses.cg.CallStringContextProvider
+import org.opalj.br.fpcf.analyses.CallStringContextProvider
 import org.opalj.tac.fpcf.analyses.cg.TypeIterator
 import org.opalj.tac.fpcf.analyses.cg.TypesBasedPointsToTypeIterator
 

--- a/OPAL/tac/src/main/scala/org/opalj/tac/cg/CallGraph.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/cg/CallGraph.scala
@@ -7,10 +7,10 @@ import org.opalj.fpcf.EUBP
 import org.opalj.fpcf.PropertyStore
 import org.opalj.br.DeclaredMethod
 import org.opalj.br.fpcf.properties.Context
+import org.opalj.br.fpcf.properties.cg.Callees
+import org.opalj.br.fpcf.properties.cg.Callers
+import org.opalj.br.fpcf.properties.cg.NoCallers
 import org.opalj.tac.fpcf.analyses.cg.TypeIterator
-import org.opalj.tac.fpcf.properties.cg.Callees
-import org.opalj.tac.fpcf.properties.cg.Callers
-import org.opalj.tac.fpcf.properties.cg.NoCallers
 
 /**
  * The proxy class for all call-graph related properties.

--- a/OPAL/tac/src/main/scala/org/opalj/tac/cg/CallGraphKey.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/cg/CallGraphKey.scala
@@ -18,9 +18,11 @@ import org.opalj.br.analyses.cg.InitialEntryPointsKey
 import org.opalj.br.analyses.ProjectInformationKeys
 import org.opalj.br.analyses.cg.CallBySignatureKey
 import org.opalj.br.analyses.cg.IsOverridableMethodKey
+import org.opalj.br.fpcf.ContextProviderKey
 import org.opalj.br.fpcf.FPCFAnalysesManagerKey
 import org.opalj.br.fpcf.FPCFAnalysisScheduler
 import org.opalj.br.fpcf.PropertyStoreKey
+import org.opalj.br.fpcf.analyses.ContextProvider
 import org.opalj.ai.domain.RecordCFG
 import org.opalj.ai.domain.RecordDefUse
 import org.opalj.ai.fpcf.properties.AIDomainFactoryKey
@@ -57,7 +59,7 @@ trait CallGraphKey extends ProjectInformationKey[CallGraph, Nothing] {
             case Some(requirements) => requirements ++ requiredDomains
         }
 
-        project.updateProjectInformationKeyInitializationData(TypeIteratorKey) {
+        project.updateProjectInformationKeyInitializationData(ContextProviderKey) {
             case Some(typeIterator: TypeIterator) if typeIterator ne this.typeIterator =>
                 implicit val logContext: LogContext = project.logContext
                 OPALLogger.error(
@@ -65,6 +67,13 @@ trait CallGraphKey extends ProjectInformationKey[CallGraph, Nothing] {
                     s"must not configure multiple type iterators"
                 )
                 throw new IllegalArgumentException()
+            case Some(_: ContextProvider) =>
+                implicit val logContext: LogContext = project.logContext
+                OPALLogger.error(
+                    "analysis configuration",
+                    "a context provider has already been established"
+                )
+                throw new IllegalStateException()
             case Some(_) => this.typeIterator
             case None =>
                 this.typeIterator = getTypeIterator(project)

--- a/OPAL/tac/src/main/scala/org/opalj/tac/cg/CallGraphKey.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/cg/CallGraphKey.scala
@@ -65,11 +65,10 @@ trait CallGraphKey extends ProjectInformationKey[CallGraph, Nothing] {
                     s"must not configure multiple type iterators"
                 )
                 throw new IllegalArgumentException()
-            case Some(_) => () => this.typeIterator
-            case None => () => {
+            case Some(_) => this.typeIterator
+            case None =>
                 this.typeIterator = getTypeIterator(project)
                 this.typeIterator
-            }
         }
 
         Seq(

--- a/OPAL/tac/src/main/scala/org/opalj/tac/cg/CallGraphKey.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/cg/CallGraphKey.scala
@@ -60,13 +60,16 @@ trait CallGraphKey extends ProjectInformationKey[CallGraph, Nothing] {
         }
 
         project.updateProjectInformationKeyInitializationData(ContextProviderKey) {
-            case Some(typeIterator: TypeIterator) if typeIterator ne this.typeIterator =>
-                implicit val logContext: LogContext = project.logContext
-                OPALLogger.error(
-                    "analysis configuration",
-                    s"must not configure multiple type iterators"
-                )
-                throw new IllegalArgumentException()
+            case Some(typeIterator: TypeIterator) =>
+                if (typeIterator ne this.typeIterator) {
+                    implicit val logContext: LogContext = project.logContext
+                    OPALLogger.error(
+                        "analysis configuration",
+                        s"must not configure multiple type iterators"
+                    )
+                    throw new IllegalArgumentException()
+                }
+                this.typeIterator
             case Some(_: ContextProvider) =>
                 implicit val logContext: LogContext = project.logContext
                 OPALLogger.error(
@@ -74,7 +77,6 @@ trait CallGraphKey extends ProjectInformationKey[CallGraph, Nothing] {
                     "a context provider has already been established"
                 )
                 throw new IllegalStateException()
-            case Some(_) => this.typeIterator
             case None =>
                 this.typeIterator = getTypeIterator(project)
                 this.typeIterator

--- a/OPAL/tac/src/main/scala/org/opalj/tac/cg/NoCallGraphKey.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/cg/NoCallGraphKey.scala
@@ -10,8 +10,8 @@ import org.opalj.br.fpcf.PropertyStoreKey
 import org.opalj.br.fpcf.properties.SimpleContextsKey
 import org.opalj.br.fpcf.FPCFAnalysesManagerKey
 import org.opalj.br.fpcf.FPCFAnalysisScheduler
+import org.opalj.br.fpcf.properties.cg.OnlyCallersWithUnknownContext
 import org.opalj.tac.fpcf.analyses.cg.CHATypeIterator
-import org.opalj.tac.fpcf.properties.cg.OnlyCallersWithUnknownContext
 
 /**
  * Pseudo CallGraphKey that can be used to declare methods reachable without computing a call graph.

--- a/OPAL/tac/src/main/scala/org/opalj/tac/cg/TypeBasedPointsToCallGraphKey.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/cg/TypeBasedPointsToCallGraphKey.scala
@@ -7,9 +7,9 @@ import org.opalj.br.analyses.ProjectInformationKeys
 import org.opalj.br.analyses.SomeProject
 import org.opalj.br.analyses.VirtualFormalParametersKey
 import org.opalj.br.fpcf.FPCFAnalysisScheduler
+import org.opalj.br.fpcf.analyses.SimpleContextProvider
 import org.opalj.br.fpcf.properties.SimpleContextsKey
 import org.opalj.tac.common.DefinitionSitesKey
-import org.opalj.tac.fpcf.analyses.cg.SimpleContextProvider
 import org.opalj.tac.fpcf.analyses.cg.TypeIterator
 import org.opalj.tac.fpcf.analyses.cg.TypesBasedPointsToTypeIterator
 import org.opalj.tac.fpcf.analyses.pointsto.TypeBasedArraycopyPointsToAnalysisScheduler

--- a/OPAL/tac/src/main/scala/org/opalj/tac/cg/TypeIteratorKey.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/cg/TypeIteratorKey.scala
@@ -8,6 +8,8 @@ import org.opalj.log.OPALLogger
 import org.opalj.br.analyses.ProjectInformationKey
 import org.opalj.br.analyses.ProjectInformationKeys
 import org.opalj.br.analyses.SomeProject
+import org.opalj.br.fpcf.ContextProviderKey
+import org.opalj.br.fpcf.analyses.ContextProvider
 import org.opalj.tac.fpcf.analyses.cg.CHATypeIterator
 import org.opalj.tac.fpcf.analyses.cg.TypeIterator
 
@@ -17,14 +19,14 @@ import org.opalj.tac.fpcf.analyses.cg.TypeIterator
  *  This key is intended to be set up by a corresponding [[org.opalj.tac.cg.CallGraphKey]].
  */
 object TypeIteratorKey
-    extends ProjectInformationKey[TypeIterator, () => TypeIterator] {
+    extends ProjectInformationKey[TypeIterator, TypeIterator] {
 
     override def requirements(project: SomeProject): ProjectInformationKeys = Nil
 
     override def compute(project: SomeProject): TypeIterator = {
-        project.getProjectInformationKeyInitializationData(this) match {
-            case Some(init) =>
-                init()
+
+        val typeIterator = project.getProjectInformationKeyInitializationData(this) match {
+            case Some(typeIterator: TypeIterator) => typeIterator
             case None =>
                 implicit val logContext: LogContext = project.logContext
                 OPALLogger.warn(
@@ -33,5 +35,19 @@ object TypeIteratorKey
                 )
                 new CHATypeIterator(project)
         }
+
+        project.updateProjectInformationKeyInitializationData(ContextProviderKey) {
+            case Some(contextProvider: ContextProvider) if contextProvider ne typeIterator =>
+                implicit val logContext: LogContext = project.logContext
+                OPALLogger.error(
+                    "analysis configuration",
+                    s"must not configure multiple type iterators"
+                )
+                throw new IllegalArgumentException()
+            case Some(_) => typeIterator
+            case None    => typeIterator
+        }
+
+        project.get(ContextProviderKey).asInstanceOf[TypeIterator]
     }
 }

--- a/OPAL/tac/src/main/scala/org/opalj/tac/cg/TypeIteratorKey.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/cg/TypeIteratorKey.scala
@@ -18,36 +18,42 @@ import org.opalj.tac.fpcf.analyses.cg.TypeIterator
  *  the current project's call graph.
  *  This key is intended to be set up by a corresponding [[org.opalj.tac.cg.CallGraphKey]].
  */
-object TypeIteratorKey
-    extends ProjectInformationKey[TypeIterator, TypeIterator] {
+object TypeIteratorKey extends ProjectInformationKey[TypeIterator, TypeIterator] {
 
-    override def requirements(project: SomeProject): ProjectInformationKeys = Nil
+    override def requirements(project: SomeProject): ProjectInformationKeys = {
+        implicit val logContext: LogContext = project.logContext
 
-    override def compute(project: SomeProject): TypeIterator = {
-
-        val typeIterator = project.getProjectInformationKeyInitializationData(this) match {
-            case Some(typeIterator: TypeIterator) => typeIterator
-            case None =>
-                implicit val logContext: LogContext = project.logContext
-                OPALLogger.warn(
-                    "analysis configuration",
-                    s"no type iterator configured, using CHA as a fallback"
-                )
-                new CHATypeIterator(project)
-        }
-
-        project.updateProjectInformationKeyInitializationData(ContextProviderKey) {
-            case Some(contextProvider: ContextProvider) if contextProvider ne typeIterator =>
-                implicit val logContext: LogContext = project.logContext
+        project.getProjectInformationKeyInitializationData(this) match {
+            case Some(_) =>
                 OPALLogger.error(
                     "analysis configuration",
-                    s"must not configure multiple type iterators"
+                    "TypeIteratorKey has no initialization data, configure ContextProviderKey instead"
                 )
-                throw new IllegalArgumentException()
-            case Some(_) => typeIterator
-            case None    => typeIterator
+            case _ =>
         }
 
+        project.getProjectInformationKeyInitializationData(ContextProviderKey) match {
+            case Some(_: TypeIterator) =>
+            case Some(_: ContextProvider) =>
+                OPALLogger.error(
+                    "analysis configuration",
+                    "a context provider has already been established"
+                )
+                throw new IllegalStateException()
+            case None =>
+                OPALLogger.warn(
+                    "analysis configuration",
+                    "no type iterator configured, using CHA as a fallback"
+                )
+                project.updateProjectInformationKeyInitializationData(ContextProviderKey) {
+                    _ => new CHATypeIterator(project)
+                }
+        }
+
+        Seq(ContextProviderKey)
+    }
+
+    override def compute(project: SomeProject): TypeIterator = {
         project.get(ContextProviderKey).asInstanceOf[TypeIterator]
     }
 }

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/APIBasedAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/APIBasedAnalysis.scala
@@ -14,9 +14,9 @@ import org.opalj.br.DeclaredMethod
 import org.opalj.br.analyses.DeclaredMethodsKey
 import org.opalj.br.analyses.DeclaredMethods
 import org.opalj.br.fpcf.FPCFAnalysis
-import org.opalj.tac.fpcf.properties.cg.Callers
+import org.opalj.br.fpcf.analyses.ContextProvider
+import org.opalj.br.fpcf.properties.cg.Callers
 import org.opalj.tac.fpcf.analyses.cg.ContextualAnalysis
-import org.opalj.tac.fpcf.analyses.cg.TypeIterator
 
 /**
  * A trait for analyses that model the result of the invocation of a specific
@@ -36,7 +36,7 @@ import org.opalj.tac.fpcf.analyses.cg.TypeIterator
 trait APIBasedAnalysis extends FPCFAnalysis with ContextualAnalysis {
     val apiMethod: DeclaredMethod
 
-    implicit val typeIterator: TypeIterator
+    implicit val contextProvider: ContextProvider
     implicit val declaredMethods: DeclaredMethods = p.get(DeclaredMethodsKey)
 
     def handleNewCaller(

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/FieldLocalityAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/FieldLocalityAnalysis.scala
@@ -51,16 +51,17 @@ import org.opalj.br.analyses.cg.TypeExtensibilityKey
 import org.opalj.br.cfg.BasicBlock
 import org.opalj.br.cfg.CFGNode
 import org.opalj.br.cfg.ExitNode
+import org.opalj.br.fpcf.analyses.ContextProvider
 import org.opalj.br.fpcf.properties.Context
-import org.opalj.tac.fpcf.properties.cg.Callees
+import org.opalj.br.fpcf.properties.cg.Callees
+import org.opalj.br.fpcf.properties.cg.Callers
+import org.opalj.br.fpcf.ContextProviderKey
 import org.opalj.ai.PCs
 import org.opalj.ai.ValueOrigin
 import org.opalj.tac.cg.TypeIteratorKey
 import org.opalj.tac.common.DefinitionSiteLike
 import org.opalj.tac.common.DefinitionSitesKey
-import org.opalj.tac.fpcf.analyses.cg.TypeIterator
 import org.opalj.tac.fpcf.properties.TACAI
-import org.opalj.tac.fpcf.properties.cg.Callers
 
 /**
  * Determines whether the lifetime of a reference type field is the same as that of its owning
@@ -77,7 +78,7 @@ class FieldLocalityAnalysis private[analyses] (
     type V = DUVar[ValueInformation]
 
     final implicit val declaredMethods: DeclaredMethods = project.get(DeclaredMethodsKey)
-    private[this] implicit val typeIterator: TypeIterator = project.get(TypeIteratorKey)
+    private[this] implicit val contextProvider: ContextProvider = project.get(ContextProviderKey)
     final val typeExtensiblity = project.get(TypeExtensibilityKey)
     final val fieldAccessInformation = project.get(FieldAccessInformationKey)
     final val definitionSites = project.get(DefinitionSitesKey)

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/FieldLocalityState.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/FieldLocalityState.scala
@@ -21,10 +21,10 @@ import org.opalj.br.fpcf.properties.LocalField
 import org.opalj.br.ObjectType
 import org.opalj.br.fpcf.properties.Context
 import org.opalj.br.fpcf.properties.ReturnValueFreshness
-import org.opalj.tac.fpcf.properties.cg.Callees
+import org.opalj.br.fpcf.properties.cg.Callees
+import org.opalj.br.fpcf.properties.cg.Callers
 import org.opalj.tac.common.DefinitionSiteLike
 import org.opalj.tac.fpcf.properties.TACAI
-import org.opalj.tac.fpcf.properties.cg.Callers
 
 class FieldLocalityState(val field: Field, val thisIsCloneable: Boolean) {
 

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/SystemPropertiesAnalysisScheduler.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/SystemPropertiesAnalysisScheduler.scala
@@ -25,17 +25,14 @@ import org.opalj.br.analyses.SomeProject
 import org.opalj.br.fpcf.BasicFPCFTriggeredAnalysisScheduler
 import org.opalj.br.analyses.DeclaredMethodsKey
 import org.opalj.br.analyses.ProjectInformationKeys
-import org.opalj.tac.fpcf.properties.cg.Callers
+import org.opalj.br.fpcf.properties.cg.Callers
 import org.opalj.tac.cg.TypeIteratorKey
 import org.opalj.tac.fpcf.analyses.cg.ReachableMethodAnalysis
-import org.opalj.tac.fpcf.analyses.cg.TypeIterator
 import org.opalj.tac.fpcf.properties.TACAI
 
 class SystemPropertiesAnalysisScheduler private[analyses] (
         final val project: SomeProject
 ) extends ReachableMethodAnalysis {
-
-    final override implicit val typeIterator: TypeIterator = project.get(TypeIteratorKey)
 
     def processMethod(
         callContext: ContextType, tacaiEP: EPS[Method, TACAI]

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/TACAIBasedAPIBasedAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/TACAIBasedAPIBasedAnalysis.scala
@@ -14,7 +14,7 @@ import org.opalj.fpcf.UBP
 import org.opalj.fpcf.UBPS
 import org.opalj.br.DeclaredMethod
 import org.opalj.br.Method
-import org.opalj.tac.fpcf.properties.cg.Callees
+import org.opalj.br.fpcf.properties.cg.Callees
 import org.opalj.tac.fpcf.properties.TACAI
 import org.opalj.tac.fpcf.properties.TheTACAI
 import org.opalj.tac.fpcf.analyses.cg.uVarForDefSites

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/CallGraphAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/CallGraphAnalysis.scala
@@ -36,10 +36,10 @@ import org.opalj.br.analyses.cg.InitialEntryPointsKey
 import org.opalj.br.analyses.DeclaredMethodsKey
 import org.opalj.br.analyses.ProjectInformationKeys
 import org.opalj.br.analyses.cg.CallBySignatureKey
-import org.opalj.tac.fpcf.properties.cg.Callees
-import org.opalj.tac.fpcf.properties.cg.Callers
-import org.opalj.tac.fpcf.properties.cg.OnlyCallersWithUnknownContext
 import org.opalj.br.fpcf.BasicFPCFTriggeredAnalysisScheduler
+import org.opalj.br.fpcf.properties.cg.Callees
+import org.opalj.br.fpcf.properties.cg.Callers
+import org.opalj.br.fpcf.properties.cg.OnlyCallersWithUnknownContext
 import org.opalj.tac.cg.TypeIteratorKey
 import org.opalj.tac.fpcf.properties.TACAI
 

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/CallGraphDeserializer.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/CallGraphDeserializer.scala
@@ -31,8 +31,8 @@ import org.opalj.br.PCAndInstruction
 import org.opalj.br.analyses.ProjectInformationKeys
 import org.opalj.br.fpcf.properties.SimpleContextsKey
 import org.opalj.br.fpcf.properties.SimpleContexts
-import org.opalj.tac.fpcf.properties.cg.Callees
-import org.opalj.tac.fpcf.properties.cg.Callers
+import org.opalj.br.fpcf.properties.cg.Callees
+import org.opalj.br.fpcf.properties.cg.Callers
 import org.opalj.br.instructions.Instruction
 
 /**

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/CalleesAndCallers.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/CalleesAndCallers.scala
@@ -22,12 +22,12 @@ import org.opalj.br.ObjectType
 import org.opalj.br.analyses.DeclaredMethods
 import org.opalj.br.fpcf.properties.Context
 import org.opalj.br.ClassHierarchy
-import org.opalj.tac.fpcf.properties.cg.Callees
-import org.opalj.tac.fpcf.properties.cg.Callers
-import org.opalj.tac.fpcf.properties.cg.CallersOnlyWithConcreteCallers
-import org.opalj.tac.fpcf.properties.cg.ConcreteCallees
-import org.opalj.tac.fpcf.properties.cg.NoCallees
-import org.opalj.tac.fpcf.properties.cg.OnlyVMLevelCallers
+import org.opalj.br.fpcf.analyses.ContextProvider
+import org.opalj.br.fpcf.properties.cg.Callees
+import org.opalj.br.fpcf.properties.cg.Callers
+import org.opalj.br.fpcf.properties.cg.CallersOnlyWithConcreteCallers
+import org.opalj.br.fpcf.properties.cg.NoCallees
+import org.opalj.br.fpcf.properties.cg.OnlyVMLevelCallers
 
 /**
  * A convenience class for call graph constructions. Manages direct/indirect calls and incomplete
@@ -85,7 +85,7 @@ sealed trait CalleesAndCallers {
             case _: EPK[_, _] =>
                 Some(InterimEUBP(
                     callerContext.method,
-                    ConcreteCallees(
+                    org.opalj.br.fpcf.properties.cg.ConcreteCallees(
                         callerContext,
                         directCallees, indirectCallees,
                         incompleteCallSites,
@@ -198,13 +198,13 @@ trait IndirectCallsBase extends Calls {
         callee:        DeclaredMethod,
         params:        Seq[Option[(ValueInformation, IntTrieSet)]],
         receiver:      Option[(ValueInformation, IntTrieSet)]
-    )(implicit typeIterator: TypeIterator, classHierarchy: ClassHierarchy): Unit = {
+    )(implicit contextProvider: ContextProvider, classHierarchy: ClassHierarchy): Unit = {
         if (callee.descriptor.parameterTypes.size == params.size) {
             if (receiver.isEmpty || isTypeCompatible(callee.declaringClassType, receiver.get._1, true)) {
                 if (params.zip(callee.descriptor.parameterTypes).forall { p =>
                     p._1.isEmpty || isTypeCompatible(p._2, p._1.get._1)
                 }) {
-                    val calleeContext = typeIterator.expandContext(callerContext, callee, pc)
+                    val calleeContext = contextProvider.expandContext(callerContext, callee, pc)
                     addCall(callerContext, pc, calleeContext)
                     _parameters = _parameters.updated(
                         pc,

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/ConfiguredNativeMethodsCallGraphAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/ConfiguredNativeMethodsCallGraphAnalysis.scala
@@ -25,11 +25,12 @@ import org.opalj.br.DeclaredMethod
 import org.opalj.br.analyses.DeclaredMethods
 import org.opalj.br.analyses.DeclaredMethodsKey
 import org.opalj.br.analyses.ProjectInformationKeys
-import org.opalj.tac.fpcf.properties.cg.Callees
-import org.opalj.tac.fpcf.properties.cg.Callers
-import org.opalj.tac.fpcf.properties.cg.NoCallers
 import org.opalj.br.fpcf.BasicFPCFTriggeredAnalysisScheduler
-import org.opalj.tac.cg.TypeIteratorKey
+import org.opalj.br.fpcf.analyses.ContextProvider
+import org.opalj.br.fpcf.properties.cg.Callees
+import org.opalj.br.fpcf.properties.cg.Callers
+import org.opalj.br.fpcf.properties.cg.NoCallers
+import org.opalj.br.fpcf.ContextProviderKey
 
 /**
  * Add calls from configured native methods to the call graph.
@@ -54,7 +55,7 @@ class ConfiguredNativeMethodsCallGraphAnalysis private[analyses] (
     val configKey = "org.opalj.fpcf.analyses.ConfiguredNativeMethodsAnalysis"
 
     private[this] implicit val declaredMethods: DeclaredMethods = project.get(DeclaredMethodsKey)
-    private[this] implicit val typeIterator: TypeIterator = project.get(TypeIteratorKey)
+    private[this] implicit val contextProvider: ContextProvider = project.get(ContextProviderKey)
 
     private[this] val nativeMethodData: Map[DeclaredMethod, Option[Array[MethodDescription]]] = {
         ConfiguredMethods.reader.read(
@@ -119,7 +120,7 @@ class ConfiguredNativeMethodsCallGraphAnalysis private[analyses] (
                     calls.addVMReachableMethod(tgtMethod);
                 } else {
                     calls.addCall(
-                        calleeContext, 0, typeIterator.expandContext(calleeContext, tgtMethod, 0)
+                        calleeContext, 0, contextProvider.expandContext(calleeContext, tgtMethod, 0)
                     )
                 }
             }
@@ -132,7 +133,7 @@ class ConfiguredNativeMethodsCallGraphAnalysis private[analyses] (
 
 object ConfiguredNativeMethodsCallGraphAnalysisScheduler extends BasicFPCFTriggeredAnalysisScheduler {
     override def requiredProjectInformation: ProjectInformationKeys =
-        Seq(DeclaredMethodsKey, TypeIteratorKey)
+        Seq(DeclaredMethodsKey, ContextProviderKey)
 
     override def uses: Set[PropertyBounds] = PropertyBounds.ubs(Callers)
 

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/DoPrivilegedCGAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/DoPrivilegedCGAnalysis.scala
@@ -24,12 +24,12 @@ import org.opalj.br.fpcf.BasicFPCFEagerAnalysisScheduler
 import org.opalj.br.ArrayType
 import org.opalj.br.MethodDescriptor
 import org.opalj.br.ObjectType
-import org.opalj.tac.fpcf.properties.cg.Callees
-import org.opalj.tac.fpcf.properties.cg.Callers
 import org.opalj.br.ReferenceType
 import org.opalj.br.analyses.ProjectInformationKeys
 import org.opalj.br.analyses.VirtualFormalParametersKey
 import org.opalj.br.fpcf.FPCFAnalysis
+import org.opalj.br.fpcf.properties.cg.Callees
+import org.opalj.br.fpcf.properties.cg.Callers
 import org.opalj.tac.cg.TypeIteratorKey
 import org.opalj.tac.common.DefinitionSitesKey
 import org.opalj.tac.fpcf.properties.TheTACAI

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/FinalizerAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/FinalizerAnalysis.scala
@@ -25,9 +25,9 @@ import org.opalj.br.analyses.SomeProject
 import org.opalj.br.fpcf.BasicFPCFTriggeredAnalysisScheduler
 import org.opalj.br.fpcf.FPCFAnalysis
 import org.opalj.br.DeclaredMethod
-import org.opalj.tac.fpcf.properties.cg.Callers
-import org.opalj.tac.fpcf.properties.cg.NoCallers
-import org.opalj.tac.fpcf.properties.cg.OnlyVMLevelCallers
+import org.opalj.br.fpcf.properties.cg.Callers
+import org.opalj.br.fpcf.properties.cg.NoCallers
+import org.opalj.br.fpcf.properties.cg.OnlyVMLevelCallers
 
 /**
  * Computes the set of finalize methods that are being called by the VM during the execution of the

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/LoadedClassesAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/LoadedClassesAnalysis.scala
@@ -29,9 +29,9 @@ import org.opalj.br.analyses.ProjectInformationKeys
 import org.opalj.br.analyses.SomeProject
 import org.opalj.br.fpcf.BasicFPCFTriggeredAnalysisScheduler
 import org.opalj.br.fpcf.FPCFAnalysis
-import org.opalj.tac.fpcf.properties.cg.Callers
-import org.opalj.tac.fpcf.properties.cg.LoadedClasses
-import org.opalj.tac.fpcf.properties.cg.NoCallers
+import org.opalj.br.fpcf.properties.cg.Callers
+import org.opalj.br.fpcf.properties.cg.LoadedClasses
+import org.opalj.br.fpcf.properties.cg.NoCallers
 import org.opalj.tac.fpcf.properties.TACAI
 
 /**

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/ReachableMethodAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/ReachableMethodAnalysis.scala
@@ -20,8 +20,8 @@ import org.opalj.br.analyses.DeclaredMethods
 import org.opalj.br.analyses.DeclaredMethodsKey
 import org.opalj.br.DeclaredMethod
 import org.opalj.br.Method
-import org.opalj.tac.fpcf.properties.cg.Callers
-import org.opalj.tac.fpcf.properties.cg.NoCallers
+import org.opalj.br.fpcf.properties.cg.Callers
+import org.opalj.br.fpcf.properties.cg.NoCallers
 import org.opalj.tac.fpcf.properties.TACAI
 
 /**

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/SerializationRelatedCallsAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/SerializationRelatedCallsAnalysis.scala
@@ -33,10 +33,10 @@ import org.opalj.br.ObjectType.{ObjectOutputStream => ObjectOutputStreamType}
 import org.opalj.br.ObjectType.{ObjectInputStream => ObjectInputStreamType}
 import org.opalj.br.analyses.DeclaredMethodsKey
 import org.opalj.br.analyses.ProjectInformationKeys
-import org.opalj.tac.fpcf.properties.cg.Callees
-import org.opalj.tac.fpcf.properties.cg.Callers
 import org.opalj.br.Method
 import org.opalj.br.ReferenceType
+import org.opalj.br.fpcf.properties.cg.Callees
+import org.opalj.br.fpcf.properties.cg.Callers
 import org.opalj.tac.cg.TypeIteratorKey
 import org.opalj.tac.fpcf.properties.TACAI
 import org.opalj.tac.fpcf.properties.TheTACAI

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/StaticInitializerAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/StaticInitializerAnalysis.scala
@@ -31,9 +31,9 @@ import org.opalj.br.analyses.ProjectInformationKeys
 import org.opalj.br.analyses.SomeProject
 import org.opalj.br.fpcf.BasicFPCFEagerAnalysisScheduler
 import org.opalj.br.fpcf.FPCFAnalysis
-import org.opalj.tac.fpcf.properties.cg.Callers
-import org.opalj.tac.fpcf.properties.cg.LoadedClasses
-import org.opalj.tac.fpcf.properties.cg.OnlyVMLevelCallers
+import org.opalj.br.fpcf.properties.cg.Callers
+import org.opalj.br.fpcf.properties.cg.LoadedClasses
+import org.opalj.br.fpcf.properties.cg.OnlyVMLevelCallers
 
 /**
  * Extends the call graph analysis to include calls to static initializers from within the JVM for

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/ThreadRelatedCallsAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/ThreadRelatedCallsAnalysis.scala
@@ -5,6 +5,8 @@ package fpcf
 package analyses
 package cg
 
+import scala.collection.immutable.ArraySeq
+
 import org.opalj.fpcf.Entity
 import org.opalj.fpcf.EPS
 import org.opalj.fpcf.FinalEP
@@ -26,15 +28,13 @@ import org.opalj.br.analyses.DeclaredMethodsKey
 import org.opalj.br.Method
 import org.opalj.br.analyses.ProjectInformationKeys
 import org.opalj.br.fpcf.BasicFPCFEagerAnalysisScheduler
-import org.opalj.tac.fpcf.properties.cg.Callees
-import org.opalj.tac.fpcf.properties.cg.Callers
 import org.opalj.br.ReferenceType
 import org.opalj.br.fpcf.properties.Context
+import org.opalj.br.fpcf.properties.cg.Callees
+import org.opalj.br.fpcf.properties.cg.Callers
 import org.opalj.tac.cg.TypeIteratorKey
 import org.opalj.tac.fpcf.properties.TACAI
 import org.opalj.tac.fpcf.properties.TheTACAI
-
-import scala.collection.immutable.ArraySeq
 
 /**
  * On calls to Thread.start(), it adds calls to the corresponding run method.

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/TypeConsumerAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/TypeConsumerAnalysis.scala
@@ -6,10 +6,12 @@ package analyses
 package cg
 
 import org.opalj.br.analyses.ProjectBasedAnalysis
+import org.opalj.br.fpcf.analyses.ContextProvider
 import org.opalj.tac.cg.TypeIteratorKey
 
 trait TypeConsumerAnalysis extends ProjectBasedAnalysis {
     implicit val typeIterator: TypeIterator = project.get(TypeIteratorKey)
+    implicit val contextProvider: ContextProvider = typeIterator
 
     type ContextType = typeIterator.ContextType
     type PropertyType = typeIterator.PropertyType

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/TypeIterator.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/TypeIterator.scala
@@ -424,7 +424,7 @@ class RTATypeIterator(project: SomeProject)
 
     val usedPropertyKinds: Set[PropertyBounds] = Set(PropertyBounds.ub(InstantiatedTypes))
 
-    private[this] val propertyStore = project.get(PropertyStoreKey)
+    private[this] lazy val propertyStore = project.get(PropertyStoreKey)
 
     @inline override def typesProperty(
         use: V, context: SimpleContext, depender: Entity, stmts: Array[Stmt[V]]
@@ -526,7 +526,7 @@ class PropagationBasedTypeIterator(
 
     val usedPropertyKinds: Set[PropertyBounds] = Set(PropertyBounds.ub(InstantiatedTypes))
 
-    private[this] val propertyStore = project.get(PropertyStoreKey)
+    private[this] lazy val propertyStore = project.get(PropertyStoreKey)
 
     @inline override def typesProperty(
         use: V, context: SimpleContext, depender: Entity, stmts: Array[Stmt[V]]
@@ -631,10 +631,10 @@ trait PointsToTypeIterator[ElementType, PointsToSet >: Null <: PointsToSetLike[E
     protected[this] val pointsToProperty: PropertyKey[PointsToSet]
     protected[this] def emptyPointsToSet: PointsToSet
 
-    private[this] val propertyStore = project.get(PropertyStoreKey)
-    protected[this] implicit val formalParameters: VirtualFormalParameters =
+    private[this] lazy val propertyStore = project.get(PropertyStoreKey)
+    protected[this] implicit lazy val formalParameters: VirtualFormalParameters =
         project.get(VirtualFormalParametersKey)
-    protected[this] implicit val definitionSites: DefinitionSites = project.get(DefinitionSitesKey)
+    protected[this] implicit lazy val definitionSites: DefinitionSites = project.get(DefinitionSitesKey)
     private[this] implicit val typeIterator: TypeIterator = this
 
     protected[this] def createPointsToSet(
@@ -804,7 +804,7 @@ trait TypesBasedPointsToTypeIterator
 abstract class AbstractAllocationSitesPointsToTypeIterator(project: SomeProject)
     extends TypeIterator(project) with PointsToTypeIterator[AllocationSite, AllocationSitePointsToSet] {
 
-    protected[this] val fieldAccesses: FieldAccessInformation = project.get(FieldAccessInformationKey)
+    protected[this] lazy val fieldAccesses: FieldAccessInformation = project.get(FieldAccessInformationKey)
 
     val mergeStringBuilderBuffer: Boolean =
         project.config.getBoolean(mergeStringBuilderBufferConfigKey)

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/reflection/ReflectionRelatedCallsAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/reflection/ReflectionRelatedCallsAnalysis.scala
@@ -8,9 +8,12 @@ package reflection
 
 import scala.language.existentials
 
+import scala.collection.immutable.ArraySeq
+
 import org.opalj.log.Error
 import org.opalj.log.Info
 import org.opalj.log.OPALLogger.logOnce
+import org.opalj.log.Warn
 import org.opalj.collection.immutable.IntTrieSet
 import org.opalj.collection.immutable.UIDSet
 import org.opalj.fpcf.Entity
@@ -19,6 +22,7 @@ import org.opalj.fpcf.EPS
 import org.opalj.fpcf.FinalEP
 import org.opalj.fpcf.InterimEUBP
 import org.opalj.fpcf.InterimPartialResult
+import org.opalj.fpcf.InterimResult
 import org.opalj.fpcf.PartialResult
 import org.opalj.fpcf.ProperPropertyComputationResult
 import org.opalj.fpcf.PropertyBounds
@@ -33,33 +37,29 @@ import org.opalj.br.analyses.SomeProject
 import org.opalj.br.DeclaredMethod
 import org.opalj.br.fpcf.FPCFAnalysis
 import org.opalj.br.ArrayType
-import org.opalj.br.MethodDescriptor
-import org.opalj.br.ObjectType
 import org.opalj.br.InvokeInterfaceMethodHandle
 import org.opalj.br.InvokeSpecialMethodHandle
 import org.opalj.br.InvokeStaticMethodHandle
 import org.opalj.br.InvokeVirtualMethodHandle
+import org.opalj.br.MethodDescriptor
 import org.opalj.br.NewInvokeSpecialMethodHandle
+import org.opalj.br.ObjectType
 import org.opalj.br.analyses.DeclaredMethodsKey
 import org.opalj.br.BooleanType
+import org.opalj.br.analyses.ProjectIndexKey
 import org.opalj.br.analyses.ProjectInformationKeys
 import org.opalj.br.fpcf.BasicFPCFEagerAnalysisScheduler
-import org.opalj.tac.fpcf.properties.cg.Callees
-import org.opalj.tac.fpcf.properties.cg.Callers
-import org.opalj.tac.fpcf.properties.cg.ForNameClasses
-import org.opalj.br.analyses.ProjectIndexKey
 import org.opalj.br.Method
+import org.opalj.br.ReferenceType
+import org.opalj.br.fpcf.properties.cg.Callees
+import org.opalj.br.fpcf.properties.cg.Callers
+import org.opalj.br.fpcf.properties.cg.ForNameClasses
+import org.opalj.br.fpcf.properties.cg.LoadedClasses
 import org.opalj.tac.cg.TypeIteratorKey
 import org.opalj.tac.fpcf.analyses.cg.reflection.MatcherUtil.retrieveSuitableMatcher
 import org.opalj.tac.fpcf.analyses.cg.reflection.MethodHandlesUtil.retrieveDescriptorBasedMethodMatcher
 import org.opalj.tac.fpcf.properties.TACAI
 import org.opalj.tac.fpcf.properties.TheTACAI
-import scala.collection.immutable.ArraySeq
-
-import org.opalj.log.Warn
-import org.opalj.fpcf.InterimResult
-import org.opalj.br.ReferenceType
-import org.opalj.tac.fpcf.properties.cg.LoadedClasses
 
 sealed trait ReflectionAnalysis extends TACAIBasedAPIBasedAnalysis {
 

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/reflection/TamiFlexCallGraphAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/reflection/TamiFlexCallGraphAnalysis.scala
@@ -6,6 +6,8 @@ package analyses
 package cg
 package reflection
 
+import scala.collection.immutable.ArraySeq
+
 import org.opalj.collection.immutable.IntTrieSet
 import org.opalj.fpcf.ProperPropertyComputationResult
 import org.opalj.fpcf.PropertyBounds
@@ -23,18 +25,17 @@ import org.opalj.br.analyses.DeclaredMethods
 import org.opalj.br.analyses.DeclaredMethodsKey
 import org.opalj.br.analyses.ProjectInformationKeys
 import org.opalj.br.fpcf.BasicFPCFEagerAnalysisScheduler
-import org.opalj.tac.fpcf.properties.cg.Callees
-import org.opalj.tac.fpcf.properties.cg.Callers
+import org.opalj.br.fpcf.properties.cg.Callees
+import org.opalj.br.fpcf.properties.cg.Callers
 import org.opalj.tac.cg.TypeIteratorKey
 import org.opalj.tac.fpcf.analyses.pointsto.TamiFlexKey
 import org.opalj.tac.fpcf.properties.TACAI
-
-import scala.collection.immutable.ArraySeq
 
 /**
  * Adds the specified calls from the tamiflex.log to the call graph.
  * TODO: Merge with reflection analysis
  * TODO: Also handle class-forName -> Loaded classes
+ *
  * @author Florian Kuebler
  */
 class TamiFlexCallGraphAnalysis private[analyses] (

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/reflection/TypesUtil.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/reflection/TypesUtil.scala
@@ -19,7 +19,7 @@ import org.opalj.br.VoidType
 import org.opalj.br.analyses.SomeProject
 import org.opalj.br.fpcf.properties.Context
 import org.opalj.br.ArrayType
-import org.opalj.tac.fpcf.properties.cg.ForNameClasses
+import org.opalj.br.fpcf.properties.cg.ForNameClasses
 
 object TypesUtil {
 

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/rta/ConfiguredNativeMethodsInstantiatedTypesAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/rta/ConfiguredNativeMethodsInstantiatedTypesAnalysis.scala
@@ -20,16 +20,17 @@ import org.opalj.br.ArrayType
 import org.opalj.br.DeclaredMethod
 import org.opalj.br.FieldType
 import org.opalj.br.ObjectType
+import org.opalj.br.ReferenceType
 import org.opalj.br.analyses.DeclaredMethods
 import org.opalj.br.analyses.DeclaredMethodsKey
 import org.opalj.br.analyses.ProjectInformationKeys
 import org.opalj.br.analyses.SomeProject
 import org.opalj.br.fpcf.BasicFPCFTriggeredAnalysisScheduler
 import org.opalj.br.fpcf.FPCFAnalysis
-import org.opalj.tac.fpcf.properties.cg.Callers
-import org.opalj.tac.fpcf.properties.cg.InstantiatedTypes
-import org.opalj.tac.fpcf.properties.cg.NoCallers
-import org.opalj.br.ReferenceType
+import org.opalj.br.fpcf.properties.cg.Callers
+import org.opalj.br.fpcf.properties.cg.InstantiatedTypes
+import org.opalj.br.fpcf.properties.cg.NoCallers
+
 import scala.collection.immutable.ArraySeq
 
 /**

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/rta/InstantiatedTypesAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/rta/InstantiatedTypesAnalysis.scala
@@ -7,6 +7,7 @@ package cg
 package rta
 
 import scala.language.existentials
+
 import org.opalj.collection.immutable.UIDSet
 import org.opalj.fpcf.EOptionP
 import org.opalj.fpcf.EPK
@@ -30,12 +31,13 @@ import org.opalj.br.analyses.SomeProject
 import org.opalj.br.analyses.cg.InitialInstantiatedTypesKey
 import org.opalj.br.fpcf.BasicFPCFTriggeredAnalysisScheduler
 import org.opalj.br.fpcf.FPCFAnalysis
-import org.opalj.tac.fpcf.properties.cg.Callers
-import org.opalj.tac.fpcf.properties.cg.InstantiatedTypes
-import org.opalj.tac.fpcf.properties.cg.NoCallers
 import org.opalj.br.instructions.NEW
 import org.opalj.br.ReferenceType
-import org.opalj.tac.cg.TypeIteratorKey
+import org.opalj.br.fpcf.analyses.ContextProvider
+import org.opalj.br.fpcf.properties.cg.Callers
+import org.opalj.br.fpcf.properties.cg.InstantiatedTypes
+import org.opalj.br.fpcf.properties.cg.NoCallers
+import org.opalj.br.fpcf.ContextProviderKey
 
 /**
  * Marks types as instantiated if their constructor is invoked. Constructors invoked by subclass
@@ -49,7 +51,7 @@ class InstantiatedTypesAnalysis private[analyses] (
         final val project: SomeProject
 ) extends FPCFAnalysis {
 
-    private[this] implicit val typeIterator: TypeIterator = project.get(TypeIteratorKey)
+    private[this] implicit val contextProvider: ContextProvider = project.get(ContextProviderKey)
 
     def analyze(declaredMethod: DeclaredMethod): PropertyComputationResult = {
         // only constructors may initialize a class
@@ -207,7 +209,7 @@ object InstantiatedTypesAnalysis {
 
 object InstantiatedTypesAnalysisScheduler extends BasicFPCFTriggeredAnalysisScheduler {
 
-    override def requiredProjectInformation: ProjectInformationKeys = Seq(TypeIteratorKey)
+    override def requiredProjectInformation: ProjectInformationKeys = Seq(ContextProviderKey)
 
     override def uses: Set[PropertyBounds] = PropertyBounds.ubs(
         InstantiatedTypes,

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/xta/ArrayInstantiationsAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/xta/ArrayInstantiationsAnalysis.scala
@@ -12,8 +12,8 @@ import org.opalj.br.analyses.ProjectInformationKeys
 import org.opalj.br.analyses.SomeProject
 import org.opalj.br.fpcf.BasicFPCFTriggeredAnalysisScheduler
 import org.opalj.br.fpcf.FPCFAnalysis
-import org.opalj.tac.fpcf.properties.cg.Callers
-import org.opalj.tac.fpcf.properties.cg.InstantiatedTypes
+import org.opalj.br.fpcf.properties.cg.Callers
+import org.opalj.br.fpcf.properties.cg.InstantiatedTypes
 import org.opalj.br.instructions.CreateNewArrayInstruction
 import org.opalj.collection.immutable.UIDSet
 import org.opalj.fpcf.EPS
@@ -23,10 +23,10 @@ import org.opalj.fpcf.PropertyBounds
 import org.opalj.fpcf.PropertyKind
 import org.opalj.fpcf.PropertyStore
 import org.opalj.fpcf.Results
-import org.opalj.tac.fpcf.properties.TACAI
-import scala.collection.mutable
-
 import org.opalj.tac.cg.TypeIteratorKey
+import org.opalj.tac.fpcf.properties.TACAI
+
+import scala.collection.mutable
 
 /**
  * Updates InstantiatedTypes attached to a method's set for each array allocation
@@ -44,8 +44,6 @@ final class ArrayInstantiationsAnalysis(
         val project:     SomeProject,
         selectSetEntity: TypeSetEntitySelector
 ) extends ReachableMethodAnalysis {
-
-    override implicit val typeIterator: TypeIterator = project.get(TypeIteratorKey)
 
     override def processMethod(
         callContext: ContextType,

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/xta/InstantiatedTypesAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/xta/InstantiatedTypesAnalysis.scala
@@ -6,20 +6,8 @@ package analyses
 package cg
 package xta
 
-import org.opalj.br._
-import org.opalj.br.analyses.DeclaredMethodsKey
-import org.opalj.br.analyses.ProjectInformationKeys
-import org.opalj.br.analyses.SomeProject
-import org.opalj.br.analyses.cg.ClosedPackagesKey
-import org.opalj.br.analyses.cg.InitialEntryPointsKey
-import org.opalj.br.analyses.cg.InitialInstantiatedTypesKey
-import org.opalj.br.fpcf.BasicFPCFTriggeredAnalysisScheduler
-import org.opalj.br.fpcf.FPCFAnalysis
-import org.opalj.tac.fpcf.properties.cg.Callers
-import org.opalj.tac.fpcf.properties.cg.InstantiatedTypes
-import org.opalj.tac.fpcf.properties.cg.NoCallers
-import org.opalj.br.instructions.INVOKESPECIAL
-import org.opalj.br.instructions.NEW
+import scala.collection.mutable.ArrayBuffer
+
 import org.opalj.collection.immutable.UIDSet
 import org.opalj.fpcf.Entity
 import org.opalj.fpcf.EOptionP
@@ -37,10 +25,29 @@ import org.opalj.fpcf.PropertyStore
 import org.opalj.fpcf.Results
 import org.opalj.fpcf.SomeEPS
 import org.opalj.fpcf.UBP
+import org.opalj.br.analyses.DeclaredMethodsKey
+import org.opalj.br.analyses.ProjectInformationKeys
+import org.opalj.br.analyses.SomeProject
+import org.opalj.br.analyses.cg.ClosedPackagesKey
+import org.opalj.br.analyses.cg.InitialEntryPointsKey
+import org.opalj.br.analyses.cg.InitialInstantiatedTypesKey
+import org.opalj.br.fpcf.BasicFPCFTriggeredAnalysisScheduler
+import org.opalj.br.fpcf.FPCFAnalysis
+import org.opalj.br.fpcf.analyses.ContextProvider
 import org.opalj.br.fpcf.properties.Context
-import org.opalj.tac.cg.TypeIteratorKey
-
-import scala.collection.mutable.ArrayBuffer
+import org.opalj.br.fpcf.properties.cg.Callers
+import org.opalj.br.fpcf.properties.cg.InstantiatedTypes
+import org.opalj.br.fpcf.properties.cg.NoCallers
+import org.opalj.br.fpcf.ContextProviderKey
+import org.opalj.br.instructions.INVOKESPECIAL
+import org.opalj.br.instructions.NEW
+import org.opalj.br.ArrayType
+import org.opalj.br.DeclaredMethod
+import org.opalj.br.Field
+import org.opalj.br.ObjectType
+import org.opalj.br.PCAndInstruction
+import org.opalj.br.ReferenceType
+import org.opalj.br.Type
 
 /**
  * Marks types as instantiated if their constructor is invoked. Constructors invoked by subclass
@@ -62,7 +69,7 @@ class InstantiatedTypesAnalysis private[analyses] (
         val setEntitySelector: TypeSetEntitySelector
 ) extends FPCFAnalysis {
 
-    private[this] implicit val typeIterator: TypeIterator = project.get(TypeIteratorKey)
+    private[this] implicit val contextProvider: ContextProvider = project.get(ContextProviderKey)
 
     def analyze(declaredMethod: DeclaredMethod): PropertyComputationResult = {
         // only constructors may initialize a class
@@ -256,7 +263,7 @@ class InstantiatedTypesAnalysisScheduler(
 ) extends BasicFPCFTriggeredAnalysisScheduler {
 
     override def requiredProjectInformation: ProjectInformationKeys = Seq(
-        TypeIteratorKey, ClosedPackagesKey, DeclaredMethodsKey, InitialEntryPointsKey,
+        ContextProviderKey, ClosedPackagesKey, DeclaredMethodsKey, InitialEntryPointsKey,
         InitialInstantiatedTypesKey
     )
 

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/xta/LibraryInstantiatedTypesBasedEntryPointsAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/xta/LibraryInstantiatedTypesBasedEntryPointsAnalysis.scala
@@ -33,9 +33,9 @@ import org.opalj.br.analyses.DeclaredMethodsKey
 import org.opalj.br.analyses.ProjectInformationKeys
 import org.opalj.br.analyses.SomeProject
 import org.opalj.br.fpcf.FPCFAnalysis
-import org.opalj.tac.fpcf.properties.cg.Callers
-import org.opalj.tac.fpcf.properties.cg.InstantiatedTypes
-import org.opalj.tac.fpcf.properties.cg.OnlyCallersWithUnknownContext
+import org.opalj.br.fpcf.properties.cg.Callers
+import org.opalj.br.fpcf.properties.cg.InstantiatedTypes
+import org.opalj.br.fpcf.properties.cg.OnlyCallersWithUnknownContext
 
 /**
  * In a library analysis scenario, this analysis complements the call graph by marking public

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/xta/TypePropagationAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/xta/TypePropagationAnalysis.scala
@@ -6,8 +6,22 @@ package analyses
 package cg
 package xta
 
+import scala.collection.mutable.ArrayBuffer
 import scala.jdk.CollectionConverters._
 
+import org.opalj.collection.immutable.UIDSet
+import org.opalj.fpcf.Entity
+import org.opalj.fpcf.EPS
+import org.opalj.fpcf.EUBP
+import org.opalj.fpcf.InterimPartialResult
+import org.opalj.fpcf.PartialResult
+import org.opalj.fpcf.ProperPropertyComputationResult
+import org.opalj.fpcf.PropertyBounds
+import org.opalj.fpcf.PropertyKind
+import org.opalj.fpcf.PropertyStore
+import org.opalj.fpcf.Results
+import org.opalj.fpcf.SomeEPS
+import org.opalj.fpcf.SomePartialResult
 import org.opalj.br.Code
 import org.opalj.br.DeclaredMethod
 import org.opalj.br.Field
@@ -18,28 +32,13 @@ import org.opalj.br.analyses.ProjectInformationKeys
 import org.opalj.br.analyses.SomeProject
 import org.opalj.br.fpcf.BasicFPCFTriggeredAnalysisScheduler
 import org.opalj.br.fpcf.FPCFAnalysis
-import org.opalj.tac.fpcf.properties.cg.Callees
-import org.opalj.tac.fpcf.properties.cg.Callers
-import org.opalj.tac.fpcf.properties.cg.InstantiatedTypes
 import org.opalj.br.instructions.CHECKCAST
-import org.opalj.collection.immutable.UIDSet
-import org.opalj.fpcf.EPS
-import org.opalj.fpcf.EUBP
-import org.opalj.fpcf.Entity
-import org.opalj.fpcf.InterimPartialResult
-import org.opalj.fpcf.PartialResult
-import org.opalj.fpcf.ProperPropertyComputationResult
-import org.opalj.fpcf.PropertyBounds
-import org.opalj.fpcf.PropertyKind
-import org.opalj.fpcf.PropertyStore
-import org.opalj.fpcf.Results
-import org.opalj.fpcf.SomeEPS
-import org.opalj.fpcf.SomePartialResult
 import org.opalj.br.DefinedMethod
+import org.opalj.br.fpcf.properties.cg.Callees
+import org.opalj.br.fpcf.properties.cg.Callers
+import org.opalj.br.fpcf.properties.cg.InstantiatedTypes
 import org.opalj.tac.cg.TypeIteratorKey
 import org.opalj.tac.fpcf.properties.TACAI
-
-import scala.collection.mutable.ArrayBuffer
 
 /**
  * This analysis handles the type propagation of XTA, MTA, FTA and CTA call graph
@@ -47,6 +46,7 @@ import scala.collection.mutable.ArrayBuffer
  *
  * @param project         Project under analysis
  * @param selectTypeSetEntity Function which, for each entity, selects which entity its type set is attached to.
+ *
  * @author Andreas Bauer
  */
 final class TypePropagationAnalysis private[analyses] (

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/xta/TypePropagationState.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/xta/TypePropagationState.scala
@@ -6,25 +6,25 @@ package analyses
 package cg
 package xta
 
-import org.opalj.br.ClassHierarchy
-import org.opalj.br.DeclaredMethod
-import org.opalj.br.Method
-import org.opalj.br.PC
-import org.opalj.br.ReferenceType
-import org.opalj.tac.fpcf.properties.cg.Callees
-import org.opalj.tac.fpcf.properties.cg.InstantiatedTypes
-import org.opalj.collection.immutable.UIDSet
-import org.opalj.fpcf.EOptionP
-import org.opalj.fpcf.SomeEOptionP
-import org.opalj.tac.fpcf.properties.TACAI
 import java.util.{HashSet => JHashSet}
 import java.util.{HashMap => JHashMap}
 import java.util.{Set => JSet}
 
 import scala.jdk.CollectionConverters._
 
+import org.opalj.collection.immutable.UIDSet
+import org.opalj.fpcf.EOptionP
+import org.opalj.fpcf.SomeEOptionP
+import org.opalj.br.ClassHierarchy
+import org.opalj.br.DeclaredMethod
+import org.opalj.br.Method
+import org.opalj.br.PC
+import org.opalj.br.ReferenceType
 import org.opalj.br.fpcf.properties.Context
+import org.opalj.br.fpcf.properties.cg.Callees
+import org.opalj.br.fpcf.properties.cg.InstantiatedTypes
 import org.opalj.tac.fpcf.analyses.cg.BaseAnalysisState
+import org.opalj.tac.fpcf.properties.TACAI
 
 /**
  * Manages the state of each method analyzed by [[TypePropagationAnalysis]].

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/xta/TypePropagationTrace.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/xta/TypePropagationTrace.scala
@@ -18,12 +18,12 @@ import scala.collection.mutable
 import org.opalj.collection.immutable.UIDSet
 import org.opalj.fpcf.Entity
 import org.opalj.fpcf.PropertyStore
-import org.opalj.tac.fpcf.properties.cg.InstantiatedTypes
 import org.opalj.br.DefinedMethod
 import org.opalj.br.ReferenceType
-import org.opalj.tac.fpcf.properties.cg.Callees
 import org.opalj.br.DeclaredMethod
 import org.opalj.br.fpcf.properties.Context
+import org.opalj.br.fpcf.properties.cg.Callees
+import org.opalj.br.fpcf.properties.cg.InstantiatedTypes
 import org.opalj.tac.fpcf.analyses.cg.xta.TypePropagationTrace.Trace
 
 /**

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/escape/AbstractEscapeAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/escape/AbstractEscapeAnalysis.scala
@@ -22,12 +22,12 @@ import org.opalj.br.analyses.VirtualFormalParametersKey
 import org.opalj.br.fpcf.properties.EscapeViaReturn
 import org.opalj.br.fpcf.properties.EscapeViaStaticField
 import org.opalj.br.fpcf.FPCFAnalysis
+import org.opalj.br.fpcf.analyses.ContextProvider
 import org.opalj.br.fpcf.properties.Context
 import org.opalj.br.fpcf.properties.GlobalEscape
 import org.opalj.br.fpcf.properties.NoEscape
-import org.opalj.tac.cg.TypeIteratorKey
+import org.opalj.br.fpcf.ContextProviderKey
 import org.opalj.tac.common.DefinitionSiteLike
-import org.opalj.tac.fpcf.analyses.cg.TypeIterator
 import org.opalj.tac.fpcf.properties.TACAI
 
 /**
@@ -439,7 +439,7 @@ trait AbstractEscapeAnalysis extends FPCFAnalysis {
     }
 
     protected[this] implicit val declaredMethods: DeclaredMethods = project.get(DeclaredMethodsKey)
-    protected[this] implicit val typeIterator: TypeIterator = project.get(TypeIteratorKey)
+    protected[this] implicit val contextProvider: ContextProvider = project.get(ContextProviderKey)
 
     protected[this] def createContext(
         entity:       (Context, Entity),

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/escape/AbstractInterProceduralEscapeAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/escape/AbstractInterProceduralEscapeAnalysis.scala
@@ -28,7 +28,7 @@ import org.opalj.br.DeclaredMethod
 import org.opalj.br.DefinedMethod
 import org.opalj.br.analyses.VirtualFormalParameter
 import org.opalj.br.fpcf.properties.Context
-import org.opalj.tac.fpcf.properties.cg.Callees
+import org.opalj.br.fpcf.properties.cg.Callees
 import org.opalj.tac.fpcf.analyses.cg.uVarForDefSites
 
 /**

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/escape/ConstructorSensitiveEscapeAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/escape/ConstructorSensitiveEscapeAnalysis.scala
@@ -72,7 +72,7 @@ trait ConstructorSensitiveEscapeAnalysis extends AbstractEscapeAnalysis {
                 val fp = context.virtualFormalParameters(context.declaredMethods(callee))(0)
                 val fpEntity =
                     (
-                        typeIterator.expandContext(
+                        contextProvider.expandContext(
                             context.entity._1, declaredMethods(callee), call.pc
                         ),
                             fp

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/escape/InterProceduralEscapeAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/escape/InterProceduralEscapeAnalysis.scala
@@ -34,14 +34,14 @@ import org.opalj.br.fpcf.FPCFAnalysisScheduler
 import org.opalj.br.fpcf.properties.GlobalEscape
 import org.opalj.br.fpcf.properties.NoEscape
 import org.opalj.br.fpcf.BasicFPCFLazyAnalysisScheduler
+import org.opalj.br.fpcf.analyses.ContextProvider
 import org.opalj.br.fpcf.properties.Context
 import org.opalj.br.fpcf.properties.SimpleContext
-import org.opalj.tac.fpcf.properties.cg.Callees
-import org.opalj.tac.fpcf.properties.cg.Callers
-import org.opalj.tac.fpcf.properties.cg.NoCallers
-import org.opalj.tac.cg.TypeIteratorKey
+import org.opalj.br.fpcf.ContextProviderKey
+import org.opalj.br.fpcf.properties.cg.Callees
+import org.opalj.br.fpcf.properties.cg.Callers
+import org.opalj.br.fpcf.properties.cg.NoCallers
 import org.opalj.tac.common.DefinitionSitesKey
-import org.opalj.tac.fpcf.analyses.cg.TypeIterator
 import org.opalj.tac.fpcf.properties.TACAI
 
 class InterProceduralEscapeAnalysisContext(
@@ -157,7 +157,7 @@ class InterProceduralEscapeAnalysis private[analyses] (
 sealed trait InterProceduralEscapeAnalysisScheduler extends FPCFAnalysisScheduler {
 
     override def requiredProjectInformation: ProjectInformationKeys =
-        Seq(DeclaredMethodsKey, VirtualFormalParametersKey, IsOverridableMethodKey, TypeIteratorKey)
+        Seq(DeclaredMethodsKey, VirtualFormalParametersKey, IsOverridableMethodKey, ContextProviderKey)
 
     final def derivedProperty: PropertyBounds = PropertyBounds.lub(EscapeProperty)
 
@@ -180,7 +180,7 @@ object EagerInterProceduralEscapeAnalysis
         val analysis = new InterProceduralEscapeAnalysis(p)
 
         val declaredMethods = p.get(DeclaredMethodsKey)
-        implicit val typeIterator: TypeIterator = p.get(TypeIteratorKey)
+        implicit val contextProvider: ContextProvider = p.get(ContextProviderKey)
 
         val methods = declaredMethods.declaredMethods
         val callersProperties = ps(methods.to(Iterable), Callers)

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/escape/ReturnValueFreshnessAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/escape/ReturnValueFreshnessAnalysis.scala
@@ -49,6 +49,7 @@ import org.opalj.br.fpcf.BasicFPCFEagerAnalysisScheduler
 import org.opalj.br.fpcf.BasicFPCFLazyAnalysisScheduler
 import org.opalj.br.fpcf.FPCFAnalysis
 import org.opalj.br.fpcf.FPCFAnalysisScheduler
+import org.opalj.br.fpcf.analyses.ContextProvider
 import org.opalj.br.fpcf.properties.Context
 import org.opalj.br.fpcf.properties.ExtensibleGetter
 import org.opalj.br.fpcf.properties.ExtensibleLocalFieldWithGetter
@@ -56,13 +57,12 @@ import org.opalj.br.fpcf.properties.NoLocalField
 import org.opalj.br.fpcf.properties.SimpleContext
 import org.opalj.br.fpcf.properties.SimpleContexts
 import org.opalj.br.fpcf.properties.SimpleContextsKey
+import org.opalj.br.fpcf.properties.cg.Callees
+import org.opalj.br.fpcf.properties.cg.Callers
+import org.opalj.br.fpcf.ContextProviderKey
 import org.opalj.tac.cg.CallGraphKey
-import org.opalj.tac.cg.TypeIteratorKey
-import org.opalj.tac.fpcf.properties.cg.Callees
-import org.opalj.tac.fpcf.properties.cg.Callers
 import org.opalj.tac.common.DefinitionSite
 import org.opalj.tac.common.DefinitionSitesKey
-import org.opalj.tac.fpcf.analyses.cg.TypeIterator
 import org.opalj.tac.fpcf.properties.TACAI
 
 class ReturnValueFreshnessState(val context: Context) {
@@ -177,7 +177,7 @@ class ReturnValueFreshnessAnalysis private[analyses] (
 
     private[this] implicit val declaredMethods: DeclaredMethods = project.get(DeclaredMethodsKey)
     private[this] val simpleContexts: SimpleContexts = project.get(SimpleContextsKey)
-    private[this] implicit val typeIterator: TypeIterator = project.get(TypeIteratorKey)
+    private[this] implicit val contextProvider: ContextProvider = project.get(ContextProviderKey)
     private[this] val definitionSites = project.get(DefinitionSitesKey)
 
     /**
@@ -530,7 +530,7 @@ sealed trait ReturnValueFreshnessAnalysisScheduler extends FPCFAnalysisScheduler
     final def derivedProperty: PropertyBounds = PropertyBounds.lub(ReturnValueFreshness)
 
     override def requiredProjectInformation: ProjectInformationKeys =
-        Seq(DefinitionSitesKey, SimpleContextsKey, TypeIteratorKey)
+        Seq(DefinitionSitesKey, SimpleContextsKey, ContextProviderKey)
 
     override def uses: Set[PropertyBounds] = {
         Set(

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/escape/SimpleEscapeAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/escape/SimpleEscapeAnalysis.scala
@@ -28,7 +28,7 @@ import org.opalj.br.fpcf.FPCFAnalysis
 import org.opalj.br.fpcf.FPCFAnalysisScheduler
 import org.opalj.br.fpcf.properties.Context
 import org.opalj.br.fpcf.properties.SimpleContextsKey
-import org.opalj.tac.cg.TypeIteratorKey
+import org.opalj.br.fpcf.ContextProviderKey
 import org.opalj.tac.common.DefinitionSitesKey
 import org.opalj.tac.fpcf.properties.TACAI
 
@@ -94,7 +94,7 @@ class SimpleEscapeAnalysis( final val project: SomeProject)
 trait SimpleEscapeAnalysisScheduler extends FPCFAnalysisScheduler {
 
     override def requiredProjectInformation: ProjectInformationKeys =
-        Seq(DeclaredMethodsKey, VirtualFormalParametersKey, TypeIteratorKey)
+        Seq(DeclaredMethodsKey, VirtualFormalParametersKey, ContextProviderKey)
 
     final override def uses: Set[PropertyBounds] = Set(
         PropertyBounds.lub(EscapeProperty),

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/fieldassignability/AbstractFieldAssignabilityAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/fieldassignability/AbstractFieldAssignabilityAnalysis.scala
@@ -5,6 +5,18 @@ package fpcf
 package analyses
 package fieldassignability
 
+import org.opalj.fpcf.Entity
+import org.opalj.fpcf.EOptionP
+import org.opalj.fpcf.FinalEP
+import org.opalj.fpcf.FinalP
+import org.opalj.fpcf.InterimResult
+import org.opalj.fpcf.InterimUBP
+import org.opalj.fpcf.ProperPropertyComputationResult
+import org.opalj.fpcf.Result
+import org.opalj.fpcf.SomeEOptionP
+import org.opalj.fpcf.SomeEPS
+import org.opalj.fpcf.SomeInterimEP
+import org.opalj.value.ValueInformation
 import org.opalj.br.fpcf.FPCFAnalysis
 import org.opalj.br.DeclaredMethod
 import org.opalj.br.Field
@@ -17,32 +29,6 @@ import org.opalj.br.analyses.cg.ClosedPackagesKey
 import org.opalj.br.analyses.cg.TypeExtensibilityKey
 import org.opalj.br.fpcf.properties.Context
 import org.opalj.br.fpcf.properties.EscapeProperty
-import org.opalj.fpcf.EOptionP
-import org.opalj.tac.DUVar
-import org.opalj.tac.cg.TypeIteratorKey
-import org.opalj.tac.common.DefinitionSite
-import org.opalj.tac.common.DefinitionSitesKey
-import org.opalj.tac.fpcf.analyses.cg.TypeIterator
-import org.opalj.tac.fpcf.properties.TACAI
-import org.opalj.tac.fpcf.properties.cg.Callers
-import org.opalj.value.ValueInformation
-import org.opalj.br.fpcf.properties.AtMost
-import org.opalj.br.fpcf.properties.EscapeInCallee
-import org.opalj.br.fpcf.properties.EscapeViaReturn
-import org.opalj.br.fpcf.properties.NoEscape
-import org.opalj.fpcf.Entity
-import org.opalj.fpcf.FinalEP
-import org.opalj.fpcf.FinalP
-import org.opalj.fpcf.InterimUBP
-import org.opalj.fpcf.ProperPropertyComputationResult
-import org.opalj.fpcf.SomeInterimEP
-import org.opalj.tac.Stmt
-import org.opalj.fpcf.InterimResult
-import org.opalj.fpcf.Result
-import org.opalj.fpcf.SomeEPS
-import org.opalj.tac.TACMethodParameter
-import org.opalj.tac.TACode
-import org.opalj.br.ObjectType
 import org.opalj.br.BooleanType
 import org.opalj.br.ByteType
 import org.opalj.br.CharType
@@ -50,13 +36,27 @@ import org.opalj.br.DoubleType
 import org.opalj.br.FloatType
 import org.opalj.br.IntegerType
 import org.opalj.br.LongType
+import org.opalj.br.ObjectType
 import org.opalj.br.ReferenceType
 import org.opalj.br.ShortType
+import org.opalj.br.fpcf.analyses.ContextProvider
+import org.opalj.br.fpcf.properties.AtMost
+import org.opalj.br.fpcf.properties.EscapeInCallee
+import org.opalj.br.fpcf.properties.EscapeViaReturn
+import org.opalj.br.fpcf.properties.NoEscape
+import org.opalj.br.fpcf.properties.cg.Callers
 import org.opalj.br.fpcf.properties.immutability.Assignable
 import org.opalj.br.fpcf.properties.immutability.EffectivelyNonAssignable
 import org.opalj.br.fpcf.properties.immutability.FieldAssignability
 import org.opalj.br.fpcf.properties.immutability.NonAssignable
-import org.opalj.fpcf.SomeEOptionP
+import org.opalj.br.fpcf.ContextProviderKey
+import org.opalj.tac.DUVar
+import org.opalj.tac.common.DefinitionSite
+import org.opalj.tac.common.DefinitionSitesKey
+import org.opalj.tac.fpcf.properties.TACAI
+import org.opalj.tac.Stmt
+import org.opalj.tac.TACMethodParameter
+import org.opalj.tac.TACode
 
 trait AbstractFieldAssignabilityAnalysis extends FPCFAnalysis {
 
@@ -87,7 +87,7 @@ trait AbstractFieldAssignabilityAnalysis extends FPCFAnalysis {
     final val fieldAccessInformation = project.get(FieldAccessInformationKey)
     final val definitionSites = project.get(DefinitionSitesKey)
     implicit final val declaredMethods: DeclaredMethods = project.get(DeclaredMethodsKey)
-    implicit final val typeIterator: TypeIterator = project.get(TypeIteratorKey)
+    implicit final val contextProvider: ContextProvider = project.get(ContextProviderKey)
 
     def doDetermineFieldAssignability(entity: Entity): ProperPropertyComputationResult = {
         entity match {

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/fieldassignability/L1FieldAssignabilityAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/fieldassignability/L1FieldAssignabilityAnalysis.scala
@@ -19,13 +19,13 @@ import org.opalj.tac.PutField
 import org.opalj.tac.PutStatic
 import org.opalj.tac.TACMethodParameter
 import org.opalj.tac.TACode
-import org.opalj.tac.cg.TypeIteratorKey
 import org.opalj.tac.common.DefinitionSitesKey
 import org.opalj.tac.fpcf.properties.TACAI
-import org.opalj.tac.fpcf.properties.cg.Callers
 import org.opalj.tac.SelfReferenceParameter
 import org.opalj.br.Field
+import org.opalj.br.fpcf.properties.cg.Callers
 import org.opalj.br.fpcf.properties.immutability.FieldAssignability
+import org.opalj.br.fpcf.ContextProviderKey
 
 /**
  * Simple analysis that checks if a private (static or instance) field is always initialized at
@@ -98,7 +98,7 @@ sealed trait L1FieldAssignabilityAnalysisScheduler extends FPCFAnalysisScheduler
         ClosedPackagesKey,
         FieldAccessInformationKey,
         DefinitionSitesKey,
-        TypeIteratorKey
+        ContextProviderKey
     )
 
     final override def uses: Set[PropertyBounds] = PropertyBounds.lubs(TACAI, EscapeProperty)

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/fieldassignability/L2FieldAssignabilityAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/fieldassignability/L2FieldAssignabilityAnalysis.scala
@@ -6,7 +6,9 @@ package analyses
 package fieldassignability
 
 import scala.annotation.switch
+
 import scala.collection.mutable
+
 import org.opalj.br.Method
 import org.opalj.br.PCs
 import org.opalj.br.analyses.SomeProject
@@ -14,7 +16,6 @@ import org.opalj.br.fpcf.BasicFPCFEagerAnalysisScheduler
 import org.opalj.br.fpcf.BasicFPCFLazyAnalysisScheduler
 import org.opalj.br.fpcf.FPCFAnalysis
 import org.opalj.br.fpcf.FPCFAnalysisScheduler
-import org.opalj.tac.fpcf.properties.cg.Callers
 import org.opalj.br.fpcf.properties.EscapeProperty
 import org.opalj.fpcf.PropertyBounds
 import org.opalj.fpcf.PropertyStore
@@ -29,6 +30,7 @@ import org.opalj.br.fpcf.properties.immutability.LazilyInitialized
 import org.opalj.tac.common.DefinitionSitesKey
 import org.opalj.RelationalOperators.EQ
 import org.opalj.RelationalOperators.NE
+
 import org.opalj.br.cfg.BasicBlock
 import org.opalj.br.cfg.CFGNode
 import org.opalj.collection.immutable.IntTrieSet
@@ -37,6 +39,8 @@ import org.opalj.br.FieldType
 import org.opalj.br.fpcf.properties.immutability.Assignable
 import org.opalj.br.fpcf.properties.immutability.UnsafelyLazilyInitialized
 import org.opalj.br.Field
+import org.opalj.br.fpcf.properties.cg.Callers
+import org.opalj.br.fpcf.ContextProviderKey
 import org.opalj.tac.CaughtException
 import org.opalj.tac.ClassConst
 import org.opalj.tac.Compare
@@ -898,7 +902,8 @@ trait L2FieldAssignabilityAnalysisScheduler extends FPCFAnalysisScheduler {
         FieldAccessInformationKey,
         ClosedPackagesKey,
         TypeExtensibilityKey,
-        DefinitionSitesKey
+        DefinitionSitesKey,
+        ContextProviderKey
     )
 
     final override def uses: Set[PropertyBounds] = Set(

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/ifds/IFDSEvaluationRunner.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/ifds/IFDSEvaluationRunner.scala
@@ -5,30 +5,32 @@ package fpcf
 package analyses
 package ifds
 
+import scala.language.existentials
+
+import java.io.File
+import java.io.PrintWriter
+
 import com.typesafe.config.ConfigValueFactory
-import org.opalj.ai.domain.l0.PrimitiveTACAIDomain
-import org.opalj.ai.domain.l2
-import org.opalj.ai.fpcf.properties.AIDomainFactoryKey
+import org.opalj.bytecode
+
+import org.opalj.util.Milliseconds
+import org.opalj.util.PerformanceEvaluation.time
+import org.opalj.fpcf.FinalEP
+import org.opalj.fpcf.PropertyStore
+import org.opalj.fpcf.seq.PKESequentialPropertyStore
 import org.opalj.br.DeclaredMethod
 import org.opalj.br.analyses.Project
 import org.opalj.br.analyses.SomeProject
 import org.opalj.br.fpcf.FPCFAnalysesManagerKey
 import org.opalj.br.fpcf.PropertyStoreKey
-import org.opalj.bytecode
-import org.opalj.fpcf.FinalEP
-import org.opalj.fpcf.PropertyStore
-import org.opalj.fpcf.seq.PKESequentialPropertyStore
+import org.opalj.br.fpcf.properties.cg.Callers
+import org.opalj.ai.domain.l0.PrimitiveTACAIDomain
+import org.opalj.ai.domain.l2
+import org.opalj.ai.fpcf.properties.AIDomainFactoryKey
+import org.opalj.tac.cg.RTACallGraphKey
 import org.opalj.ifds.IFDSAnalysis
 import org.opalj.ifds.IFDSAnalysisScheduler
 import org.opalj.ifds.Statistics
-import org.opalj.tac.cg.RTACallGraphKey
-import org.opalj.tac.fpcf.properties.cg.Callers
-import org.opalj.util.Milliseconds
-import org.opalj.util.PerformanceEvaluation.time
-
-import java.io.File
-import java.io.PrintWriter
-import scala.language.existentials
 
 /**
  * Setup to run different Evaluations of IFDS Analyses

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/ifds/JavaICFG.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/ifds/JavaICFG.scala
@@ -5,18 +5,19 @@ package fpcf
 package analyses
 package ifds
 
+import org.opalj.fpcf.FinalEP
+import org.opalj.fpcf.PropertyStore
+import org.opalj.value.ValueInformation
 import org.opalj.br.analyses.DeclaredMethods
 import org.opalj.br.analyses.DeclaredMethodsKey
 import org.opalj.br.analyses.SomeProject
 import org.opalj.br.fpcf.PropertyStoreKey
 import org.opalj.br.DeclaredMethod
 import org.opalj.br.Method
-import org.opalj.fpcf.FinalEP
-import org.opalj.fpcf.PropertyStore
-import org.opalj.ifds.ICFG
-import org.opalj.tac.cg.TypeIteratorKey
-import org.opalj.tac.fpcf.analyses.cg.TypeIterator
-import org.opalj.tac.fpcf.properties.cg.Callees
+import org.opalj.br.fpcf.analyses.ContextProvider
+import org.opalj.br.fpcf.properties.cg.Callees
+import org.opalj.br.fpcf.properties.cg.Callers
+import org.opalj.br.fpcf.ContextProviderKey
 import org.opalj.tac.Assignment
 import org.opalj.tac.DUVar
 import org.opalj.tac.Expr
@@ -31,8 +32,7 @@ import org.opalj.tac.TACMethodParameter
 import org.opalj.tac.TACode
 import org.opalj.tac.VirtualFunctionCall
 import org.opalj.tac.VirtualMethodCall
-import org.opalj.tac.fpcf.properties.cg.Callers
-import org.opalj.value.ValueInformation
+import org.opalj.ifds.ICFG
 
 /**
  * Interprocedural control flow graph for Java projects used in IFDS Analysis
@@ -45,7 +45,7 @@ abstract class JavaICFG(project: SomeProject)
     val tacai: Method => TACode[TACMethodParameter, DUVar[ValueInformation]] = project.get(LazyDetachedTACAIKey)
     val declaredMethods: DeclaredMethods = project.get(DeclaredMethodsKey)
     implicit val propertyStore: PropertyStore = project.get(PropertyStoreKey)
-    implicit val typeIterator: TypeIterator = project.get(TypeIteratorKey)
+    implicit val contextProvider: ContextProvider = project.get(ContextProviderKey)
 
     /**
      * Determines the statements at which the analysis starts.
@@ -108,7 +108,7 @@ abstract class JavaICFG(project: SomeProject)
         val caller = declaredMethods(statement.callable)
         val ep = propertyStore(caller, Callees.key)
         ep match {
-            case FinalEP(_, p) => definedMethods(p.directCallees(typeIterator.newContext(caller), pc).map(_.method))
+            case FinalEP(_, p) => definedMethods(p.directCallees(contextProvider.newContext(caller), pc).map(_.method))
             case _ =>
                 throw new IllegalStateException(
                     "call graph must be computed before the analysis starts"

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/AbstractPointsToAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/AbstractPointsToAnalysis.scala
@@ -29,9 +29,7 @@ import org.opalj.value.IsMultipleReferenceValue
 import org.opalj.value.IsReferenceValue
 import org.opalj.value.IsSArrayValue
 import org.opalj.value.ValueInformation
-import org.opalj.tac.fpcf.properties.cg.Callees
 import org.opalj.br.Method
-import org.opalj.tac.fpcf.properties.cg.NoCallees
 import org.opalj.br.fpcf.properties.pointsto.PointsToSetLike
 import org.opalj.br.ReferenceType
 import org.opalj.br.FieldType
@@ -42,16 +40,18 @@ import org.opalj.br.analyses.ProjectInformationKeys
 import org.opalj.br.analyses.SomeProject
 import org.opalj.br.analyses.VirtualFormalParametersKey
 import org.opalj.br.fpcf.FPCFAnalysis
-import org.opalj.tac.fpcf.properties.cg.Callers
 import org.opalj.br.fpcf.FPCFTriggeredAnalysisScheduler
 import org.opalj.br.DeclaredMethod
+import org.opalj.br.fpcf.analyses.SimpleContextProvider
 import org.opalj.br.fpcf.properties.Context
+import org.opalj.br.fpcf.properties.cg.Callees
+import org.opalj.br.fpcf.properties.cg.Callers
+import org.opalj.br.fpcf.properties.cg.NoCallees
 import org.opalj.tac.cg.TypeIteratorKey
 import org.opalj.tac.common.DefinitionSite
 import org.opalj.tac.common.DefinitionSitesKey
 import org.opalj.tac.fpcf.analyses.cg.ReachableMethodAnalysis
 import org.opalj.tac.fpcf.analyses.cg.valueOriginsOfPCs
-import org.opalj.tac.fpcf.analyses.cg.SimpleContextProvider
 import org.opalj.tac.fpcf.analyses.cg.V
 import org.opalj.tac.fpcf.properties.TACAI
 

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/ArraycopyPointsToAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/ArraycopyPointsToAnalysis.scala
@@ -23,11 +23,11 @@ import org.opalj.br.VoidType
 import org.opalj.br.analyses.DeclaredMethodsKey
 import org.opalj.br.analyses.ProjectInformationKeys
 import org.opalj.br.analyses.VirtualFormalParametersKey
-import org.opalj.br.fpcf.properties.pointsto.AllocationSitePointsToSet
-import org.opalj.br.fpcf.FPCFAnalysis
-import org.opalj.tac.fpcf.properties.cg.Callers
-import org.opalj.br.fpcf.properties.pointsto.TypeBasedPointsToSet
 import org.opalj.br.fpcf.BasicFPCFEagerAnalysisScheduler
+import org.opalj.br.fpcf.FPCFAnalysis
+import org.opalj.br.fpcf.properties.cg.Callers
+import org.opalj.br.fpcf.properties.pointsto.AllocationSitePointsToSet
+import org.opalj.br.fpcf.properties.pointsto.TypeBasedPointsToSet
 import org.opalj.tac.cg.TypeIteratorKey
 import org.opalj.tac.common.DefinitionSitesKey
 import org.opalj.tac.fpcf.analyses.cg.V

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/ConfiguredMethodsPointsToAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/ConfiguredMethodsPointsToAnalysis.scala
@@ -27,8 +27,6 @@ import org.opalj.br.DeclaredMethod
 import org.opalj.br.analyses.DeclaredMethods
 import org.opalj.br.analyses.DeclaredMethodsKey
 import org.opalj.br.ObjectType
-import org.opalj.tac.fpcf.properties.cg.Callers
-import org.opalj.tac.fpcf.properties.cg.NoCallers
 import org.opalj.br.fpcf.properties.pointsto.AllocationSitePointsToSet
 import org.opalj.br.FieldType
 import org.opalj.br.fpcf.properties.pointsto.TypeBasedPointsToSet
@@ -37,9 +35,11 @@ import org.opalj.br.fpcf.properties.pointsto.PointsToSetLike
 import org.opalj.br.ArrayType
 import org.opalj.br.ReferenceType
 import org.opalj.br.analyses.ProjectInformationKeys
+import org.opalj.br.fpcf.analyses.SimpleContextProvider
+import org.opalj.br.fpcf.properties.cg.Callers
+import org.opalj.br.fpcf.properties.cg.NoCallers
 import org.opalj.tac.cg.TypeIteratorKey
 import org.opalj.tac.common.DefinitionSitesKey
-import org.opalj.tac.fpcf.analyses.cg.SimpleContextProvider
 import org.opalj.tac.fpcf.analyses.cg.TypeConsumerAnalysis
 
 /**

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/LibraryPointsToAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/LibraryPointsToAnalysis.scala
@@ -32,8 +32,8 @@ import org.opalj.br.DeclaredMethod
 import org.opalj.br.analyses.VirtualFormalParametersKey
 import org.opalj.br.fpcf.properties.NoContext
 import org.opalj.br.fpcf.FPCFEagerAnalysisScheduler
+import org.opalj.br.fpcf.properties.cg.Callers
 import org.opalj.tac.cg.TypeIteratorKey
-import org.opalj.tac.fpcf.properties.cg.Callers
 
 /**
  * Provides initial points to sets for the parameters of entry point methods, fields and arrays as

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/NewInstanceAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/NewInstanceAnalysis.scala
@@ -32,10 +32,10 @@ import org.opalj.br.analyses.ProjectInformationKeys
 import org.opalj.br.fpcf.BasicFPCFEagerAnalysisScheduler
 import org.opalj.br.fpcf.properties.pointsto.TypeBasedPointsToSet
 import org.opalj.br.ArrayType
+import org.opalj.br.fpcf.properties.cg.Callees
 import org.opalj.tac.cg.TypeIteratorKey
 import org.opalj.tac.common.DefinitionSite
 import org.opalj.tac.common.DefinitionSitesKey
-import org.opalj.tac.fpcf.properties.cg.Callees
 
 /**
  * Introduces object allocations for newInstance reflection methods.

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/PointsToAnalysisBase.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/PointsToAnalysisBase.scala
@@ -5,7 +5,9 @@ package fpcf
 package analyses
 package pointsto
 
+import scala.collection.immutable.ArraySeq
 import scala.collection.mutable.ArrayBuffer
+
 import org.opalj.collection.immutable.IntTrieSet
 import org.opalj.fpcf.Entity
 import org.opalj.fpcf.EOptionP
@@ -27,11 +29,9 @@ import org.opalj.br.ReferenceType
 import org.opalj.br.fpcf.properties.pointsto.PointsToSetLike
 import org.opalj.br.ObjectType
 import org.opalj.br.analyses.VirtualFormalParameter
+import org.opalj.br.fpcf.analyses.SimpleContextProvider
 import org.opalj.br.fpcf.properties.Context
-import org.opalj.tac.fpcf.analyses.cg.SimpleContextProvider
 import org.opalj.tac.fpcf.analyses.cg.TypeConsumerAnalysis
-
-import scala.collection.immutable.ArraySeq
 
 /**
  * Base class for handling instructions in points-to analysis scenarios.

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/PointsToAnalysisState.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/PointsToAnalysisState.scala
@@ -20,14 +20,14 @@ import org.opalj.fpcf.PropertyStore
 import org.opalj.fpcf.SomeEOptionP
 import org.opalj.fpcf.SomeEPK
 import org.opalj.br.Method
-import org.opalj.tac.fpcf.properties.cg.Callees
 import org.opalj.br.fpcf.properties.pointsto.PointsToSetLike
-import org.opalj.tac.fpcf.properties.cg.NoCallees
 import org.opalj.br.ArrayType
 import org.opalj.br.DeclaredMethod
 import org.opalj.br.Field
 import org.opalj.br.ReferenceType
 import org.opalj.br.fpcf.properties.Context
+import org.opalj.br.fpcf.properties.cg.Callees
+import org.opalj.br.fpcf.properties.cg.NoCallees
 import org.opalj.tac.fpcf.analyses.cg.BaseAnalysisState
 import org.opalj.tac.fpcf.properties.TACAI
 

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/ReflectionAllocationsAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/ReflectionAllocationsAnalysis.scala
@@ -1,6 +1,8 @@
 /* BSD 2-Clause License - see OPAL/LICENSE for details. */
 package org.opalj.tac.fpcf.analyses.pointsto
 
+import scala.collection.immutable.ArraySeq
+
 import org.opalj.fpcf.ProperPropertyComputationResult
 import org.opalj.fpcf.PropertyBounds
 import org.opalj.fpcf.PropertyComputationResult
@@ -18,14 +20,12 @@ import org.opalj.br.analyses.ProjectInformationKeys
 import org.opalj.br.analyses.VirtualFormalParametersKey
 import org.opalj.br.fpcf.properties.pointsto.PointsToSetLike
 import org.opalj.br.fpcf.BasicFPCFEagerAnalysisScheduler
-import org.opalj.tac.fpcf.properties.cg.Callers
 import org.opalj.br.fpcf.FPCFAnalysis
+import org.opalj.br.fpcf.properties.cg.Callers
 import org.opalj.br.fpcf.properties.pointsto.AllocationSitePointsToSet
 import org.opalj.tac.cg.TypeIteratorKey
 import org.opalj.tac.common.DefinitionSitesKey
 import org.opalj.tac.fpcf.analyses.APIBasedAnalysis
-
-import scala.collection.immutable.ArraySeq
 
 /**
  * Introduces additional allocation sites for reflection methods.

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/TamiFlexPointsToAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/TamiFlexPointsToAnalysis.scala
@@ -5,6 +5,8 @@ package fpcf
 package analyses
 package pointsto
 
+import scala.collection.immutable.ArraySeq
+
 import org.opalj.fpcf.FinalEP
 import org.opalj.fpcf.ProperPropertyComputationResult
 import org.opalj.fpcf.PropertyBounds
@@ -21,7 +23,6 @@ import org.opalj.br.ObjectType
 import org.opalj.br.analyses.DeclaredMethodsKey
 import org.opalj.br.fpcf.FPCFAnalysis
 import org.opalj.br.IntegerType
-import org.opalj.tac.fpcf.properties.cg.Callers
 import org.opalj.br.fpcf.properties.pointsto.AllocationSitePointsToSet
 import org.opalj.br.fpcf.BasicFPCFEagerAnalysisScheduler
 import org.opalj.br.BooleanType
@@ -30,14 +31,13 @@ import org.opalj.br.VoidType
 import org.opalj.br.analyses.DeclaredMethods
 import org.opalj.br.analyses.ProjectInformationKeys
 import org.opalj.br.analyses.VirtualFormalParametersKey
+import org.opalj.br.fpcf.properties.cg.Callers
 import org.opalj.br.fpcf.properties.pointsto.PointsToSetLike
 import org.opalj.br.fpcf.properties.pointsto.TypeBasedPointsToSet
 import org.opalj.tac.cg.TypeIteratorKey
 import org.opalj.tac.common.DefinitionSitesKey
 import org.opalj.tac.fpcf.analyses.cg.V
 import org.opalj.tac.fpcf.properties.TheTACAI
-
-import scala.collection.immutable.ArraySeq
 
 /**
  * Handles the effect of tamiflex logs for the points-to sets.

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/UnsafePointsToAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/UnsafePointsToAnalysis.scala
@@ -5,6 +5,8 @@ package fpcf
 package analyses
 package pointsto
 
+import scala.collection.immutable.ArraySeq
+
 import org.opalj.fpcf.FinalEP
 import org.opalj.fpcf.ProperPropertyComputationResult
 import org.opalj.fpcf.PropertyBounds
@@ -22,7 +24,6 @@ import org.opalj.br.analyses.DeclaredMethodsKey
 import org.opalj.br.analyses.ProjectInformationKeys
 import org.opalj.br.analyses.VirtualFormalParametersKey
 import org.opalj.br.fpcf.BasicFPCFEagerAnalysisScheduler
-import org.opalj.tac.fpcf.properties.cg.Callers
 import org.opalj.br.fpcf.FPCFAnalysis
 import org.opalj.br.fpcf.properties.pointsto.AllocationSitePointsToSet
 import org.opalj.br.fpcf.properties.pointsto.TypeBasedPointsToSet
@@ -31,12 +32,11 @@ import org.opalj.br.IntegerType
 import org.opalj.br.ReferenceType
 import org.opalj.br.VoidType
 import org.opalj.br.analyses.DeclaredMethods
+import org.opalj.br.fpcf.properties.cg.Callers
 import org.opalj.tac.cg.TypeIteratorKey
 import org.opalj.tac.common.DefinitionSitesKey
 import org.opalj.tac.fpcf.analyses.cg.V
 import org.opalj.tac.fpcf.properties.TheTACAI
-
-import scala.collection.immutable.ArraySeq
 
 /**
  * Models effects of `sun.misc.Unsafe` to points-to sets.

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/package.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/package.scala
@@ -8,28 +8,11 @@ import org.opalj.fpcf.Entity
 import org.opalj.value.ValueInformation
 import org.opalj.br.analyses.VirtualFormalParameters
 import org.opalj.br.fpcf.properties.Context
-import org.opalj.br.PC
-import org.opalj.br.fpcf.properties.pointsto.AllocationSite
+import org.opalj.br.fpcf.analyses.ContextProvider
+import org.opalj.br.fpcf.analyses.SimpleContextProvider
 import org.opalj.tac.common.DefinitionSites
-import org.opalj.tac.fpcf.analyses.cg.SimpleContextProvider
-import org.opalj.tac.fpcf.analyses.cg.TypeIterator
 
 package object pointsto {
-
-    @inline def longToAllocationSite(
-        encodedAllocationSite: AllocationSite
-    )(
-        implicit
-        typeIterator: TypeIterator
-    ): (Context, PC, Int) /* method, pc, typeid */ = {
-        val contextID = encodedAllocationSite.toInt & 0x3FFFFFF
-        val pc = (encodedAllocationSite >> 26).toInt & 0x1FFFF
-        (
-            typeIterator.contextFromId(if (contextID == 0x3FFFFFF) -1 else contextID),
-            if (pc > 0xFFFF) pc | 0xFFFF0000 else pc,
-            (encodedAllocationSite >> 44).toInt
-        )
-    }
 
     /**
      * Given a definition site (value origin) in a certain method, this returns the
@@ -41,7 +24,7 @@ package object pointsto {
         implicit
         formalParameters: VirtualFormalParameters,
         definitionSites:  DefinitionSites,
-        typeIterator:     TypeIterator
+        contextProvider:  ContextProvider
     ): Entity = {
         val entity = if (ai.isMethodExternalExceptionOrigin(defSite)) {
             val pc = ai.pcOfMethodExternalException(defSite)
@@ -54,7 +37,7 @@ package object pointsto {
         } else {
             definitionSites(context.method.definedMethod, stmts(defSite).pc)
         }
-        typeIterator match {
+        contextProvider match {
             case _: SimpleContextProvider => entity
             case _                        => (context, entity)
         }

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/purity/AbstractPurityAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/purity/AbstractPurityAnalysis.scala
@@ -44,7 +44,7 @@ import org.opalj.br.fpcf.properties.Context
 import org.opalj.br.fpcf.properties.Purity
 import org.opalj.br.fpcf.properties.SimpleContexts
 import org.opalj.br.fpcf.properties.SimpleContextsKey
-import org.opalj.tac.fpcf.properties.cg.Callees
+import org.opalj.br.fpcf.properties.cg.Callees
 import org.opalj.ai.ValueOrigin
 import org.opalj.ai.isImmediateVMException
 import org.opalj.br.fpcf.properties.immutability.ClassImmutability
@@ -55,9 +55,9 @@ import org.opalj.br.fpcf.properties.immutability.NonAssignable
 import org.opalj.br.fpcf.properties.immutability.TransitivelyImmutableClass
 import org.opalj.br.fpcf.properties.immutability.TransitivelyImmutableType
 import org.opalj.br.fpcf.properties.immutability.TypeImmutability
-import org.opalj.tac.cg.TypeIteratorKey
+import org.opalj.br.fpcf.ContextProviderKey
+import org.opalj.br.fpcf.analyses.ContextProvider
 import org.opalj.tac.fpcf.analyses.cg.uVarForDefSites
-import org.opalj.tac.fpcf.analyses.cg.TypeIterator
 import org.opalj.tac.fpcf.properties.TACAI
 
 /**
@@ -98,7 +98,7 @@ trait AbstractPurityAnalysis extends FPCFAnalysis {
 
     protected[this] implicit val declaredMethods: DeclaredMethods = project.get(DeclaredMethodsKey)
     private[this] val simpleContexts: Option[SimpleContexts] = project.has(SimpleContextsKey)
-    protected[this] implicit val typeIterator: TypeIterator = project.get(TypeIteratorKey)
+    protected[this] implicit val contextProvider: ContextProvider = project.get(ContextProviderKey)
 
     val configuredPurity: ConfiguredPurity = project.get(ConfiguredPurityKey)
 

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/purity/L1PurityAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/purity/L1PurityAnalysis.scala
@@ -42,12 +42,11 @@ import org.opalj.br.fpcf.FPCFEagerAnalysisScheduler
 import org.opalj.br.fpcf.FPCFAnalysisScheduler
 import org.opalj.br.fpcf.FPCFLazyAnalysisScheduler
 import org.opalj.br.fpcf.analyses.ConfiguredPurityKey
-import org.opalj.tac.fpcf.properties.cg.Callees
-import org.opalj.tac.fpcf.properties.cg.Callers
 import org.opalj.br.MethodDescriptor
 import org.opalj.br.fpcf.properties.Context
 import org.opalj.br.fpcf.properties.SimpleContext
 import org.opalj.br.fpcf.properties.SimpleContextsKey
+import org.opalj.br.fpcf.properties.cg.Callees
 import org.opalj.ai.isImmediateVMException
 import org.opalj.br.fpcf.properties.immutability.ClassImmutability
 import org.opalj.br.fpcf.properties.immutability.EffectivelyNonAssignable
@@ -57,9 +56,11 @@ import org.opalj.br.fpcf.properties.immutability.NonAssignable
 import org.opalj.br.fpcf.properties.immutability.TransitivelyImmutableClass
 import org.opalj.br.fpcf.properties.immutability.TransitivelyImmutableType
 import org.opalj.br.fpcf.properties.immutability.TypeImmutability
+import org.opalj.br.fpcf.properties.cg.Callers
+import org.opalj.br.fpcf.properties.cg.NoCallers
+import org.opalj.br.fpcf.ContextProviderKey
 import org.opalj.tac.cg.CallGraphKey
 import org.opalj.tac.fpcf.properties.TACAI
-import org.opalj.tac.fpcf.properties.cg.NoCallers
 
 /**
  * An inter-procedural analysis to determine a method's purity.
@@ -329,7 +330,7 @@ class L1PurityAnalysis private[analyses] (val project: SomeProject) extends Abst
             candidate foreach { mdc =>
                 if (mdc.method.classFile.thisType != ObjectType.Throwable) {
                     val fISTMethod = declaredMethods(mdc.method)
-                    val fISTContext = typeIterator.expandContext(state.context, fISTMethod, 0)
+                    val fISTContext = contextProvider.expandContext(state.context, fISTMethod, 0)
                     val fISTPurity = propertyStore(fISTContext, Purity.key)
                     if (!checkMethodPurity(fISTPurity, Seq.empty))
                         // Early return for impure fillInStackTrace
@@ -437,7 +438,7 @@ trait L1PurityAnalysisScheduler extends FPCFAnalysisScheduler {
     final def derivedProperty: PropertyBounds = PropertyBounds.lub(Purity)
 
     override def requiredProjectInformation: ProjectInformationKeys =
-        Seq(DeclaredMethodsKey, SimpleContextsKey, ConfiguredPurityKey)
+        Seq(DeclaredMethodsKey, SimpleContextsKey, ConfiguredPurityKey, ContextProviderKey)
 
     override def uses: Set[PropertyBounds] = {
 

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/purity/L2PurityAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/purity/L2PurityAnalysis.scala
@@ -64,19 +64,20 @@ import org.opalj.br.fpcf.FPCFLazyAnalysisScheduler
 import org.opalj.br.fpcf.properties.Purity
 import org.opalj.br.fpcf.FPCFAnalysisScheduler
 import org.opalj.br.fpcf.analyses.ConfiguredPurityKey
-import org.opalj.tac.fpcf.properties.cg.Callees
-import org.opalj.tac.fpcf.properties.cg.Callers
 import org.opalj.br.MethodDescriptor
 import org.opalj.br.fpcf.properties.Context
 import org.opalj.br.fpcf.properties.SimpleContext
 import org.opalj.br.fpcf.properties.SimpleContextsKey
+import org.opalj.br.fpcf.properties.cg.Callees
 import org.opalj.ai.isImmediateVMException
 import org.opalj.br.fpcf.properties.immutability.ClassImmutability
 import org.opalj.br.fpcf.properties.immutability.FieldAssignability
 import org.opalj.br.fpcf.properties.immutability.TypeImmutability
+import org.opalj.br.fpcf.properties.cg.Callers
+import org.opalj.br.fpcf.properties.cg.NoCallers
+import org.opalj.br.fpcf.ContextProviderKey
 import org.opalj.tac.cg.CallGraphKey
 import org.opalj.tac.fpcf.properties.TACAI
-import org.opalj.tac.fpcf.properties.cg.NoCallers
 
 /**
  * An inter-procedural analysis to determine a method's purity.
@@ -835,7 +836,7 @@ class L2PurityAnalysis private[analyses] (val project: SomeProject) extends Abst
             candidate foreach { mdc =>
                 if (mdc.method.classFile.thisType != ObjectType.Throwable) {
                     val fISTMethod = declaredMethods(mdc.method)
-                    val fISTContext = typeIterator.expandContext(state.context, fISTMethod, 0)
+                    val fISTContext = contextProvider.expandContext(state.context, fISTMethod, 0)
                     val fISTPurity = propertyStore(fISTContext, Purity.key)
                     val self = UVar(
                         ASObjectValue(isNull = No, isPrecise = false, state.declClass),
@@ -956,7 +957,7 @@ trait L2PurityAnalysisScheduler extends FPCFAnalysisScheduler {
     final def derivedProperty: PropertyBounds = PropertyBounds.lub(Purity)
 
     override def requiredProjectInformation: ProjectInformationKeys =
-        Seq(DeclaredMethodsKey, SimpleContextsKey, ConfiguredPurityKey)
+        Seq(DeclaredMethodsKey, SimpleContextsKey, ConfiguredPurityKey, ContextProviderKey)
 
     override def uses: Set[PropertyBounds] = {
         Set(

--- a/OPAL/tac/src/test/scala/org/opalj/tac/fpcf/properties/CallersTest.scala
+++ b/OPAL/tac/src/test/scala/org/opalj/tac/fpcf/properties/CallersTest.scala
@@ -19,18 +19,18 @@ import org.opalj.br.analyses.Project
 import org.opalj.br.reader.Java8Framework.ClassFiles
 import org.opalj.br.DeclaredMethod
 import org.opalj.br.analyses.SomeProject
+import org.opalj.br.fpcf.analyses.ContextProvider
 import org.opalj.br.fpcf.properties.SimpleContexts
 import org.opalj.br.fpcf.properties.SimpleContextsKey
+import org.opalj.br.fpcf.properties.cg.Callers
+import org.opalj.br.fpcf.properties.cg.CallersImplWithOtherCalls
+import org.opalj.br.fpcf.properties.cg.CallersOnlyWithConcreteCallers
+import org.opalj.br.fpcf.properties.cg.NoCallers
+import org.opalj.br.fpcf.properties.cg.OnlyCallersWithUnknownContext
+import org.opalj.br.fpcf.properties.cg.OnlyVMCallersAndWithUnknownContext
+import org.opalj.br.fpcf.properties.cg.OnlyVMLevelCallers
+import org.opalj.br.fpcf.ContextProviderKey
 import org.opalj.tac.cg.CHACallGraphKey
-import org.opalj.tac.cg.TypeIteratorKey
-import org.opalj.tac.fpcf.analyses.cg.TypeIterator
-import org.opalj.tac.fpcf.properties.cg.Callers
-import org.opalj.tac.fpcf.properties.cg.CallersImplWithOtherCalls
-import org.opalj.tac.fpcf.properties.cg.CallersOnlyWithConcreteCallers
-import org.opalj.tac.fpcf.properties.cg.NoCallers
-import org.opalj.tac.fpcf.properties.cg.OnlyCallersWithUnknownContext
-import org.opalj.tac.fpcf.properties.cg.OnlyVMCallersAndWithUnknownContext
-import org.opalj.tac.fpcf.properties.cg.OnlyVMLevelCallers
 
 @RunWith(classOf[JUnitRunner])
 class CallersTest extends AnyFlatSpec with Matchers {
@@ -44,7 +44,7 @@ class CallersTest extends AnyFlatSpec with Matchers {
     typesProject.get(CHACallGraphKey)
     implicit val declaredMethods: DeclaredMethods = typesProject.get(DeclaredMethodsKey)
     val simpleContexts: SimpleContexts = typesProject.get(SimpleContextsKey)
-    implicit val typeIterator: TypeIterator = typesProject.get(TypeIteratorKey)
+    implicit val contextProvider: ContextProvider = typesProject.get(ContextProviderKey)
 
     val declaredMethod: DeclaredMethod = declaredMethods.declaredMethods.find(_ => true).get
     val otherMethod: DeclaredMethod = declaredMethods.declaredMethods.find(_ ne declaredMethod).get


### PR DESCRIPTION
The `ContextProvider` interface now allows using context functions in `br` and provides better separation of concerns as many clients don't need the full `TypeIterator`.