### PR TITLE
Automate use of TamiFlex modules based on config key being present

### DIFF
--- a/OPAL/tac/src/main/scala/org/opalj/tac/cg/AllocationSiteBasedPointsToCallGraphKey.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/cg/AllocationSiteBasedPointsToCallGraphKey.scala
@@ -21,6 +21,7 @@ import org.opalj.tac.fpcf.analyses.pointsto.AllocationSiteBasedSerializationAllo
 import org.opalj.tac.fpcf.analyses.pointsto.AllocationSiteBasedTamiFlexPointsToAnalysisScheduler
 import org.opalj.tac.fpcf.analyses.pointsto.AllocationSiteBasedUnsafePointsToAnalysisScheduler
 import org.opalj.tac.fpcf.analyses.pointsto.ReflectionAllocationsAnalysisScheduler
+import org.opalj.tac.fpcf.analyses.pointsto.TamiFlexKey
 
 /**
  * A [[org.opalj.br.analyses.ProjectInformationKey]] to compute a [[CallGraph]] based on
@@ -46,7 +47,6 @@ object AllocationSiteBasedPointsToCallGraphKey extends CallGraphKey {
         List(
             AllocationSiteBasedPointsToAnalysisScheduler,
             AllocationSiteBasedConfiguredMethodsPointsToAnalysisScheduler,
-            AllocationSiteBasedTamiFlexPointsToAnalysisScheduler,
             AllocationSiteBasedArraycopyPointsToAnalysisScheduler,
             AllocationSiteBasedUnsafePointsToAnalysisScheduler,
             ReflectionAllocationsAnalysisScheduler,
@@ -54,7 +54,11 @@ object AllocationSiteBasedPointsToCallGraphKey extends CallGraphKey {
             AllocationSiteBasedNewInstanceAnalysisScheduler,
             EagerFieldAccessInformationAnalysis,
             ReflectionRelatedFieldAccessesAnalysisScheduler
-        ) ::: (if (isLibrary) List(AllocationSiteBasedLibraryPointsToAnalysisScheduler) else Nil)
+        ) ::: (
+            if (isLibrary) List(AllocationSiteBasedLibraryPointsToAnalysisScheduler) else Nil
+        ) ::: (
+            if (TamiFlexKey.isConfigured(project)) List(AllocationSiteBasedTamiFlexPointsToAnalysisScheduler) else Nil
+        )
     }
     override def getTypeIterator(project: SomeProject) =
         new AllocationSitesPointsToTypeIterator(project)

--- a/OPAL/tac/src/main/scala/org/opalj/tac/cg/TypeBasedPointsToCallGraphKey.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/cg/TypeBasedPointsToCallGraphKey.scala
@@ -14,6 +14,7 @@ import org.opalj.tac.fpcf.analyses.cg.TypeIterator
 import org.opalj.tac.fpcf.analyses.cg.TypesBasedPointsToTypeIterator
 import org.opalj.tac.fpcf.analyses.fieldaccess.EagerFieldAccessInformationAnalysis
 import org.opalj.tac.fpcf.analyses.fieldaccess.reflection.ReflectionRelatedFieldAccessesAnalysisScheduler
+import org.opalj.tac.fpcf.analyses.pointsto.TamiFlexKey
 import org.opalj.tac.fpcf.analyses.pointsto.TypeBasedArraycopyPointsToAnalysisScheduler
 import org.opalj.tac.fpcf.analyses.pointsto.TypeBasedConfiguredMethodsPointsToAnalysisScheduler
 import org.opalj.tac.fpcf.analyses.pointsto.TypeBasedLibraryPointsToAnalysisScheduler
@@ -48,14 +49,17 @@ object TypeBasedPointsToCallGraphKey extends CallGraphKey {
         List(
             TypeBasedPointsToAnalysisScheduler,
             TypeBasedConfiguredMethodsPointsToAnalysisScheduler,
-            TypeBasedTamiFlexPointsToAnalysisScheduler,
             TypeBasedArraycopyPointsToAnalysisScheduler,
             TypeBasedUnsafePointsToAnalysisScheduler,
             TypeBasedNewInstanceAnalysisScheduler,
             EagerFieldAccessInformationAnalysis,
             TypeBasedSerializationAllocationsAnalysisScheduler,
             ReflectionRelatedFieldAccessesAnalysisScheduler
-        ) ::: (if (isLibrary) List(TypeBasedLibraryPointsToAnalysisScheduler) else Nil)
+        ) ::: (
+            if (isLibrary) List(TypeBasedLibraryPointsToAnalysisScheduler) else Nil
+        ) ::: (
+            if (TamiFlexKey.isConfigured(project)) List(TypeBasedTamiFlexPointsToAnalysisScheduler) else Nil
+        )
     }
 
     override def getTypeIterator(project: SomeProject): TypeIterator =

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/TamiFlexKey.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/TamiFlexKey.scala
@@ -102,6 +102,8 @@ class TamiFlexLogData(
 object TamiFlexKey extends ProjectInformationKey[TamiFlexLogData, Nothing] {
     val configKey = "org.opalj.tac.fpcf.analyses.pointsto.TamiFlex.logFile"
 
+    def isConfigured(project: SomeProject): Boolean = project.config.hasPath(configKey)
+
     override def requirements(project: SomeProject): ProjectInformationKeys = Seq(DeclaredMethodsKey)
 
     override def compute(project: SomeProject): TamiFlexLogData = {


### PR DESCRIPTION
Avoids loading the TamiFlexKey unless a TamiFlex log is actually configured to be used and makes using the call graphs easier