### PR TITLE
Fix issue with running integration tests on fork PRs

### DIFF
--- a/.github/workflows/run_it_test_on_comment.yml
+++ b/.github/workflows/run_it_test_on_comment.yml
@@ -17,8 +17,6 @@ jobs:
         
       - name: Checkout PR branch
         uses: actions/checkout@v3
-        with:
-          ref: ${{ steps.comment-branch.outputs.head_ref }}
 
       - name: Set latest commit status as pending
         uses: myrotvorets/set-commit-status-action@655d7d2517bab7f5d1b6e74cd7d5e995264184b1


### PR DESCRIPTION
As pointed out in [this PR comment](https://github.com/opalj/opal/pull/156#issuecomment-1810578103), our current workflow for triggering integration tests on PRs is broken for fork PRs. The solution seems to be to remove th `with`-Block in the GitHub-Action as described [here](https://github.com/sreekanthreddybalne/django-df-chat/commit/55e04b9c79835f721fdebc7095382c5d492489d9) and [here](https://github.com/WeblateOrg/weblate/issues/6240). In order to test it, i will have to merge those changes to develop.