### PR TITLE
Schedule the required FieldAccessInformationAnalysis in runners

### DIFF
--- a/DEVELOPING_OPAL/tools/src/main/scala/org/opalj/support/info/FieldAssignabilityRunner.scala
+++ b/DEVELOPING_OPAL/tools/src/main/scala/org/opalj/support/info/FieldAssignabilityRunner.scala
@@ -18,6 +18,7 @@ import org.opalj.br.fpcf.properties.immutability.NonAssignable
 import org.opalj.br.fpcf.properties.immutability.UnsafelyLazilyInitialized
 import org.opalj.tac.cg.RTACallGraphKey
 import org.opalj.tac.fpcf.analyses.escape.LazySimpleEscapeAnalysis
+import org.opalj.tac.fpcf.analyses.fieldaccess.EagerFieldAccessInformationAnalysis
 import org.opalj.tac.fpcf.analyses.fieldassignability.LazyL2FieldAssignabilityAnalysis
 
 /**
@@ -42,6 +43,7 @@ object FieldAssignabilityRunner extends ProjectAnalysisApplication {
         val (ps, _) = project
             .get(FPCFAnalysesManagerKey)
             .runAll(
+                EagerFieldAccessInformationAnalysis,
                 LazyL2FieldAssignabilityAnalysis,
                 LazyStaticDataUsageAnalysis,
                 LazyL0CompileTimeConstancyAnalysis,

--- a/DEVELOPING_OPAL/tools/src/main/scala/org/opalj/support/info/Immutability.scala
+++ b/DEVELOPING_OPAL/tools/src/main/scala/org/opalj/support/info/Immutability.scala
@@ -65,9 +65,8 @@ import org.opalj.tac.cg.CallGraphKey
 import org.opalj.tac.cg.XTACallGraphKey
 import org.opalj.tac.fpcf.analyses.LazyFieldImmutabilityAnalysis
 import org.opalj.tac.fpcf.analyses.escape.LazySimpleEscapeAnalysis
+import org.opalj.tac.fpcf.analyses.fieldaccess.EagerFieldAccessInformationAnalysis
 import org.opalj.tac.fpcf.analyses.fieldassignability.LazyL2FieldAssignabilityAnalysis
-import org.opalj.tac.fpcf.analyses.purity.L2PurityAnalysis
-import org.opalj.tac.fpcf.analyses.purity.SystemOutLoggingAllExceptionRater
 import org.opalj.util.PerformanceEvaluation.time
 import org.opalj.util.Seconds
 
@@ -146,6 +145,7 @@ object Immutability {
 
         val dependencies: List[FPCFAnalysisScheduler] =
             List(
+                EagerFieldAccessInformationAnalysis,
                 LazyL2FieldAssignabilityAnalysis,
                 LazyFieldImmutabilityAnalysis,
                 LazyClassImmutabilityAnalysis,
@@ -156,8 +156,6 @@ object Immutability {
             )
 
         project.get(callgraphKey)
-
-        L2PurityAnalysis.setRater(Some(SystemOutLoggingAllExceptionRater))
 
         project.updateProjectInformationKeyInitializationData(AIDomainFactoryKey) { _ =>
             if (level == 0)

--- a/DEVELOPING_OPAL/tools/src/main/scala/org/opalj/support/info/PureVoidMethods.scala
+++ b/DEVELOPING_OPAL/tools/src/main/scala/org/opalj/support/info/PureVoidMethods.scala
@@ -23,6 +23,7 @@ import org.opalj.tac.cg.RTACallGraphKey
 import org.opalj.tac.fpcf.analyses.LazyFieldLocalityAnalysis
 import org.opalj.tac.fpcf.analyses.escape.LazyInterProceduralEscapeAnalysis
 import org.opalj.tac.fpcf.analyses.escape.LazyReturnValueFreshnessAnalysis
+import org.opalj.tac.fpcf.analyses.fieldaccess.EagerFieldAccessInformationAnalysis
 import org.opalj.tac.fpcf.analyses.fieldassignability.LazyL1FieldAssignabilityAnalysis
 import org.opalj.tac.fpcf.analyses.purity.EagerL2PurityAnalysis
 
@@ -50,6 +51,7 @@ object PureVoidMethods extends ProjectAnalysisApplication {
         project.get(RTACallGraphKey)
 
         project.get(FPCFAnalysesManagerKey).runAll(
+            EagerFieldAccessInformationAnalysis,
             LazyL0CompileTimeConstancyAnalysis,
             LazyStaticDataUsageAnalysis,
             LazyInterProceduralEscapeAnalysis,

--- a/DEVELOPING_OPAL/tools/src/main/scala/org/opalj/support/info/Purity.scala
+++ b/DEVELOPING_OPAL/tools/src/main/scala/org/opalj/support/info/Purity.scala
@@ -66,6 +66,7 @@ import org.opalj.tac.fpcf.analyses.LazyFieldLocalityAnalysis
 import org.opalj.tac.fpcf.analyses.escape.LazyInterProceduralEscapeAnalysis
 import org.opalj.tac.fpcf.analyses.escape.LazyReturnValueFreshnessAnalysis
 import org.opalj.tac.fpcf.analyses.escape.LazySimpleEscapeAnalysis
+import org.opalj.tac.fpcf.analyses.fieldaccess.EagerFieldAccessInformationAnalysis
 import org.opalj.tac.fpcf.analyses.fieldassignability.EagerL0FieldAssignabilityAnalysis
 import org.opalj.tac.fpcf.analyses.fieldassignability.EagerL1FieldAssignabilityAnalysis
 import org.opalj.tac.fpcf.analyses.fieldassignability.EagerL2FieldAssignabilityAnalysis
@@ -579,6 +580,8 @@ object Purity {
                 Console.println(usage)
                 return;
         }
+
+        support ::= EagerFieldAccessInformationAnalysis
 
         if (eager) {
             support ::= EagerClassImmutabilityAnalysis

--- a/DEVELOPING_OPAL/tools/src/main/scala/org/opalj/support/info/UnusedResults.scala
+++ b/DEVELOPING_OPAL/tools/src/main/scala/org/opalj/support/info/UnusedResults.scala
@@ -42,6 +42,7 @@ import org.opalj.tac.cg.RTACallGraphKey
 import org.opalj.tac.fpcf.analyses.LazyFieldLocalityAnalysis
 import org.opalj.tac.fpcf.analyses.escape.LazyInterProceduralEscapeAnalysis
 import org.opalj.tac.fpcf.analyses.escape.LazyReturnValueFreshnessAnalysis
+import org.opalj.tac.fpcf.analyses.fieldaccess.EagerFieldAccessInformationAnalysis
 import org.opalj.tac.fpcf.analyses.fieldassignability.LazyL1FieldAssignabilityAnalysis
 import org.opalj.tac.fpcf.analyses.purity.EagerL2PurityAnalysis
 import org.opalj.tac.fpcf.properties.TACAI
@@ -79,6 +80,7 @@ object UnusedResults extends ProjectAnalysisApplication {
         project.get(RTACallGraphKey)
 
         project.get(FPCFAnalysesManagerKey).runAll(
+            EagerFieldAccessInformationAnalysis,
             LazyInterProceduralEscapeAnalysis,
             LazyReturnValueFreshnessAnalysis,
             LazyFieldLocalityAnalysis,


### PR DESCRIPTION
We forgot to add them when the FieldAccessInformation became a necessary prerequisite for the FieldAssignability analyses