### PR TITLE
Turn assertion into logged error

### DIFF
--- a/OPAL/br/src/main/scala/org/opalj/br/analyses/ProjectLike.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/analyses/ProjectLike.scala
@@ -594,12 +594,12 @@ abstract class ProjectLike extends ClassFileRepository { project =>
 
         project.classFile(receiverType) match {
             case Some(classFile) =>
-                assert(
-                    !classFile.isInterfaceDeclaration, {
-                        val methodInfo = descriptor.toJava(receiverType.toJava, name)
-                        s"the method is defined in an interface $methodInfo"
-                    }
-                )
+                if (classFile.isInterfaceDeclaration) {
+                    OPALLogger.error(
+                        "project configuration - class hierarchy",
+                        s"invalid inheritance: $receiverType is an interface"
+                    )
+                }
 
                 def resolveSuperclassMethodReference(): Result[Method] = {
                     classFile.superclassType match {


### PR DESCRIPTION
In case of separately compiled class files, a method reference that should be in a class is actually found in an interface.

I didn't check if this would still be executable bytecode, but I think it is better for OPAL to continue trying to provide reasonable analysis results while warning users about the problem rather than throwing an assertion error in development mode and silently doing nothing in production mode.