### PR TITLE
Fix incorrect double-checked locking leading to duplice VirtualDeclaredMethods

### DIFF
--- a/OPAL/br/src/main/scala/org/opalj/br/analyses/DeclaredMethods.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/analyses/DeclaredMethods.scala
@@ -97,7 +97,7 @@ class DeclaredMethods(
         // In case of an unseen method, compute id
         lock.writeLock().lock()
         try {
-            if (!dmSet.contains(context)) {
+            if (!dmSet.containsKey(context)) {
                 val vm = new VirtualDeclaredMethod(runtimeType, name, descriptor, idCounter)
                 idCounter += 1
                 dmSet.put(MethodContext(p, runtimeType, "", name, descriptor, false), vm)


### PR DESCRIPTION
The check was on the values, but needs to on the keys to avoid duplicate VirtualDeclaredMethods being added if two threads happen to try to insert the same VirtualDeclaredMethod at the same time.