### PR TITLE
Change canonical form of single value integer range likes

### DIFF
--- a/OPAL/ai/src/main/scala/org/opalj/ai/domain/l1/DefaultIntegerRangeValues.scala
+++ b/OPAL/ai/src/main/scala/org/opalj/ai/domain/l1/DefaultIntegerRangeValues.scala
@@ -178,13 +178,6 @@ trait DefaultIntegerRangeValues extends DefaultSpecialDomainValuesBinding with I
 
         override def newInstance: IntegerRange = IntegerRange(lowerBound, upperBound)
 
-        override def constantValue: Option[ValueOrigin] = {
-            if (lowerBound == upperBound)
-                Some(lowerBound)
-            else
-                None
-        }
-
         override def hashCode: Int = this.lowerBound * 13 + this.upperBound
 
         override def equals(other: Any): Boolean = {

--- a/OPAL/ai/src/main/scala/org/opalj/ai/domain/l1/IntegerRangeValues.scala
+++ b/OPAL/ai/src/main/scala/org/opalj/ai/domain/l1/IntegerRangeValues.scala
@@ -9,8 +9,6 @@ import scala.Int.{MinValue => MinInt}
 
 import org.opalj.br.CTIntType
 import org.opalj.value.IsIntegerValue
-import org.opalj.value.TheIntegerValue
-import org.opalj.value.ValueInformation
 
 /**
  * This domain represents integer values using ranges.
@@ -151,11 +149,11 @@ trait IntegerRangeValues
 
         val upperBound: Int // inclusive
 
-        override final def toCanonicalForm: ValueInformation = {
+        override def constantValue: Option[ValueOrigin] = {
             if (lowerBound == upperBound)
-                TheIntegerValue(lowerBound)
+                Some(lowerBound)
             else
-                super.toCanonicalForm
+                None
         }
     }
 

--- a/OPAL/ai/src/main/scala/org/opalj/ai/domain/l1/IntegerRangeValues.scala
+++ b/OPAL/ai/src/main/scala/org/opalj/ai/domain/l1/IntegerRangeValues.scala
@@ -9,6 +9,8 @@ import scala.Int.{MinValue => MinInt}
 
 import org.opalj.br.CTIntType
 import org.opalj.value.IsIntegerValue
+import org.opalj.value.TheIntegerValue
+import org.opalj.value.ValueInformation
 
 /**
  * This domain represents integer values using ranges.
@@ -149,6 +151,12 @@ trait IntegerRangeValues
 
         val upperBound: Int // inclusive
 
+        override final def toCanonicalForm: ValueInformation = {
+            if (lowerBound == upperBound)
+                TheIntegerValue(lowerBound)
+            else
+                super.toCanonicalForm
+        }
     }
 
     /**

--- a/OPAL/br/src/main/scala/org/opalj/value/ValueInformation.scala
+++ b/OPAL/br/src/main/scala/org/opalj/value/ValueInformation.scala
@@ -370,7 +370,10 @@ case class TheShortValue(value: Short) extends IsShortValue {
 trait IsIntegerValue extends IsIntegerLikeValue[IntegerType] {
     override final def primitiveType: IntegerType = IntegerType
     override final def hasCategory2ComputationalType: Boolean = false
-    override def toCanonicalForm: ValueInformation = AnIntegerValue
+    override def toCanonicalForm: ValueInformation = {
+        if (constantValue.isDefined) TheIntegerValue(constantValue.get)
+        else AnIntegerValue
+    }
     override def asConstantInteger: Integer = constantValue.get // Expected to be overridden!
     def lowerBound: Int
     def upperBound: Int


### PR DESCRIPTION
Provides better support for integer range likes with matching upper and lower bounds by converting them to a concrete `TheIntegerValue` as their canonical form.

> [!NOTE]
> We might want to implement this in more domain parts than the `IntegerRangeValues`, e.g. `IntegerSetValues` containing only one value. Any thoughts on this?

* Related to (and discovered during) #1