### PR TITLE
Fix output for empty high-soundness-mode string

### DIFF
--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/reflection/ReflectionRelatedCallsAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/reflection/ReflectionRelatedCallsAnalysis.scala
@@ -70,9 +70,9 @@ sealed trait ReflectionAnalysis extends TACAIBasedAPIBasedAnalysis {
                 if (key == "all") {
                     Set("class", "method")
                 } else {
-                    val options = key.split(',').toSet
+                    val options = key.split(',').toSet - ""
 
-                    val unrecognizedOptions = options -- Set("", "class", "method")
+                    val unrecognizedOptions = options -- Set("class", "method")
                     if (unrecognizedOptions.nonEmpty) {
                         logOnce(Warn(
                             "analysis configuration - reflection analysis",


### PR DESCRIPTION
The options were not empty, but a set containing the empty string, messing with the subsequent code.