### PR TITLE
Use correct ContextKey for k-l-CFAs

### DIFF
--- a/OPAL/tac/src/main/scala/org/opalj/tac/cg/CFA_1_0_CallGraphKey.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/cg/CFA_1_0_CallGraphKey.scala
@@ -5,8 +5,11 @@ package cg
 
 import org.opalj.br.analyses.ProjectInformationKeys
 import org.opalj.br.analyses.SomeProject
+import org.opalj.br.analyses.VirtualFormalParametersKey
 import org.opalj.br.fpcf.FPCFAnalysisScheduler
 import org.opalj.br.fpcf.analyses.CallStringContextProvider
+import org.opalj.br.fpcf.properties.CallStringContextsKey
+import org.opalj.tac.common.DefinitionSitesKey
 import org.opalj.tac.fpcf.analyses.cg.TypeIterator
 import org.opalj.tac.fpcf.analyses.cg.TypesBasedPointsToTypeIterator
 
@@ -21,7 +24,8 @@ import org.opalj.tac.fpcf.analyses.cg.TypesBasedPointsToTypeIterator
 object CFA_1_0_CallGraphKey extends CallGraphKey {
 
     override def requirements(project: SomeProject): ProjectInformationKeys = {
-        TypeBasedPointsToCallGraphKey.requirements(project)
+        Seq(DefinitionSitesKey, VirtualFormalParametersKey, CallStringContextsKey) ++:
+            super.requirements(project)
     }
 
     override protected def callGraphSchedulers(

--- a/OPAL/tac/src/main/scala/org/opalj/tac/cg/CFA_1_1_CallGraphKey.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/cg/CFA_1_1_CallGraphKey.scala
@@ -5,7 +5,10 @@ package cg
 
 import org.opalj.br.analyses.ProjectInformationKeys
 import org.opalj.br.analyses.SomeProject
+import org.opalj.br.analyses.VirtualFormalParametersKey
 import org.opalj.br.fpcf.FPCFAnalysisScheduler
+import org.opalj.br.fpcf.properties.CallStringContextsKey
+import org.opalj.tac.common.DefinitionSitesKey
 import org.opalj.tac.fpcf.analyses.cg.CFA_k_l_TypeIterator
 
 /**
@@ -19,7 +22,8 @@ import org.opalj.tac.fpcf.analyses.cg.CFA_k_l_TypeIterator
 object CFA_1_1_CallGraphKey extends CallGraphKey {
 
     override def requirements(project: SomeProject): ProjectInformationKeys = {
-        AllocationSiteBasedPointsToCallGraphKey.requirements(project)
+        Seq(DefinitionSitesKey, VirtualFormalParametersKey, CallStringContextsKey) ++:
+            super.requirements(project)
     }
 
     override protected def callGraphSchedulers(
@@ -27,6 +31,7 @@ object CFA_1_1_CallGraphKey extends CallGraphKey {
     ): Iterable[FPCFAnalysisScheduler] = {
         AllocationSiteBasedPointsToCallGraphKey.callGraphSchedulers(project)
     }
+
     override def getTypeIterator(project: SomeProject) =
         new CFA_k_l_TypeIterator(project, 1, 1)
 }


### PR DESCRIPTION
The CFA_1_0 and CFA_1_1 call graphs use CallStringContexts