### PR TITLE
Make uncaughtException from ThreadGroup subtypes VM-reachable

### DIFF
--- a/DEVELOPING_OPAL/validate/src/test/java/org/opalj/fpcf/fixtures/threads/CreateThreadGroup.java
+++ b/DEVELOPING_OPAL/validate/src/test/java/org/opalj/fpcf/fixtures/threads/CreateThreadGroup.java
@@ -7,7 +7,7 @@ import org.opalj.fpcf.properties.callgraph.VMReachable;
 public class CreateThreadGroup {
     @DirectCall(
             name = "run",
-            line = 16,
+            line = 15,
             resolvedTargets = {"Lorg/opalj/fpcf/fixtures/threads/MyRunnable;"})
     public static void main(String[] args) {
         ThreadGroup myThreadGroup = new MyThreadGroup();

--- a/DEVELOPING_OPAL/validate/src/test/java/org/opalj/fpcf/fixtures/threads/CreateThreadGroup.java
+++ b/DEVELOPING_OPAL/validate/src/test/java/org/opalj/fpcf/fixtures/threads/CreateThreadGroup.java
@@ -1,5 +1,5 @@
+/* BSD 2-Clause License - see OPAL/LICENSE for details. */
 package org.opalj.fpcf.fixtures.threads;
-
 
 import org.opalj.fpcf.properties.callgraph.DirectCall;
 import org.opalj.fpcf.properties.callgraph.VMReachable;
@@ -8,22 +8,22 @@ public class CreateThreadGroup {
     @DirectCall(
             name = "run",
             line = 16,
-            resolvedTargets = {
-                    "Lorg/opalj/fpcf/fixtures/threads/MyRunnable;"})
+            resolvedTargets = {"Lorg/opalj/fpcf/fixtures/threads/MyRunnable;"})
     public static void main(String[] args) {
         ThreadGroup myThreadGroup = new MyThreadGroup();
         Thread testThread = new Thread(myThreadGroup, new MyRunnable());
         testThread.start();
     }
 }
+
 class MyRunnable implements Runnable {
     @Override
     public void run() {
         System.out.println("Hello");
     }
 }
-class MyThreadGroup extends ThreadGroup {
 
+class MyThreadGroup extends ThreadGroup {
 
     public MyThreadGroup() {
         super("mythreadgroup");

--- a/DEVELOPING_OPAL/validate/src/test/java/org/opalj/fpcf/fixtures/threads/CreateThreadGroup.java
+++ b/DEVELOPING_OPAL/validate/src/test/java/org/opalj/fpcf/fixtures/threads/CreateThreadGroup.java
@@ -7,7 +7,7 @@ import org.opalj.fpcf.properties.callgraph.VMReachable;
 public class CreateThreadGroup {
     @DirectCall(
             name = "run",
-            line = 17,
+            line = 16,
             resolvedTargets = {
                     "Lorg/opalj/fpcf/fixtures/threads/MyRunnable;"})
     public static void main(String[] args) {

--- a/DEVELOPING_OPAL/validate/src/test/java/org/opalj/fpcf/fixtures/threads/CreateThreadGroup.java
+++ b/DEVELOPING_OPAL/validate/src/test/java/org/opalj/fpcf/fixtures/threads/CreateThreadGroup.java
@@ -1,0 +1,38 @@
+package org.opalj.fpcf.fixtures.threads;
+
+
+import org.opalj.fpcf.properties.callgraph.DirectCall;
+import org.opalj.fpcf.properties.callgraph.VMReachable;
+
+public class CreateThreadGroup {
+    @DirectCall(
+            name = "run",
+            line = 17,
+            resolvedTargets = {
+                    "Lorg/opalj/fpcf/fixtures/threads/MyRunnable;"})
+    public static void main(String[] args) {
+        ThreadGroup myThreadGroup = new MyThreadGroup();
+        Thread testThread = new Thread(myThreadGroup, new MyRunnable());
+        testThread.start();
+    }
+}
+class MyRunnable implements Runnable {
+    @Override
+    public void run() {
+        System.out.println("Hello");
+    }
+}
+class MyThreadGroup extends ThreadGroup {
+
+
+    public MyThreadGroup() {
+        super("mythreadgroup");
+    }
+
+    @VMReachable
+    @Override
+    public void uncaughtException(Thread t, Throwable e) {
+        e.printStackTrace();
+        super.uncaughtException(t, e);
+    }
+}

--- a/DEVELOPING_OPAL/validate/src/test/java/org/opalj/fpcf/properties/callgraph/VMReachable.java
+++ b/DEVELOPING_OPAL/validate/src/test/java/org/opalj/fpcf/properties/callgraph/VMReachable.java
@@ -1,0 +1,32 @@
+/* BSD 2-Clause License - see OPAL/LICENSE for details. */
+package org.opalj.fpcf.properties.callgraph;
+
+import org.opalj.fpcf.properties.PropertyValidator;
+import org.opalj.tac.fpcf.analyses.cg.TypeIterator;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.CLASS;
+
+/**
+ * Describes a method that should be marked as vm-reachable
+ *
+ * @author Julius Naeumann
+ */
+@Retention(CLASS)
+@Target({METHOD, CONSTRUCTOR})
+@Documented
+@PropertyValidator(key = "VMReachable", validator = VMReachableMethodMatcher.class)
+public @interface VMReachable {
+
+    /**
+     * The call graph analyses which we expect to resolve the annotated calls.
+     * If the list is empty, we assume the annotation applies to any call graph
+     * algorithm.
+     */
+    Class<? extends TypeIterator>[] analyses() default {};
+}

--- a/DEVELOPING_OPAL/validate/src/test/scala/org/opalj/fpcf/ThreadRelatedCallsTest.scala
+++ b/DEVELOPING_OPAL/validate/src/test/scala/org/opalj/fpcf/ThreadRelatedCallsTest.scala
@@ -1,0 +1,66 @@
+/* BSD 2-Clause License - see OPAL/LICENSE for details. */
+package org.opalj.fpcf
+
+import com.typesafe.config.{Config, ConfigValueFactory}
+import org.opalj.ai.domain.l1.DefaultReferenceValuesDomainWithCFGAndDefUse
+import org.opalj.ai.fpcf.properties.AIDomainFactoryKey
+import org.opalj.br.analyses.Project
+import org.opalj.br.analyses.cg.{InitialEntryPointsKey, InitialInstantiatedTypesKey}
+import org.opalj.tac.cg.{CHACallGraphKey, TypeIteratorKey}
+import org.opalj.tac.fpcf.analyses.LazyTACAIProvider
+import org.opalj.tac.fpcf.analyses.cg._
+import org.opalj.tac.fpcf.analyses.pointsto.AllocationSiteBasedPointsToAnalysisScheduler
+
+import java.net.URL
+
+/**
+ * Tests  ThreadRelatedCallsAnalysis
+ *
+ * @author Julius Naeumann
+ */
+class ThreadRelatedCallsTest extends PropertiesTest {
+
+    override def init(p: Project[URL]): Unit = {
+        p.updateProjectInformationKeyInitializationData(TypeIteratorKey) {
+            case Some(_) => throw new IllegalArgumentException()
+            case None    => () => CHACallGraphKey.getTypeIterator(p)
+        }
+        val requiredDomains: Set[Class[_ <: AnyRef]] = Set(classOf[DefaultReferenceValuesDomainWithCFGAndDefUse[_]])
+        p.updateProjectInformationKeyInitializationData(AIDomainFactoryKey) {
+            case None               => requiredDomains
+            case Some(requirements) => requirements ++ requiredDomains
+        }
+    }
+
+    override def createConfig(): Config = {
+        val baseConfig = super.createConfig()
+        // For these tests, we want to restrict entry points to "main" methods.
+        // Also, no types should be instantiated by default.
+        baseConfig.withValue(
+            InitialEntryPointsKey.ConfigKeyPrefix+"analysis",
+            ConfigValueFactory.fromAnyRef("org.opalj.br.analyses.cg.ApplicationEntryPointsFinder")
+        ).withValue(
+                InitialInstantiatedTypesKey.ConfigKeyPrefix+"analysis",
+                ConfigValueFactory.fromAnyRef("org.opalj.br.analyses.cg.ApplicationInstantiatedTypesFinder")
+            )
+    }
+
+    override def fixtureProjectPackage: List[String] = {
+        List("org/opalj/fpcf/fixtures/threads/")
+    }
+
+    describe("ThreadStartAnalysis is executed") {
+
+        val as = executeAnalyses(
+            Set(LazyTACAIProvider, AllocationSiteBasedPointsToAnalysisScheduler, CallGraphAnalysisScheduler, ThreadRelatedCallsAnalysisScheduler)
+        )
+        as.propertyStore.shutdown()
+
+        validateProperties(
+            as,
+            declaredMethodsWithAnnotations(as.project),
+            Set("Callees", "VMReachable")
+        )
+    }
+
+}

--- a/DEVELOPING_OPAL/validate/src/test/scala/org/opalj/fpcf/ThreadRelatedCallsTest.scala
+++ b/DEVELOPING_OPAL/validate/src/test/scala/org/opalj/fpcf/ThreadRelatedCallsTest.scala
@@ -55,8 +55,10 @@ class ThreadRelatedCallsTest extends PropertiesTest {
     describe("ThreadStartAnalysis is executed") {
 
         val as = executeAnalyses(
-            Set(LazyTACAIProvider, AllocationSiteBasedPointsToAnalysisScheduler,
-                CallGraphAnalysisScheduler, ThreadRelatedCallsAnalysisScheduler)
+            Set(LazyTACAIProvider,
+                AllocationSiteBasedPointsToAnalysisScheduler,
+                CallGraphAnalysisScheduler,
+                ThreadRelatedCallsAnalysisScheduler)
         )
         as.propertyStore.shutdown()
 

--- a/DEVELOPING_OPAL/validate/src/test/scala/org/opalj/fpcf/ThreadRelatedCallsTest.scala
+++ b/DEVELOPING_OPAL/validate/src/test/scala/org/opalj/fpcf/ThreadRelatedCallsTest.scala
@@ -1,14 +1,19 @@
 /* BSD 2-Clause License - see OPAL/LICENSE for details. */
-package org.opalj.fpcf
+package org.opalj
+package fpcf
 
-import com.typesafe.config.{Config, ConfigValueFactory}
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigValueFactory
 import org.opalj.ai.domain.l1.DefaultReferenceValuesDomainWithCFGAndDefUse
 import org.opalj.ai.fpcf.properties.AIDomainFactoryKey
 import org.opalj.br.analyses.Project
-import org.opalj.br.analyses.cg.{InitialEntryPointsKey, InitialInstantiatedTypesKey}
-import org.opalj.tac.cg.{CHACallGraphKey, TypeIteratorKey}
+import org.opalj.br.analyses.cg.InitialEntryPointsKey
+import org.opalj.br.analyses.cg.InitialInstantiatedTypesKey
+import org.opalj.tac.cg.CHACallGraphKey
+import org.opalj.tac.cg.TypeIteratorKey
 import org.opalj.tac.fpcf.analyses.LazyTACAIProvider
-import org.opalj.tac.fpcf.analyses.cg._
+import org.opalj.tac.fpcf.analyses.cg.CallGraphAnalysisScheduler
+import org.opalj.tac.fpcf.analyses.cg.ThreadRelatedCallsAnalysisScheduler
 import org.opalj.tac.fpcf.analyses.pointsto.AllocationSiteBasedPointsToAnalysisScheduler
 
 import java.net.URL
@@ -36,11 +41,9 @@ class ThreadRelatedCallsTest extends PropertiesTest {
         val baseConfig = super.createConfig()
         // For these tests, we want to restrict entry points to "main" methods.
         // Also, no types should be instantiated by default.
-        baseConfig.withValue(
-            InitialEntryPointsKey.ConfigKeyPrefix+"analysis",
+        baseConfig.withValue(InitialEntryPointsKey.ConfigKeyPrefix+"analysis",
             ConfigValueFactory.fromAnyRef("org.opalj.br.analyses.cg.ApplicationEntryPointsFinder")
-        ).withValue(
-                InitialInstantiatedTypesKey.ConfigKeyPrefix+"analysis",
+        ).withValue(InitialInstantiatedTypesKey.ConfigKeyPrefix+"analysis",
                 ConfigValueFactory.fromAnyRef("org.opalj.br.analyses.cg.ApplicationInstantiatedTypesFinder")
             )
     }
@@ -52,7 +55,8 @@ class ThreadRelatedCallsTest extends PropertiesTest {
     describe("ThreadStartAnalysis is executed") {
 
         val as = executeAnalyses(
-            Set(LazyTACAIProvider, AllocationSiteBasedPointsToAnalysisScheduler, CallGraphAnalysisScheduler, ThreadRelatedCallsAnalysisScheduler)
+            Set(LazyTACAIProvider, AllocationSiteBasedPointsToAnalysisScheduler,
+                CallGraphAnalysisScheduler, ThreadRelatedCallsAnalysisScheduler)
         )
         as.propertyStore.shutdown()
 

--- a/DEVELOPING_OPAL/validate/src/test/scala/org/opalj/fpcf/ThreadRelatedCallsTest.scala
+++ b/DEVELOPING_OPAL/validate/src/test/scala/org/opalj/fpcf/ThreadRelatedCallsTest.scala
@@ -41,9 +41,11 @@ class ThreadRelatedCallsTest extends PropertiesTest {
         val baseConfig = super.createConfig()
         // For these tests, we want to restrict entry points to "main" methods.
         // Also, no types should be instantiated by default.
-        baseConfig.withValue(InitialEntryPointsKey.ConfigKeyPrefix+"analysis",
+        baseConfig.withValue(
+            InitialEntryPointsKey.ConfigKeyPrefix+"analysis",
             ConfigValueFactory.fromAnyRef("org.opalj.br.analyses.cg.ApplicationEntryPointsFinder")
-        ).withValue(InitialInstantiatedTypesKey.ConfigKeyPrefix+"analysis",
+        ).withValue(
+                InitialInstantiatedTypesKey.ConfigKeyPrefix+"analysis",
                 ConfigValueFactory.fromAnyRef("org.opalj.br.analyses.cg.ApplicationInstantiatedTypesFinder")
             )
     }
@@ -55,10 +57,12 @@ class ThreadRelatedCallsTest extends PropertiesTest {
     describe("ThreadStartAnalysis is executed") {
 
         val as = executeAnalyses(
-            Set(LazyTACAIProvider,
+            Set(
+                LazyTACAIProvider,
                 AllocationSiteBasedPointsToAnalysisScheduler,
                 CallGraphAnalysisScheduler,
-                ThreadRelatedCallsAnalysisScheduler)
+                ThreadRelatedCallsAnalysisScheduler
+            )
         )
         as.propertyStore.shutdown()
 

--- a/DEVELOPING_OPAL/validate/src/test/scala/org/opalj/fpcf/ThreadRelatedCallsTest.scala
+++ b/DEVELOPING_OPAL/validate/src/test/scala/org/opalj/fpcf/ThreadRelatedCallsTest.scala
@@ -23,7 +23,7 @@ class ThreadRelatedCallsTest extends PropertiesTest {
     override def init(p: Project[URL]): Unit = {
         p.updateProjectInformationKeyInitializationData(TypeIteratorKey) {
             case Some(_) => throw new IllegalArgumentException()
-            case None    => () => CHACallGraphKey.getTypeIterator(p)
+            case None    => CHACallGraphKey.getTypeIterator(p)
         }
         val requiredDomains: Set[Class[_ <: AnyRef]] = Set(classOf[DefaultReferenceValuesDomainWithCFGAndDefUse[_]])
         p.updateProjectInformationKeyInitializationData(AIDomainFactoryKey) {

--- a/DEVELOPING_OPAL/validate/src/test/scala/org/opalj/fpcf/properties/callgraph/VMReachableMethodMatcher.scala
+++ b/DEVELOPING_OPAL/validate/src/test/scala/org/opalj/fpcf/properties/callgraph/VMReachableMethodMatcher.scala
@@ -3,9 +3,9 @@ package org.opalj.fpcf.properties.callgraph
 
 import org.opalj.br.{AnnotationLike, ElementValue, ObjectType}
 import org.opalj.br.analyses.Project
+import org.opalj.br.fpcf.properties.cg.Callers
 import org.opalj.fpcf.Property
 import org.opalj.fpcf.properties.AbstractPropertyMatcher
-import org.opalj.tac.fpcf.properties.cg.Callers
 
 class VMReachableMethodMatcher extends AbstractPropertyMatcher {
 

--- a/DEVELOPING_OPAL/validate/src/test/scala/org/opalj/fpcf/properties/callgraph/VMReachableMethodMatcher.scala
+++ b/DEVELOPING_OPAL/validate/src/test/scala/org/opalj/fpcf/properties/callgraph/VMReachableMethodMatcher.scala
@@ -1,0 +1,44 @@
+/* BSD 2-Clause License - see OPAL/LICENSE for details. */
+package org.opalj.fpcf.properties.callgraph
+
+import org.opalj.br.{AnnotationLike, ElementValue, ObjectType}
+import org.opalj.br.analyses.Project
+import org.opalj.fpcf.Property
+import org.opalj.fpcf.properties.AbstractPropertyMatcher
+import org.opalj.tac.fpcf.properties.cg.Callers
+
+class VMReachableMethodMatcher extends AbstractPropertyMatcher {
+
+    override def validateProperty(
+        p:          Project[_],
+        as:         Set[ObjectType],
+        entity:     Any,
+        a:          AnnotationLike,
+        properties: Iterable[Property]
+    ): Option[String] = {
+        val annotationType = a.annotationType.asObjectType
+
+        // Get call graph analyses for which this annotation applies.
+        val analysesElementValues: Seq[ElementValue] =
+            getValue(p, annotationType, a.elementValuePairs, "analyses").asArrayValue.values
+        val analyses = analysesElementValues.map(ev => ev.asClassValue.value.asObjectType)
+
+        // If none of the annotated analyses match the executed ones, return...
+        // If the list of specified analyses is empty, we assume the annotation applies to all
+        // call graph algorithms, so we don't exit early.
+        if (analyses.nonEmpty && !analyses.exists(as.contains))
+            return None
+
+        val callersP = {
+            properties.find(_.isInstanceOf[Callers]) match {
+                case Some(property) => property.asInstanceOf[Callers]
+                case None           => return Some("Callers property is missing.");
+            }
+        }
+        if (!callersP.hasVMLevelCallers) {
+            Some(s"Method not VM Reachable")
+        } else {
+            None
+        }
+    }
+}

--- a/DEVELOPING_OPAL/validate/src/test/scala/org/opalj/fpcf/properties/callgraph/VMReachableMethodMatcher.scala
+++ b/DEVELOPING_OPAL/validate/src/test/scala/org/opalj/fpcf/properties/callgraph/VMReachableMethodMatcher.scala
@@ -1,7 +1,12 @@
 /* BSD 2-Clause License - see OPAL/LICENSE for details. */
-package org.opalj.fpcf.properties.callgraph
+package org.opalj
+package fpcf
+package properties
+package callgraph
 
-import org.opalj.br.{AnnotationLike, ElementValue, ObjectType}
+import org.opalj.br.AnnotationLike
+import org.opalj.br.ElementValue
+import org.opalj.br.ObjectType
 import org.opalj.br.analyses.Project
 import org.opalj.br.fpcf.properties.cg.Callers
 import org.opalj.fpcf.Property

--- a/OPAL/br/src/main/resources/reference.conf
+++ b/OPAL/br/src/main/resources/reference.conf
@@ -68,7 +68,7 @@ org.opalj {
             {declaringClass = "java/lang/Thread", name = "<init>", descriptor = "(Ljava/lang/ThreadGroup;Ljava/lang/String;)V"},
             {declaringClass = "java/lang/ThreadGroup", name = "<init>", descriptor = "()V"},
             {declaringClass = "java/lang/Thread", name = "exit", descriptor = "()V"},
-            {declaringClass = "java/lang/ThreadGroup", name = "uncaughtException", descriptor = "(Ljava/lang/Thread;Ljava/lang/Throwable;)V"},
+            {declaringClass = "java/lang/ThreadGroup+", name = "uncaughtException", descriptor = "(Ljava/lang/Thread;Ljava/lang/Throwable;)V"},
             {declaringClass = "java/lang/ref/Reference$ReferenceHandler", name = "run", descriptor = "()V"},
             {declaringClass = "java/lang/ClassLoader", name = " <init>", descriptor = "()V"},
             {declaringClass = "java/lang/ClassLoader", name = "loadClassInternal", descriptor = "(Ljava/lang/String;)Ljava/lang/Class;"},
@@ -79,17 +79,17 @@ org.opalj {
           ]
           # additional entry points can be specified by adding a respective tuple that must consist of
           # a class name and a method name and can be refined by also defining a method descriptor.
-          # In addition, the specified class name can be suffixed with a "+" which implies that all methods that match the
-          # specified name -- and if definied descriptor -- from subtypes are considered too.
+          # In addition, the specified class name can be suffixed with a "+" which implies that all methods that match
+          # the specified name -- and if definied descriptor -- from subtypes are considered too.
           # eg.:
           # entryPoints = [
-          #   {declaringClass = "java/util/List", name = "add"},
+          #   {declaringClass = "java/util/List+", name = "add"},
           #   {declaringClass = "java/util/List", name = "remove", descriptor = "(I)Z"}
           # ]
-          # Please note that the first entry point, by adding the "=" to the declaring class' name, considers all
-          # "add" methods from all subtypes independently form the respective method's descriptor. In constrast,
-          # the second entry does specify a descriptor and does not consider list subtypes (by not suffixing a plus to
-          # the declaringClass) which implies that only the remove method with this descriptor is considered as entry point.
+          # Please note that the first entry point, by adding the "+" to the declaring class' name, considers all
+          # "add" methods from all subtypes. In constrast, the second entry does specify a descriptor and does not
+          # consider list subtypes (by not suffixing a plus to the declaringClass) which implies that only the remove
+          # method with this descriptor is considered as entry point.
         }
 
         InitialInstantiatedTypesKey {

--- a/OPAL/br/src/main/resources/reference.conf
+++ b/OPAL/br/src/main/resources/reference.conf
@@ -68,6 +68,7 @@ org.opalj {
             {declaringClass = "java/lang/Thread", name = "<init>", descriptor = "(Ljava/lang/ThreadGroup;Ljava/lang/String;)V"},
             {declaringClass = "java/lang/ThreadGroup", name = "<init>", descriptor = "()V"},
             {declaringClass = "java/lang/Thread", name = "exit", descriptor = "()V"},
+            {declaringClass = "java/lang/ThreadGroup", name = "uncaughtException", descriptor = "(Ljava/lang/Thread;Ljava/lang/Throwable;)V"},
             {declaringClass = "java/lang/ref/Reference$ReferenceHandler", name = "run", descriptor = "()V"},
             {declaringClass = "java/lang/ClassLoader", name = " <init>", descriptor = "()V"},
             {declaringClass = "java/lang/ClassLoader", name = "loadClassInternal", descriptor = "(Ljava/lang/String;)Ljava/lang/Class;"},

--- a/OPAL/br/src/main/resources/reference.conf
+++ b/OPAL/br/src/main/resources/reference.conf
@@ -68,7 +68,6 @@ org.opalj {
             {declaringClass = "java/lang/Thread", name = "<init>", descriptor = "(Ljava/lang/ThreadGroup;Ljava/lang/String;)V"},
             {declaringClass = "java/lang/ThreadGroup", name = "<init>", descriptor = "()V"},
             {declaringClass = "java/lang/Thread", name = "exit", descriptor = "()V"},
-            {declaringClass = "java/lang/ThreadGroup+", name = "uncaughtException", descriptor = "(Ljava/lang/Thread;Ljava/lang/Throwable;)V"},
             {declaringClass = "java/lang/ref/Reference$ReferenceHandler", name = "run", descriptor = "()V"},
             {declaringClass = "java/lang/ClassLoader", name = " <init>", descriptor = "()V"},
             {declaringClass = "java/lang/ClassLoader", name = "loadClassInternal", descriptor = "(Ljava/lang/String;)Ljava/lang/Class;"},

--- a/OPAL/br/src/main/scala/org/opalj/br/Type.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/Type.scala
@@ -1315,6 +1315,7 @@ object ObjectType {
     final val RuntimeException = ObjectType("java/lang/RuntimeException")
 
     final val Thread = ObjectType("java/lang/Thread")
+    final val ThreadGroup = ObjectType("java/lang/ThreadGroup")
     final val Runnable = ObjectType("java/lang/Runnable")
 
     // Types related to the invokedynamic instruction

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/ThreadRelatedCallsAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/ThreadRelatedCallsAnalysis.scala
@@ -316,7 +316,7 @@ class ThreadStartAnalysis private[cg] (
                 if (indexOfThreadGroupParameter != -1) {
                     val theReceiver = params(indexOfThreadGroupParameter).asVar
                     for (threadGroupValue <- theReceiver.value.asReferenceValue.allValues) {
-                        if (threadGroupValue.isPrecise) {
+                        if (threadGroupValue.isPrecise && threadGroupValue.isNull.isNo) {
                             addThreadGroupMethod(
                                 callContext,
                                 callPC,

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/ThreadRelatedCallsAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/ThreadRelatedCallsAnalysis.scala
@@ -61,7 +61,7 @@ class ThreadStartAnalysis private[cg] (
         targetVarOption: Option[V],
         isDirect:        Boolean
     ): ProperPropertyComputationResult = {
-        val partialAnalysisResults = new ThreadStartAnalysisResults();
+        val partialAnalysisResults = new ThreadStartAnalysisResults()
         implicit val state: CGState[ContextType] = new CGState[ContextType](
             callerContext, FinalEP(callerContext.method.definedMethod, TheTACAI(tac))
         )

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/ThreadRelatedCallsAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/ThreadRelatedCallsAnalysis.scala
@@ -321,11 +321,6 @@ class ThreadStartAnalysis private[cg] (
                                 callContext,
                                 callPC,
                                 threadGroupValue,
-                                if (callContext.method == allocationContext.method)
-                                    Some(theReceiver)
-                                else
-                                    None,
-                                stmts,
                                 vmReachableMethods
                             )
                         } else {
@@ -382,8 +377,6 @@ class ThreadStartAnalysis private[cg] (
         callContext:        ContextType,
         callPC:             Int,
         receiverValue:      IsReferenceValue,
-        receiver:           Option[V],
-        stmts:              Array[Stmt[V]],
         vmReachableMethods: VMReachableMethods
     ): Unit = {
         val thisType = callContext.method.declaringClassType

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/ThreadRelatedCallsAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/ThreadRelatedCallsAnalysis.scala
@@ -161,10 +161,10 @@ class ThreadStartAnalysis private[cg] (
      * updated set.
      */
     private[this] def handleStart(
-        callContext:        ContextType,
-        callPC:             Int,
-        receiver:           V,
-        partialAnalysisResults:      ThreadStartAnalysisResults
+        callContext:            ContextType,
+        callPC:                 Int,
+        receiver:               V,
+        partialAnalysisResults: ThreadStartAnalysisResults
     )(implicit state: CGState[ContextType]): Unit = {
         // a call to Thread.start will trigger the JVM to later on call Thread.exit()
         val exitMethod = project.specialCall(
@@ -214,11 +214,11 @@ class ThreadStartAnalysis private[cg] (
     }
 
     private[this] def handleTypeAndHasRunnable(
-        tpe:           ReferenceType,
-        callContext:   ContextType,
-        callPC:        Int,
-        stmts:         Array[Stmt[V]],
-        receiver:      V,
+        tpe:                    ReferenceType,
+        callContext:            ContextType,
+        callPC:                 Int,
+        stmts:                  Array[Stmt[V]],
+        receiver:               V,
         partialAnalysisResults: ThreadStartAnalysisResults
     ): Boolean = {
         val runMethod = project.instanceCall(
@@ -265,12 +265,12 @@ class ThreadStartAnalysis private[cg] (
      * [[Runnable]] (passed as an argument to the constructor).
      */
     private[this] def handleThreadInit(
-        callContext:        ContextType,
-        callPC:             Int,
-        allocationContext:  Context,
-        threadDefSite:      Int,
-        stmts:              Array[Stmt[V]],
-        partialAnalysisResults:      ThreadStartAnalysisResults
+        callContext:            ContextType,
+        callPC:                 Int,
+        allocationContext:      Context,
+        threadDefSite:          Int,
+        stmts:                  Array[Stmt[V]],
+        partialAnalysisResults: ThreadStartAnalysisResults
     ): Unit = stmts(threadDefSite) match {
         case Assignment(_, thread, New(_, _)) =>
             for {
@@ -338,11 +338,11 @@ class ThreadStartAnalysis private[cg] (
      * updated set.
      */
     private[this] def addRunnableMethod(
-        callContext:   ContextType,
-        callPC:        Int,
-        receiverValue: IsReferenceValue,
-        receiver:      Option[V],
-        stmts:         Array[Stmt[V]],
+        callContext:            ContextType,
+        callPC:                 Int,
+        receiverValue:          IsReferenceValue,
+        receiver:               Option[V],
+        stmts:                  Array[Stmt[V]],
         partialAnalysisResults: IndirectCalls
     ): Unit = {
         val thisType = callContext.method.declaringClassType
@@ -411,14 +411,14 @@ class ThreadStartAnalysis private[cg] (
      * updated set.
      */
     private[this] def addMethod(
-        callContext:   ContextType,
-        callPC:        Int,
-        receiver:      Option[V],
-        stmts:         Array[Stmt[V]],
-        target:        org.opalj.Result[Method],
-        preciseType:   ObjectType,
-        name:          String,
-        descriptor:    MethodDescriptor,
+        callContext:            ContextType,
+        callPC:                 Int,
+        receiver:               Option[V],
+        stmts:                  Array[Stmt[V]],
+        target:                 org.opalj.Result[Method],
+        preciseType:            ObjectType,
+        name:                   String,
+        descriptor:             MethodDescriptor,
         partialAnalysisResults: IndirectCalls
     ): Unit = {
         val caller = callContext.method.asDefinedMethod


### PR DESCRIPTION
The `uncaughtException` method can be overridden in subtypes of ThreadGroup and overrides should be considered VM-reachable as per the JVM specification.