### PR TITLE
Fix critical field access information problems

### DIFF
--- a/OPAL/tac/src/main/resources/reference.conf
+++ b/OPAL/tac/src/main/resources/reference.conf
@@ -761,6 +761,86 @@ org.opalj {
             ]
           },
           {
+            cf = "java/lang/invoke/MethodHandles$Lookup",
+            name = "findGetter",
+            desc = "(Ljava/lang/Class;Ljava/lang/String;Ljava/lang/Class;)Ljava/lang/invoke/MethodHandle;",
+            pointsTo = [
+              {
+                lhs = {
+                  cf = "java/lang/invoke/MethodHandles$Lookup",
+                  name = "findGetter",
+                  desc = "(Ljava/lang/Class;Ljava/lang/String;Ljava/lang/Class;)Ljava/lang/invoke/MethodHandle;",
+                },
+                rhs = {
+                  cf = "java/lang/invoke/MethodHandles$Lookup",
+                  name = "findGetter",
+                  desc = "(Ljava/lang/Class;Ljava/lang/String;Ljava/lang/Class;)Ljava/lang/invoke/MethodHandle;",
+                  instantiatedType = "Ljava/lang/invoke/MethodHandle;"
+                }
+              }
+            ]
+          },
+          {
+            cf = "java/lang/invoke/MethodHandles$Lookup",
+            name = "findStaticGetter",
+            desc = "(Ljava/lang/Class;Ljava/lang/String;Ljava/lang/Class;)Ljava/lang/invoke/MethodHandle;",
+            pointsTo = [
+              {
+                lhs = {
+                  cf = "java/lang/invoke/MethodHandles$Lookup",
+                  name = "findStaticGetter",
+                  desc = "(Ljava/lang/Class;Ljava/lang/String;Ljava/lang/Class;)Ljava/lang/invoke/MethodHandle;",
+                },
+                rhs = {
+                  cf = "java/lang/invoke/MethodHandles$Lookup",
+                  name = "findStaticGetter",
+                  desc = "(Ljava/lang/Class;Ljava/lang/String;Ljava/lang/Class;)Ljava/lang/invoke/MethodHandle;",
+                  instantiatedType = "Ljava/lang/invoke/MethodHandle;"
+                }
+              }
+            ]
+          },
+          {
+            cf = "java/lang/invoke/MethodHandles$Lookup",
+            name = "findSetter",
+            desc = "(Ljava/lang/Class;Ljava/lang/String;Ljava/lang/Class;)Ljava/lang/invoke/MethodHandle;",
+            pointsTo = [
+              {
+                lhs = {
+                  cf = "java/lang/invoke/MethodHandles$Lookup",
+                  name = "findSetter",
+                  desc = "(Ljava/lang/Class;Ljava/lang/String;Ljava/lang/Class;)Ljava/lang/invoke/MethodHandle;",
+                },
+                rhs = {
+                  cf = "java/lang/invoke/MethodHandles$Lookup",
+                  name = "findSetter",
+                  desc = "(Ljava/lang/Class;Ljava/lang/String;Ljava/lang/Class;)Ljava/lang/invoke/MethodHandle;",
+                  instantiatedType = "Ljava/lang/invoke/MethodHandle;"
+                }
+              }
+            ]
+          },
+          {
+            cf = "java/lang/invoke/MethodHandles$Lookup",
+            name = "findStaticSetter",
+            desc = "(Ljava/lang/Class;Ljava/lang/String;Ljava/lang/Class;)Ljava/lang/invoke/MethodHandle;",
+            pointsTo = [
+              {
+                lhs = {
+                  cf = "java/lang/invoke/MethodHandles$Lookup",
+                  name = "findStaticSetter",
+                  desc = "(Ljava/lang/Class;Ljava/lang/String;Ljava/lang/Class;)Ljava/lang/invoke/MethodHandle;",
+                },
+                rhs = {
+                  cf = "java/lang/invoke/MethodHandles$Lookup",
+                  name = "findStaticSetter",
+                  desc = "(Ljava/lang/Class;Ljava/lang/String;Ljava/lang/Class;)Ljava/lang/invoke/MethodHandle;",
+                  instantiatedType = "Ljava/lang/invoke/MethodHandle;"
+                }
+              }
+            ]
+          },
+          {
             cf = "java/lang/ClassLoader",
             name = "defineClass0",
             desc = "(Ljava/lang/String;[BIILjava/security/ProtectionDomain;)Ljava/lang/Class;",

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/AbstractPointsToAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/AbstractPointsToAnalysis.scala
@@ -563,7 +563,7 @@ trait AbstractPointsToAnalysis extends PointsToAnalysisBase with ReachableMethod
                     NoMethodFieldReadAccessInformation,
                     MethodFieldReadAccessInformation.key,
                     (pc, target, newAccesses, tac, state) => handleIndirectFieldReadAccess(pc, target, newAccesses, tac)(state),
-                    newDependee => state.setReadAccessDependee(newDependee),
+                    (currentState, newDependee) => currentState.setReadAccessDependee(newDependee),
                     new PointsToAnalysisState[ElementType, PointsToSet, ContextType](state.callContext, state.tacDependee)
                 )
             )
@@ -578,7 +578,7 @@ trait AbstractPointsToAnalysis extends PointsToAnalysisBase with ReachableMethod
                     NoMethodFieldWriteAccessInformation,
                     MethodFieldWriteAccessInformation.key,
                     (pc, target, newAccesses, tac, state) => handleIndirectFieldWriteAccess(pc, target, newAccesses, tac)(state),
-                    newDependee => state.setWriteAccessDependee(newDependee),
+                    (currentState, newDependee) => currentState.setWriteAccessDependee(newDependee),
                     new PointsToAnalysisState[ElementType, PointsToSet, ContextType](state.callContext, state.tacDependee)
                 )
             )
@@ -727,7 +727,7 @@ trait AbstractPointsToAnalysis extends PointsToAnalysisBase with ReachableMethod
         noAccesses:                P,
         key:                       PropertyKey[P],
         handleIndirectFieldAccess: (PC, DeclaredField, P, TACode[TACMethodParameter, DUVar[ValueInformation]], State) => Unit,
-        setDependee:               EOptionP[Method, P] => Unit,
+        setDependee:               (State, EOptionP[Method, P]) => Unit,
         state:                     State
     )(eps: SomeEPS): ProperPropertyComputationResult = {
         eps.pk match {
@@ -748,7 +748,7 @@ trait AbstractPointsToAnalysis extends PointsToAnalysisBase with ReachableMethod
                     handleIndirectFieldAccess(pc, target, newAccesses, tac, state)
                 }
 
-                setDependee(eps.asInstanceOf[EPS[Method, P]])
+                setDependee(state, eps.asInstanceOf[EPS[Method, P]])
 
                 Results(createResults(state))
             case _ => throw new IllegalArgumentException(s"unexpected eps $eps")


### PR DESCRIPTION
Fixes two problems from the field access information analysis PRs:
1. From #126, the state handling for the continuation in the `AbstractPointsToAnalysis` was faulty and led to inconsistent states
2. From #145, the getter and setter methods from MethodHandle lookup objects needed adding to the reference.conf