### PR TITLE
Use DeclaredField for pointsto analysis

### DIFF
--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/LibraryPointsToAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/LibraryPointsToAnalysis.scala
@@ -176,10 +176,11 @@ abstract class LibraryPointsToAnalysis( final val project: SomeProject)
                             }
                         }
 
-                        if (f.isStatic) initialize(f, initialAssignments)
+                        val declaredField = declaredFields(f)
+                        if (f.isStatic) initialize(declaredField, initialAssignments)
                         else {
                             createExternalAllocation(cf.thisType).forNewestNElements(1) { as =>
-                                initialize((as, f), initialAssignments)
+                                initialize((as, declaredField), initialAssignments)
                             }
                         }
                     }


### PR DESCRIPTION
We changed the entites to use `DeclaredField`s, so convert accordingly. Equivalent of #167 but for the points to analyses.