### PR TITLE
Use FPCFAnalysesRegistry in call-graph runner

### DIFF
--- a/OPAL/br/src/main/scala/org/opalj/br/fpcf/FPCFAnalysesRegistry.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/fpcf/FPCFAnalysesRegistry.scala
@@ -14,6 +14,7 @@ import org.opalj.fpcf.PropertyBounds
 import org.opalj.fpcf.PropertyKey
 import org.opalj.log.GlobalLogContext
 import org.opalj.log.LogContext
+import org.opalj.log.OPALLogger
 import org.opalj.log.OPALLogger.error
 import org.opalj.log.OPALLogger.info
 
@@ -39,6 +40,7 @@ object FPCFAnalysesRegistry {
 
     private[this] var idToEagerScheduler: Map[String, FPCFEagerAnalysisScheduler] = Map.empty
     private[this] var idToLazyScheduler: Map[String, FPCFLazyAnalysisScheduler] = Map.empty
+    private[this] var idToTriggeredScheduler: Map[String, FPCFTriggeredAnalysisScheduler] = Map.empty
     private[this] var idToDescription: Map[String, String] = Map.empty
     private[this] var propertyToDefaultScheduler: Map[PropertyBounds, FPCFAnalysisScheduler] = Map.empty
 
@@ -55,15 +57,24 @@ object FPCFAnalysesRegistry {
         analysisID:          String,
         analysisDescription: String,
         analysisFactory:     String,
-        lazyFactory:         Boolean,
+        factoryType:         String,
         default:             Boolean
     ): Unit = this.synchronized {
         resolveAnalysisRunner(analysisFactory) match {
             case Some(analysisRunner) =>
-                if (lazyFactory) idToLazyScheduler +=
-                    ((analysisID, analysisRunner.asInstanceOf[FPCFLazyAnalysisScheduler]))
-                else idToEagerScheduler +=
-                    ((analysisID, analysisRunner.asInstanceOf[FPCFEagerAnalysisScheduler]))
+                factoryType match {
+                    case "lazy" =>
+                        idToLazyScheduler += ((analysisID, analysisRunner.asInstanceOf[FPCFLazyAnalysisScheduler]))
+                    case "triggered" =>
+                        idToTriggeredScheduler += ((
+                            analysisID,
+                            analysisRunner.asInstanceOf[FPCFTriggeredAnalysisScheduler]
+                        ))
+                    case "eager" =>
+                        idToEagerScheduler += ((analysisID, analysisRunner.asInstanceOf[FPCFEagerAnalysisScheduler]))
+                    case _ =>
+                        OPALLogger.error("project configuration", s"Unknown analysis factory type ${factoryType}")
+                }
 
                 if (default)
                     analysisRunner.derives.foreach { p =>
@@ -78,9 +89,8 @@ object FPCFAnalysesRegistry {
                     }
 
                 idToDescription += ((analysisID, analysisDescription))
-                val analysisType = if (lazyFactory) "lazy" else "eager"
                 val message =
-                    s"registered $analysisType analysis: $analysisID ($analysisDescription)"
+                    s"registered $factoryType analysis: $analysisID ($analysisDescription)"
                 info("OPAL Setup", message)
 
             case None =>
@@ -104,21 +114,9 @@ object FPCFAnalysesRegistry {
         }
     }
 
-    private[this] case class AnalysisFactory(id: String, description: String, factory: String)
-
     def registerFromConfig(): Unit = {
         val config = ConfigFactory.load()
         try {
-            /* HANDLING FOR AN ARRAY OF ANALYSES... analyses = [ {},...,{}]
-            //import com.typesafe.config.Config
-            //import net.ceedubs.ficus.Ficus._
-            //import net.ceedubs.ficus.readers.ArbitraryTypeReader._
-            val key = "org.opalj.fpcf.registry.analyses"
-            val registeredAnalyses = config.as[List[AnalysisFactory]](key)
-            registeredAnalyses foreach { a =>
-                register(a.id, a.description, a.factory)
-            }
-             */
             val registeredAnalyses = config.getObject("org.opalj.fpcf.registry.analyses")
             val entriesIterator = registeredAnalyses.entrySet.iterator
             while (entriesIterator.hasNext) {
@@ -128,17 +126,29 @@ object FPCFAnalysesRegistry {
                 val description = metaData.getOrDefault("description", null).unwrapped.toString
                 val default = metaData.getOrDefault("default", ConfigValueFactory.fromAnyRef(false))
                     .unwrapped().asInstanceOf[Boolean]
+
                 val lazyFactory = metaData.getOrDefault("lazyFactory", null)
                 if (lazyFactory ne null)
-                    register(id, description, lazyFactory.unwrapped.toString, true, default)
+                    register(id, description, lazyFactory.unwrapped.toString, "lazy", default)
+
+                val triggeredFactory = metaData.getOrDefault("triggeredFactory", null)
+                if (triggeredFactory ne null)
+                    register(
+                        id,
+                        description,
+                        triggeredFactory.unwrapped.toString,
+                        "triggered",
+                        default && (lazyFactory eq null)
+                    )
+
                 val eagerFactory = metaData.getOrDefault("eagerFactory", null)
                 if (eagerFactory ne null)
                     register(
                         id,
                         description,
                         eagerFactory.unwrapped.toString,
-                        false,
-                        default && (lazyFactory eq null)
+                        "eager",
+                        default && (lazyFactory eq null) && (triggeredFactory eq null)
                     )
             }
         } catch {
@@ -170,6 +180,13 @@ object FPCFAnalysesRegistry {
     }
 
     /**
+     * Returns the current view of the registry for triggered factories.
+     */
+    def triggeredFactories: Iterable[FPCFTriggeredAnalysisScheduler] = this.synchronized {
+        idToTriggeredScheduler.values
+    }
+
+    /**
      * Returns the current view of the registry for lazy factories.
      */
     def lazyFactories: Iterable[FPCFLazyAnalysisScheduler] = this.synchronized {
@@ -184,10 +201,24 @@ object FPCFAnalysesRegistry {
     }
 
     /**
+     * Returns the triggered factory for analysis with a matching description.
+     */
+    def triggeredFactory(id: String): FPCFTriggeredAnalysisScheduler = this.synchronized {
+        idToTriggeredScheduler(id)
+    }
+
+    /**
      * Returns the lazy factory for analysis with a matching description.
      */
     def lazyFactory(id: String): FPCFLazyAnalysisScheduler = this.synchronized {
         idToLazyScheduler(id)
+    }
+
+    /**
+     * Returns the most suitable factory for analysis with a matching description.
+     */
+    def factory(id: String): FPCFAnalysisScheduler = this.synchronized {
+        idToLazyScheduler.getOrElse(id, idToTriggeredScheduler.getOrElse(id, idToEagerScheduler(id)))
     }
 
     def defaultAnalysis(property: PropertyBounds): Option[ComputationSpecification[FPCFAnalysis]] = {

--- a/OPAL/tac/src/main/resources/reference.conf
+++ b/OPAL/tac/src/main/resources/reference.conf
@@ -5,10 +5,6 @@ org.opalj {
   fpcf {
     registry {
       analyses {
-        #"EntryPointsAnalysis" {
-        #  description = "Computes the entry points of the project w.r.t. to the given analysis mode.",
-        #  eagerFactory = "org.opalj.fpcf.analyses.EntryPointsAnalysis"
-        #},
         "L0TACAIAnalysis" {
           description = "Performs an abstract interpretation using the configured domain and then computes the 3-address code.",
           eagerFactory = "org.opalj.tac.fpcf.analyses.EagerL0TACAIAnalysis",
@@ -79,6 +75,46 @@ org.opalj {
         "ReflectionRelatedFieldAccessesAnalysis" {
           description = "Determines the reflective indirect read and write accesses to fields.",
           eagerFactory = "org.opalj.tac.fpcf.analyses.fieldaccess.reflection.ReflectionRelatedFieldAccessesAnalysisScheduler"
+        },
+        "LoadedClassesAnalysis" {
+          description = "Computes the set of classes loaded, e.g., due to instantiation or static member access",
+          triggeredFactory = "org.opalj.tac.fpcf.analyses.cg.LoadedClassesAnalysisScheduler"
+        },
+        "FinalizerAnalysis" {
+          description = "Resolves invocations of class finalizers."
+          triggeredFactory = "org.opalj.tac.fpcf.analyses.cg.FinalizerAnalysisScheduler"
+        },
+        "StaticInitializerAnalysis" {
+          description = "Resolves invocations of static initializers.",
+          eagerFactory = "org.opalj.tac.fpcf.analyses.cg.StaticInitializerAnalysisScheduler"
+        },
+        "ReflectionRelatedCallsAnalysis" {
+          description = "Resolves invocations due to reflection.",
+          eagerFactory = "org.opalj.tac.fpcf.analyses.cg.reflection.ReflectionRelatedCallsAnalysisScheduler"
+        },
+        "SerializationRelatedCallsAnalysis" {
+          description = "Resolves invocations due to (de-)serialization.",
+          eagerFactory = "org.opalj.tac.fpcf.analyses.cg.SerializationRelatedCallsAnalysisScheduler"
+        },
+        "ThreadRelatedCallsAnalysis" {
+          description = "Resolves invocations of Thread.run resulting from Thread.start.",
+          eagerFactory = "org.opalj.tac.fpcf.analyses.cg.ThreadRelatedCallsAnalysisScheduler"
+        },
+        "DoPrivilegedAnalysis" {
+          description = "Resolves invocations of methods invoked via AccessController.doPrivileged.",
+          eagerFactory = "org.opalj.tac.fpcf.analyses.cg.DoPrivilegedAnalysisScheduler"
+        },
+        "ConfiguredNativeMethodsCallGraphAnalysis" {
+          description = "Resolves calls from native methods as specified in the configuration.",
+          triggeredFactory = "org.opalj.tac.fpcf.analyses.cg.ConfiguredNativeMethodsCallGraphAnalysisScheduler"
+        },
+        "ReflectionAllocationsAnalysis" {
+          description = "Produces points-to sets for the results of reflection methods like Class.getMethod.",
+          eagerFactory = "org.opalj.tac.fpcf.analyses.pointsto.ReflectionAllocationsAnalysisScheduler"
+        },
+        "SystemPropertiesAnalysis" {
+          description = "Computes Strings available from system properties.",
+          triggeredFactory = "org.opalj.tac.fpcf.analyses.SystemPropertiesAnalysisScheduler"
         }
       }
     },


### PR DESCRIPTION
This makes it possible to use the CLI with any future or renamed modules without having to change the runner each time