### PR TITLE
Address some deprecation warnings in build definition

### DIFF
--- a/.github/workflows/run_it_test_on_comment.yml
+++ b/.github/workflows/run_it_test_on_comment.yml
@@ -54,9 +54,9 @@ jobs:
           status: pending
 
       - name: Run Integration Tests
-        run: sbt -J-Xmx40G cleanBuild it:test
+        run: sbt -J-Xmx40G "cleanBuild; IntegrationTest / test"
       - name: Run Cross Language Tests
-        run: sbt -J-Xmx40G "project LLVM;it:test;project ValidateCross;it:test"
+        run: sbt -J-Xmx40G "project LLVM; IntegrationTest / test;project ValidateCross; IntegrationTest / test"
         
       - name: Set latest commit status as ${{ job.status }}
         uses: myrotvorets/set-commit-status-action@655d7d2517bab7f5d1b6e74cd7d5e995264184b1

--- a/build.sbt
+++ b/build.sbt
@@ -82,15 +82,15 @@ ThisBuild / javaOptions ++= Seq(
 addCommandAlias(
   "compileAll",
   "; copyResources ; scalastyle ; " +
-    "test:compile ; test:scalastyle ; " +
-    "it:scalariformFormat ; it:scalastyle ; it:compile "
+    "OPAL / test / compile ; test:scalastyle ; " +
+    "OPAL / IntegrationTest / scalariformFormat ; OPAL / IntegrationTest / scalastyle ; OPAL / IntegrationTest / compile "
 )
 
 addCommandAlias("buildAll", "; compileAll ; unidoc ;  publishLocal ")
 
 addCommandAlias(
   "cleanAll",
-  "; clean ; cleanCache ; cleanLocal ; test:clean ; it:clean ; cleanFiles"
+  "; clean ; cleanCache ; cleanLocal ; OPAL / Test / clean ; OPAL / IntegrationTest / clean ; cleanFiles"
 )
 
 addCommandAlias("cleanBuild", "; project OPAL ; cleanAll ; buildAll ")
@@ -115,7 +115,7 @@ lazy val buildSettings =
     scalariformSettings ++
     PublishingOverwrite.onSnapshotOverwriteSettings ++
     Seq(libraryDependencies ++= Dependencies.testlibs) ++
-    Seq(Defaults.itSettings: _*) ++
+    Seq(inConfig(IntegrationTest)(Defaults.testSettings): _*) ++
     Seq(
       unmanagedSourceDirectories
         .withRank(KeyRanks.Invisible) := (Compile / scalaSource).value :: Nil

--- a/build.sbt
+++ b/build.sbt
@@ -82,7 +82,7 @@ ThisBuild / javaOptions ++= Seq(
 addCommandAlias(
   "compileAll",
   "; copyResources ; scalastyle ; " +
-    "OPAL / test / compile ; test:scalastyle ; " +
+    "OPAL / Test / compile ; OPAL / Test / scalastyle ; " +
     "OPAL / IntegrationTest / scalariformFormat ; OPAL / IntegrationTest / scalastyle ; OPAL / IntegrationTest / compile "
 )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,7 +10,7 @@ addSbtPlugin("org.scalariform" % "sbt-scalariform"        % "1.8.3")
 addSbtPlugin("org.scalameta"   % "sbt-scalafmt"           % "2.4.2")
 
 addSbtPlugin("com.eed3si9n"     % "sbt-unidoc"   % "0.4.3")
-addSbtPlugin("com.eed3si9n"     % "sbt-assembly" % "0.15.0")
+addSbtPlugin("com.eed3si9n"     % "sbt-assembly" % "2.1.4")
 
 // Dependency management:
 addSbtPlugin("net.vonbuchholtz" % "sbt-dependency-check" % "3.1.1")


### PR DESCRIPTION
This PR addresses some of the deprecation warnings the showed up in SBT when execution `cleanBuild` (and other tasks). In particular, the following issues have been dealt with:

* `warning: lazy value itSettings in object Defaults is deprecated (since 1.9.0): [..]`
* `[warn] Ignored unknown package option FixedTimestamp`
* `[warn] sbt 0.13 shell syntax is deprecated; use slash syntax instead` 