### PR TITLE
Set commit status to pending when triggering integration tests via comment

### DIFF
--- a/.github/workflows/run_it_test_on_comment.yml
+++ b/.github/workflows/run_it_test_on_comment.yml
@@ -20,6 +20,14 @@ jobs:
         with:
           ref: ${{ steps.comment-branch.outputs.head_ref }}
 
+      - name: Set latest commit status as pending
+        uses: myrotvorets/set-commit-status-action@655d7d2517bab7f5d1b6e74cd7d5e995264184b1
+        if: always()
+        with:
+          sha: ${{ steps.comment-branch.outputs.head_sha }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          status: pending
+
       - name: Run Integration Tests
         run: sbt -J-Xmx40G cleanBuild it:test
       - name: Run Cross Language Tests


### PR DESCRIPTION
This PR improves on the existing github workflow to trigger integration tests via a magic comment phrase by setting the commit's build status to `pending` before starting the build. Before, users would not notice any immediate change when commenting the magic phrase - they would have to wait until the test execution finished.

**Note**: I tried to address the fact that many `skipped` runs show up in the GitHub Action logs, but it does not seem possible - Workflows will be triggered for every issue and pr comment, and will show up as skipped if the comment is not a PR comment or does not contain the magic phrase. There seems to be a sort of [hacky workaround](https://stackoverflow.com/a/74349772) that would make it so all runs show up as `finished` / `success` instead of `skipped`, but i don't know if that is what we want.