### PR TITLE
Attempt to fix issue with integration tests being triggered on fork PRs

### DIFF
--- a/.github/workflows/run_it_test_on_comment.yml
+++ b/.github/workflows/run_it_test_on_comment.yml
@@ -17,6 +17,9 @@ jobs:
         
       - name: Checkout PR branch
         uses: actions/checkout@v3
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set latest commit status as pending
         uses: myrotvorets/set-commit-status-action@655d7d2517bab7f5d1b6e74cd7d5e995264184b1


### PR DESCRIPTION
Next attempt to fix the GitHub action that triggeres intergation tests not working for fork PRs. The action supports a `repository` [attribute](https://github.com/actions/checkout#Checkout-pull-request-HEAD-commit-instead-of-merge-commit) and the API provides information about the [head commit's repository](https://docs.github.com/de/webhooks/webhook-events-and-payloads#pull_request).