### PR TITLE
Fix initialization of field access information key

### DIFF
--- a/OPAL/br/src/main/scala/org/opalj/br/analyses/FieldAccessInformationKey.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/analyses/FieldAccessInformationKey.scala
@@ -19,19 +19,15 @@ import org.opalj.log.OPALLogger
 object FieldAccessInformationKey extends ProjectInformationKey[FieldAccessInformation, Seq[FPCFAnalysisScheduler]] {
 
     override def requirements(project: SomeProject): ProjectInformationKeys = {
-        val schedulers = project.getProjectInformationKeyInitializationData(this) match {
-            case Some(s) => s
-            case None =>
+        val schedulers = project.getOrCreateProjectInformationKeyInitializationData(
+            this, {
                 OPALLogger.warn(
                     "analysis configuration",
                     s"no field access information analysis configured, using SimpleFieldAccessInformationAnalysis as a fallback"
                 )(project.logContext)
-                project.updateProjectInformationKeyInitializationData(this) {
-                    case None             => Seq(EagerSimpleFieldAccessInformationAnalysis)
-                    case Some(schedulers) => schedulers ++ Seq(EagerSimpleFieldAccessInformationAnalysis)
-                }
                 Seq(EagerSimpleFieldAccessInformationAnalysis)
-        }
+            }
+        )
 
         schedulers.flatMap(_.requiredProjectInformation)
     }

--- a/OPAL/br/src/main/scala/org/opalj/br/analyses/FieldAccessInformationKey.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/analyses/FieldAccessInformationKey.scala
@@ -26,6 +26,10 @@ object FieldAccessInformationKey extends ProjectInformationKey[FieldAccessInform
                     "analysis configuration",
                     s"no field access information analysis configured, using SimpleFieldAccessInformationAnalysis as a fallback"
                 )(project.logContext)
+                project.updateProjectInformationKeyInitializationData(this) {
+                    case None             => Seq(EagerSimpleFieldAccessInformationAnalysis)
+                    case Some(schedulers) => schedulers ++ Seq(EagerSimpleFieldAccessInformationAnalysis)
+                }
                 Seq(EagerSimpleFieldAccessInformationAnalysis)
         }
 


### PR DESCRIPTION
Fixes an initialization bug for the `FieldAccessInformationKey`. When no initialization data was configured, the requirements stated that as a fallback, the `SimpleFieldAccessInformationAnalysis` will be used.

Actually, the requirements only used this fallback for determining `ProjectInformationKey` dependencies but not for running the actual key itself. This subsequently caused the `compute` step to fail.