### PR TITLE
Add triggered field access information analysis and use for call graphs

### DIFF
--- a/OPAL/tac/src/main/resources/reference.conf
+++ b/OPAL/tac/src/main/resources/reference.conf
@@ -1554,7 +1554,7 @@ org.opalj {
         "SerializationAllocations",
         "NewInstance",
         "org.opalj.tac.fpcf.analyses.pointsto.ReflectionAllocationsAnalysisScheduler",
-        "org.opalj.tac.fpcf.analyses.fieldaccess.EagerFieldAccessInformationAnalysis",
+        "org.opalj.tac.fpcf.analyses.fieldaccess.TriggeredFieldAccessInformationAnalysis",
         "org.opalj.tac.fpcf.analyses.fieldaccess.reflection.ReflectionRelatedFieldAccessesAnalysisScheduler",
       ]
     }

--- a/OPAL/tac/src/main/scala/org/opalj/tac/cg/PropagationBasedCallGraphKeys.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/cg/PropagationBasedCallGraphKeys.scala
@@ -19,7 +19,7 @@ import org.opalj.tac.fpcf.analyses.cg.xta.MTASetEntitySelector
 import org.opalj.tac.fpcf.analyses.cg.xta.TypePropagationAnalysisScheduler
 import org.opalj.tac.fpcf.analyses.cg.xta.TypeSetEntitySelector
 import org.opalj.tac.fpcf.analyses.cg.xta.XTASetEntitySelector
-import org.opalj.tac.fpcf.analyses.fieldaccess.EagerFieldAccessInformationAnalysis
+import org.opalj.tac.fpcf.analyses.fieldaccess.TriggeredFieldAccessInformationAnalysis
 import org.opalj.tac.fpcf.analyses.fieldaccess.reflection.ReflectionRelatedFieldAccessesAnalysisScheduler
 
 /**
@@ -62,7 +62,7 @@ trait PropagationBasedCallGraphKey extends CallGraphKey {
             new ArrayInstantiationsAnalysisScheduler(theTypeSetEntitySelector),
             new TypePropagationAnalysisScheduler(theTypeSetEntitySelector),
             ConfiguredNativeMethodsInstantiatedTypesAnalysisScheduler,
-            EagerFieldAccessInformationAnalysis,
+            TriggeredFieldAccessInformationAnalysis,
             ReflectionRelatedFieldAccessesAnalysisScheduler
         ) ::: (if (isLibrary) List(LibraryInstantiatedTypesBasedEntryPointsAnalysis) else Nil)
     }

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/fieldaccess/FieldAccessInformationAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/fieldaccess/FieldAccessInformationAnalysis.scala
@@ -6,29 +6,38 @@ package analyses
 package fieldaccess
 
 import org.opalj.br.Method
+import org.opalj.br.analyses.DeclaredFields
 import org.opalj.br.analyses.DeclaredFieldsKey
+import org.opalj.br.analyses.DeclaredMethods
 import org.opalj.br.analyses.DeclaredMethodsKey
 import org.opalj.br.analyses.ProjectInformationKeys
 import org.opalj.br.analyses.SomeProject
 import org.opalj.br.fpcf.BasicFPCFEagerAnalysisScheduler
+import org.opalj.br.fpcf.BasicFPCFTriggeredAnalysisScheduler
 import org.opalj.br.fpcf.ContextProviderKey
 import org.opalj.br.fpcf.FPCFAnalysis
+import org.opalj.br.fpcf.FPCFAnalysisScheduler
+import org.opalj.br.fpcf.analyses.ContextProvider
 import org.opalj.br.fpcf.properties.Context
+import org.opalj.br.fpcf.properties.cg.Callers
 import org.opalj.br.fpcf.properties.fieldaccess.DirectFieldAccesses
 import org.opalj.br.fpcf.properties.fieldaccess.FieldReadAccessInformation
 import org.opalj.br.fpcf.properties.fieldaccess.FieldWriteAccessInformation
 import org.opalj.br.fpcf.properties.fieldaccess.MethodFieldReadAccessInformation
 import org.opalj.br.fpcf.properties.fieldaccess.MethodFieldWriteAccessInformation
 import org.opalj.fpcf.EOptionP
+import org.opalj.fpcf.EPS
 import org.opalj.fpcf.InterimPartialResult
 import org.opalj.fpcf.ProperPropertyComputationResult
 import org.opalj.fpcf.PropertyBounds
 import org.opalj.fpcf.PropertyComputationResult
+import org.opalj.fpcf.PropertyKind
 import org.opalj.fpcf.PropertyStore
 import org.opalj.fpcf.Results
 import org.opalj.fpcf.SomeEPS
 import org.opalj.fpcf.UBP
 import org.opalj.tac.fpcf.analyses.cg.BaseAnalysisState
+import org.opalj.tac.fpcf.analyses.cg.ReachableMethodAnalysis
 import org.opalj.tac.fpcf.analyses.cg.persistentUVar
 import org.opalj.tac.fpcf.properties.TACAI
 import org.opalj.tac.fpcf.properties.TheTACAI
@@ -41,67 +50,20 @@ import org.opalj.value.ValueInformation
  *
  * @author Maximilian Rüsch
  */
