### PR TITLE
Yet another attempt to fix workflow for intergration testing.

### DIFF
--- a/.github/workflows/run_it_test_on_comment.yml
+++ b/.github/workflows/run_it_test_on_comment.yml
@@ -11,15 +11,27 @@ jobs:
     if: github.event.issue.pull_request && contains(github.event.comment.body, '/it:test') && github.event.comment.author_association == 'COLLABORATOR'
 
     steps:
+      - name: Get Head Ref and Repo
+        uses: actions/github-script@v7
+        id: head-branch
+        with:
+          script: |
+            octokit.rest.pulls.get({
+              pull_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+
+
       - name: Get PR branch
         uses: xt0rted/pull-request-comment-branch@d97294d304604fa98a2600a6e2f916a84b596dc7
         id: comment-branch
         
       - name: Checkout PR branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{ steps.head-branch.outputs.result.head.repo.full_name }}
+          ref: ${{ steps.head-branch.outputs.result.head.sha }}
 
       - name: Set latest commit status as pending
         uses: myrotvorets/set-commit-status-action@655d7d2517bab7f5d1b6e74cd7d5e995264184b1


### PR DESCRIPTION
Next try... this time i'm using a new action `github-script` to make one additional call to the GitHub API in order to retrieve an actual `pull_requst` API object, which i can then (hopefully) use to retrieve the repository name and SHA of the HEAD branch. As last time: If this works, i'll remove the superfluous use of the `pull-request-comment-branch` action.