### PR TITLE
Fix wrong name for github client in script action

### DIFF
--- a/.github/workflows/run_it_test_on_comment.yml
+++ b/.github/workflows/run_it_test_on_comment.yml
@@ -16,7 +16,7 @@ jobs:
         id: head-branch
         with:
           script: |
-            octokit.rest.pulls.get({
+            github.rest.pulls.get({
               pull_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
GitHub API documentation and the `github-script` action use different names for their API client ... this should be the right one, [see here](https://github.com/actions/github-script#retries)