### PR TITLE
Make loaded constants available for RTA and XTA

### DIFF
--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/package.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/package.scala
@@ -91,25 +91,27 @@ package object cg {
         method: DeclaredMethod
     )(implicit logContext: LogContext): UIDSet[ReferenceType] = {
         var constantTypes = UIDSet.empty[ReferenceType]
-        method.foreachDefinedMethod { m =>
-            for {
-                code <- m.body
-                inst <- code.instructions
-            } {
-                if ((inst ne null) && inst.isLoadConstantInstruction &&
-                    inst.asInstanceOf[LoadConstantInstruction[_]].computationalType == ComputationalTypeReference) {
-                    inst match {
-                        case _: LoadClass | _: LoadClass_W               => constantTypes += ObjectType.Class
-                        case _: LoadMethodHandle | _: LoadMethodHandle_W => constantTypes += ObjectType.MethodHandle
-                        case _: LoadMethodType | _: LoadMethodType_W     => constantTypes += ObjectType.MethodType
-                        case _: LoadString | _: LoadString_W             => constantTypes += ObjectType.String
-                        case _: LoadDynamic =>
-                            constantTypes += inst.asInstanceOf[LoadDynamic].descriptor.asReferenceType
-                        case _: LoadDynamic_W =>
-                            constantTypes += inst.asInstanceOf[LoadDynamic_W].descriptor.asReferenceType
-                        case ACONST_NULL =>
-                        case _ =>
-                            logOnce(Warn("unknown load constant instruction"))
+        if (method.hasSingleDefinedMethod || method.hasMultipleDefinedMethods) {
+            method.foreachDefinedMethod { m =>
+                for {
+                    code <- m.body
+                    inst <- code.instructions
+                } {
+                    if ((inst ne null) && inst.isLoadConstantInstruction &&
+                        inst.asInstanceOf[LoadConstantInstruction[_]].computationalType == ComputationalTypeReference) {
+                        inst match {
+                            case _: LoadClass | _: LoadClass_W               => constantTypes += ObjectType.Class
+                            case _: LoadMethodHandle | _: LoadMethodHandle_W => constantTypes += ObjectType.MethodHandle
+                            case _: LoadMethodType | _: LoadMethodType_W     => constantTypes += ObjectType.MethodType
+                            case _: LoadString | _: LoadString_W             => constantTypes += ObjectType.String
+                            case _: LoadDynamic =>
+                                constantTypes += inst.asInstanceOf[LoadDynamic].descriptor.asReferenceType
+                            case _: LoadDynamic_W =>
+                                constantTypes += inst.asInstanceOf[LoadDynamic_W].descriptor.asReferenceType
+                            case ACONST_NULL =>
+                            case _ =>
+                                logOnce(Warn("unknown load constant instruction"))
+                        }
                     }
                 }
             }

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/package.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/package.scala
@@ -6,8 +6,24 @@ package analyses
 
 import org.opalj.collection.immutable.IntTrieSet
 import org.opalj.collection.immutable.EmptyIntTrieSet
+import org.opalj.collection.immutable.UIDSet
 import org.opalj.value.ValueInformation
 import org.opalj.br.PCs
+import org.opalj.br.instructions.LoadConstantInstruction
+import org.opalj.br.ComputationalTypeReference
+import org.opalj.br.DeclaredMethod
+import org.opalj.br.ObjectType
+import org.opalj.br.ReferenceType
+import org.opalj.br.instructions.LoadClass
+import org.opalj.br.instructions.LoadClass_W
+import org.opalj.br.instructions.LoadDynamic
+import org.opalj.br.instructions.LoadDynamic_W
+import org.opalj.br.instructions.LoadMethodHandle
+import org.opalj.br.instructions.LoadMethodHandle_W
+import org.opalj.br.instructions.LoadMethodType
+import org.opalj.br.instructions.LoadMethodType_W
+import org.opalj.br.instructions.LoadString
+import org.opalj.br.instructions.LoadString_W
 import org.opalj.ai.ValueOrigin
 import org.opalj.ai.pcOfImmediateVMException
 import org.opalj.ai.pcOfMethodExternalException
@@ -65,5 +81,31 @@ package object cg {
         pcToIndex: Array[Int]
     ): V = {
         UVar(defSites._1, valueOriginsOfPCs(defSites._2, pcToIndex))
+    }
+
+    private[cg] def getLoadConstantTypes(method: DeclaredMethod): UIDSet[ReferenceType] = {
+        var constantTypes = UIDSet.empty[ReferenceType]
+        method.foreachDefinedMethod { m =>
+            for {
+                code <- m.body
+                inst <- code.instructions
+            } {
+                if ((inst ne null) && inst.isLoadConstantInstruction &&
+                    inst.asInstanceOf[LoadConstantInstruction[_]].computationalType == ComputationalTypeReference) {
+                    val loadedType = inst match {
+                        case _: LoadClass | _: LoadClass_W               => ObjectType.Class
+                        case _: LoadMethodHandle | _: LoadMethodHandle_W => ObjectType.MethodHandle
+                        case _: LoadMethodType | _: LoadMethodType_W     => ObjectType.MethodType
+                        case _: LoadString | _: LoadString_W             => ObjectType.String
+                        case _: LoadDynamic =>
+                            inst.asInstanceOf[LoadDynamic].descriptor.asReferenceType
+                        case _: LoadDynamic_W =>
+                            inst.asInstanceOf[LoadDynamic_W].descriptor.asReferenceType
+                    }
+                    constantTypes += loadedType
+                }
+            }
+        }
+        constantTypes
     }
 }

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/rta/InstantiatedTypesAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/rta/InstantiatedTypesAnalysis.scala
@@ -54,18 +54,6 @@ class InstantiatedTypesAnalysis private[analyses] (
     private[this] implicit val contextProvider: ContextProvider = project.get(ContextProviderKey)
 
     def analyze(declaredMethod: DeclaredMethod): PropertyComputationResult = {
-        // only constructors may initialize a class
-        if (declaredMethod.name != "<init>")
-            return NoResult;
-
-        val declaredType = declaredMethod.declaringClassType
-
-        val cfOpt = project.classFile(declaredType)
-
-        // abstract classes can never be instantiated
-        if (cfOpt.isDefined && cfOpt.get.isAbstract)
-            return NoResult;
-
         val callersEOptP = propertyStore(declaredMethod, Callers.key)
 
         val callersUB: Callers = (callersEOptP: @unchecked) match {
@@ -84,46 +72,62 @@ class InstantiatedTypesAnalysis private[analyses] (
             // the method is reachable, so we analyze it!
         }
 
+        val declaredType = declaredMethod.declaringClassType
+        val instantiatedTypes = getLoadConstantTypes(declaredMethod)
+
+        val cfOpt = project.classFile(declaredType)
+
+        // only constructors may initialize a class; abstract classes can never be instantiated
+        if (declaredMethod.name != "<init>" || cfOpt.isDefined && cfOpt.get.isAbstract) {
+            if (instantiatedTypes.isEmpty)
+                return NoResult;
+            else
+                return partialResult(instantiatedTypes)
+        }
+
         // the set of types that are definitely initialized at this point in time
         val instantiatedTypesEOptP = propertyStore(project, InstantiatedTypes.key)
         val instantiatedTypesUB: UIDSet[ReferenceType] = getInstantiatedTypesUB(instantiatedTypesEOptP)
 
-        // if the current type is already instantiated, no work is left
-        if (instantiatedTypesUB.contains(declaredType))
+        val newInstantiatedTypes = instantiatedTypes.diff(instantiatedTypesUB)
+
+        // if the current type and all constants' types are already instantiated, no work is left
+        if (instantiatedTypesUB.contains(declaredType) && newInstantiatedTypes.isEmpty)
             return NoResult;
 
-        processCallers(declaredMethod, declaredType, callersEOptP, callersUB, null)
+        processCallers(declaredMethod, declaredType, newInstantiatedTypes, callersEOptP, callersUB, null)
     }
 
     private[this] def processCallers(
-        declaredMethod: DeclaredMethod,
-        declaredType:   ObjectType,
-        callersEOptP:   EOptionP[DeclaredMethod, Callers],
-        callersUB:      Callers,
-        seenCallers:    Callers
+        declaredMethod:    DeclaredMethod,
+        declaredType:      ObjectType,
+        instantiatedTypes: UIDSet[ReferenceType],
+        callersEOptP:      EOptionP[DeclaredMethod, Callers],
+        callersUB:         Callers,
+        seenCallers:       Callers
     ): PropertyComputationResult = {
         callersUB.forNewCallerContexts(seenCallers, callersEOptP.e) {
             (_, callerContext, _, isDirect) =>
                 // unknown or VM level calls always have to be treated as instantiations
                 if (!callerContext.hasContext) {
-                    return partialResult(declaredType);
+                    return partialResult(instantiatedTypes + declaredType);
                 }
 
                 // indirect calls, e.g. via reflection, are to be treated as instantiations as well
                 if (!isDirect) {
-                    return partialResult(declaredType);
+                    return partialResult(instantiatedTypes + declaredType);
                 }
 
                 val caller = callerContext.method
 
                 // a constructor is called by a non-constructor method, there will be an initialization.
                 if (caller.name != "<init>") {
-                    return partialResult(declaredType);
+                    return partialResult(instantiatedTypes + declaredType);
                 }
 
                 // if the caller is not available, we have to assume that it was no super call
                 if (!caller.hasSingleDefinedMethod) {
-                    return partialResult(declaredType);
+                    return partialResult(instantiatedTypes + declaredType);
                 }
 
                 // the constructor is called from another constructor. it is only an new instantiated
@@ -131,7 +135,7 @@ class InstantiatedTypesAnalysis private[analyses] (
                 project.classFile(caller.declaringClassType).foreach { cf =>
                     cf.superclassType.foreach { supertype =>
                         if (supertype != declaredType)
-                            return partialResult(declaredType);
+                            return partialResult(instantiatedTypes + declaredType);
                     }
                 }
 
@@ -142,35 +146,39 @@ class InstantiatedTypesAnalysis private[analyses] (
                 val newInstr = NEW(declaredType)
                 val hasNew = body.exists(pcInst => pcInst.instruction == newInstr)
                 if (hasNew)
-                    return partialResult(declaredType);
+                    return partialResult(instantiatedTypes + declaredType);
         }
 
         if (callersEOptP.isFinal) {
-            NoResult
+            if (instantiatedTypes.isEmpty)
+                NoResult
+            else
+                partialResult(instantiatedTypes)
         } else {
             InterimPartialResult(
                 Set(callersEOptP),
-                continuation(declaredMethod, declaredType, callersUB)
+                continuation(declaredMethod, declaredType, instantiatedTypes, callersUB)
             )
         }
     }
 
     private[this] def continuation(
-        declaredMethod: DeclaredMethod,
-        declaredType:   ObjectType,
-        seenCallers:    Callers
+        declaredMethod:    DeclaredMethod,
+        declaredType:      ObjectType,
+        instantiatedTypes: UIDSet[ReferenceType],
+        seenCallers:       Callers
     )(someEPS: SomeEPS): PropertyComputationResult = {
         val eps = someEPS.asInstanceOf[EPS[DeclaredMethod, Callers]]
-        processCallers(declaredMethod, declaredType, eps, eps.ub, seenCallers)
+        processCallers(declaredMethod, declaredType, instantiatedTypes, eps, eps.ub, seenCallers)
     }
 
     private[this] def partialResult(
-        declaredType: ObjectType
+        instantiatedTypes: UIDSet[ReferenceType]
     ): PartialResult[SomeProject, InstantiatedTypes] = {
         PartialResult[SomeProject, InstantiatedTypes](
             project,
             InstantiatedTypes.key,
-            InstantiatedTypesAnalysis.update(project, UIDSet(declaredType))
+            InstantiatedTypesAnalysis.update(project, instantiatedTypes)
         )
     }
 


### PR DESCRIPTION
Types can become available when a constant is loaded from the constant pool.