-class FieldAccessInformationAnalysis(val project: SomeProject) extends FPCFAnalysis {
+sealed trait FieldAccessInformationAnalysis extends FPCFAnalysis {
+
+    val project: SomeProject
 
     type ContextType <: Context
 
-    private[this] class State(
+    protected[this] class State(
         override val callContext:                  ContextType,
         override protected[this] var _tacDependee: EOptionP[Method, TACAI]
     ) extends BaseAnalysisState with TACAIBasedAnalysisState[ContextType]
 
-    private val declaredMethods = project.get(DeclaredMethodsKey)
-    private val declaredFields = project.get(DeclaredFieldsKey)
-    private val contextProvider = project.get(ContextProviderKey)
+    protected[this] val declaredFields: DeclaredFields = project.get(DeclaredFieldsKey)
 
-    def analyzeMethod(method: Method): PropertyComputationResult = {
-        val context = contextProvider.newContext(declaredMethods(method)).asInstanceOf[ContextType]
-
-        val tacEP = propertyStore(method, TACAI.key)
-
-        if (tacEP.hasUBP && tacEP.ub.tac.isDefined) {
-            analyzeWithTAC(context, tacEP)
-        } else {
-            InterimPartialResult(Set(tacEP), tac => analyzeWithTAC(context, tac.asInstanceOf[EOptionP[Method, TACAI]]))
-        }
-
-    }
-
-    def analyzeWithTAC(context: ContextType, tacEP: EOptionP[Method, TACAI]): ProperPropertyComputationResult = {
-        implicit val state: State = new State(context, tacEP)
-        implicit val fieldAccesses: DirectFieldAccesses = new DirectFieldAccesses()
-
-        handleTac(context, tacEP.ub.tac.get)
-        returnResult(context)
-    }
-
-    private def continuation(context: ContextType, state: State)(eps: SomeEPS): ProperPropertyComputationResult = {
-        eps match {
-            case UBP(tac: TheTACAI) =>
-                val fieldAccesses = new DirectFieldAccesses()
-                handleTac(context, tac.theTAC)(fieldAccesses)
-
-                returnResult(context)(state, fieldAccesses)
-
-            case _ =>
-                InterimPartialResult(state.dependees, continuation(context, state))
-        }
-    }
-
-    private def returnResult(context: ContextType)(implicit
-        state:         State,
-        fieldAccesses: DirectFieldAccesses
-    ): ProperPropertyComputationResult = {
-        if (state.hasOpenDependencies)
-            Results(
-                InterimPartialResult(state.dependees, continuation(context, state)),
-                fieldAccesses.partialResults(context)
-            )
-        else
-            Results(fieldAccesses.partialResults(context))
-    }
-
-    private def handleTac(
+    protected[this] def handleTac(
         context: ContextType,
         tac:     TACode[TACMethodParameter, DUVar[ValueInformation]]
     )(implicit fieldAccesses: DirectFieldAccesses): Unit = {
@@ -148,13 +110,89 @@ class FieldAccessInformationAnalysis(val project: SomeProject) extends FPCFAnaly
     }
 }
 
-object EagerFieldAccessInformationAnalysis extends BasicFPCFEagerAnalysisScheduler {
+private[fieldaccess] class EagerTacBasedFieldAccessInformationAnalysis(
+    val project: SomeProject
+) extends FieldAccessInformationAnalysis {
 
-    override def requiredProjectInformation: ProjectInformationKeys = Seq(
-        DeclaredMethodsKey,
-        DeclaredFieldsKey,
-        ContextProviderKey
-    )
+    private[this] val declaredMethods: DeclaredMethods = project.get(DeclaredMethodsKey)
+    private[this] val contextProvider: ContextProvider = project.get(ContextProviderKey)
+
+    def analyzeMethod(method: Method): PropertyComputationResult = {
+        val context = contextProvider.newContext(declaredMethods(method)).asInstanceOf[ContextType]
+
+        val tacEP = propertyStore(method, TACAI.key)
+
+        if (tacEP.hasUBP && tacEP.ub.tac.isDefined) {
+            analyzeWithTAC(context, tacEP.asInstanceOf[EPS[Method, TACAI]])
+        } else {
+            InterimPartialResult(Set(tacEP), tac => analyzeWithTAC(context, tac.asInstanceOf[EPS[Method, TACAI]]))
+        }
+    }
+
+    private def analyzeWithTAC(context: ContextType, tacEP: EPS[Method, TACAI]): ProperPropertyComputationResult = {
+        implicit val state: State = new State(context, tacEP)
+        implicit val fieldAccesses: DirectFieldAccesses = new DirectFieldAccesses()
+
+        handleTac(context, tacEP.ub.tac.get)
+        returnResult(context)
+    }
+
+    private def continuation(context: ContextType, state: State)(eps: SomeEPS): ProperPropertyComputationResult = {
+        eps match {
+            case UBP(tac: TheTACAI) =>
+                val fieldAccesses = new DirectFieldAccesses()
+                handleTac(context, tac.theTAC)(fieldAccesses)
+
+                returnResult(context)(state, fieldAccesses)
+
+            case _ =>
+                InterimPartialResult(state.dependees, continuation(context, state))
+        }
+    }
+
+    private def returnResult(context: ContextType)(implicit
+        state:         State,
+        fieldAccesses: DirectFieldAccesses
+    ): ProperPropertyComputationResult = {
+        if (state.hasOpenDependencies)
+            Results(
+                InterimPartialResult(state.dependees, continuation(context, state)),
+                fieldAccesses.partialResults(context)
+            )
+        else
+            Results(fieldAccesses.partialResults(context))
+    }
+}
+
+private[fieldaccess] class ReachableTacBasedFieldAccessInformationAnalysis(
+    val project: SomeProject
+) extends FieldAccessInformationAnalysis with ReachableMethodAnalysis {
+
+    override def processMethod(callContext: ContextType, tacEP: EPS[Method, TACAI]): ProperPropertyComputationResult = {
+        implicit val state: State = new State(callContext, tacEP)
+        implicit val fieldAccesses: DirectFieldAccesses = new DirectFieldAccesses()
+
+        handleTac(callContext, tacEP.ub.tac.get)
+        returnResult(callContext)
+    }
+
+    private def returnResult(context: ContextType)(implicit
+        state:         State,
+        fieldAccesses: DirectFieldAccesses
+    ): ProperPropertyComputationResult = {
+        if (state.hasOpenDependencies)
+            Results(
+                InterimPartialResult(state.dependees, continuationForTAC(context.method)),
+                fieldAccesses.partialResults(context)
+            )
+        else
+            Results(fieldAccesses.partialResults(context))
+    }
+}
+
+private[fieldaccess] trait FieldAccessInformationAnalysisScheduler extends FPCFAnalysisScheduler {
+
+    override def requiredProjectInformation: ProjectInformationKeys = Seq(DeclaredFieldsKey)
 
     override def uses: Set[PropertyBounds] = PropertyBounds.ubs(
         TACAI,
@@ -164,18 +202,47 @@ object EagerFieldAccessInformationAnalysis extends BasicFPCFEagerAnalysisSchedul
         MethodFieldWriteAccessInformation
     )
 
-    override def derivesEagerly: Set[PropertyBounds] = Set.empty
-
-    override def derivesCollaboratively: Set[PropertyBounds] = PropertyBounds.ubs(
+    protected def derivedProperties: Set[PropertyBounds] = PropertyBounds.ubs(
         FieldReadAccessInformation,
         FieldWriteAccessInformation,
         MethodFieldReadAccessInformation,
         MethodFieldWriteAccessInformation
     )
+}
+
+object EagerFieldAccessInformationAnalysis
+    extends FieldAccessInformationAnalysisScheduler
+    with BasicFPCFEagerAnalysisScheduler {
+
+    override def requiredProjectInformation: ProjectInformationKeys = super.requiredProjectInformation ++ Seq(
+        DeclaredMethodsKey,
+        ContextProviderKey
+    )
+
+    override def derivesEagerly: Set[PropertyBounds] = Set.empty
+
+    override def derivesCollaboratively: Set[PropertyBounds] = derivedProperties
 
     override def start(p: SomeProject, ps: PropertyStore, i: InitializationData): FPCFAnalysis = {
-        val analysis = new FieldAccessInformationAnalysis(p)
+        val analysis = new EagerTacBasedFieldAccessInformationAnalysis(p)
         ps.scheduleEagerComputationsForEntities(p.allMethodsWithBody)(analysis.analyzeMethod)
+        analysis
+    }
+}
+
+object TriggeredFieldAccessInformationAnalysis
+    extends FieldAccessInformationAnalysisScheduler
+    with BasicFPCFTriggeredAnalysisScheduler {
+
+    override def triggeredBy: PropertyKind = Callers
+
+    override def derivesEagerly: Set[PropertyBounds] = Set.empty
+
+    override def derivesCollaboratively: Set[PropertyBounds] = derivedProperties
+
+    override def register(p: SomeProject, ps: PropertyStore, i: InitializationData): FPCFAnalysis = {
+        val analysis = new ReachableTacBasedFieldAccessInformationAnalysis(p)
+        ps.registerTriggeredComputation(Callers.key, analysis.analyze)
         analysis
     }
 }


### PR DESCRIPTION
The current field access information analysis is eager. Using it in call graphs usually results in many upfront calculations, growing directly proportional to the number of methods under analysis, regardless of whether they are reachable or not.

This PR adds a triggered analysis for field accesses tor rectify this issue and thus brings the field access information analysis in line with other call graph related analysis and others that are used during call graph computation. Now, field accesses are only computed for methods that are deemed reachable, which is also the only case call graph analyses need such information.

Thus, the points to keys are reconfigured to use the new triggered analysis instead of the previous eager analysis.