### PR TITLE
Add proper equals method to class DVar

### DIFF
--- a/OPAL/tac/src/main/scala/org/opalj/tac/DUVar.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/DUVar.scala
@@ -188,7 +188,7 @@ class DVar[+Value <: ValueInformation /*org.opalj.ai.ValuesDomain#DomainValue*/ 
     override def equals(other: Any): Boolean = {
         other match {
             case that: DVar[_] => this.origin == that.origin && this.useSites == that.useSites
-            case _ => false
+            case _             => false
         }
     }
 

--- a/OPAL/tac/src/main/scala/org/opalj/tac/DUVar.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/DUVar.scala
@@ -129,6 +129,8 @@ class DVar[+Value <: ValueInformation /*org.opalj.ai.ValuesDomain#DomainValue*/ 
         new DVar(origin, value, useSites)
     }
 
+    def originatedAt: ValueOrigin = origin
+
     def definedBy: Nothing = throw new UnsupportedOperationException
 
     /**
@@ -182,6 +184,13 @@ class DVar[+Value <: ValueInformation /*org.opalj.ai.ValuesDomain#DomainValue*/ 
     }
 
     override def hashCode(): Int = Var.ASTID * 1171 - 13 + origin
+
+    override def equals(other: Any): Boolean = {
+        other match {
+            case that: DVar[_] => this.origin == that.origin && this.useSites == that.useSites
+            case _ => false
+        }
+    }
 
     override def toString: String = {
         s"DVar(useSites=${useSites.mkString("{", ",", "}")},value=$value,origin=$origin)"


### PR DESCRIPTION
Hi,
while working with Opal, we encountered a problem related to comparing different variables. In our project, we use many Java data structures and data structures from the `guava` library that require precise implementations of the `equals` and `hashCode` methods. More precisely, we would like to save statements from the TAC in sets, lists etc. However, we noticed that the class `DVar` does not implement a (proper) `equals` method, leading to some problems. For example, if we have to [assignments](https://github.com/opalj/opal/blob/ff01c1c9e696946a88b090a52881a41445cf07f1/OPAL/tac/src/main/scala/org/opalj/tac/Stmt.scala#L365) `assign1` and `assign2`, then the comparison `assign1 == assign2` evaluates to `false` because the comparison of the fields `targetVar` from both statements is always false, even in the case where the statements are equal, i.e. the `pc` and `expr` are equal and the `targetVal` should be equal, too. Therefore, we propose to add a proper implementation of the `equals` method to deal with this problem. The class `UVar` does already implement a proper `equals` method, so we assume that the corresponding method for the class `DVar` is just missing.

Additionally, we propose to add a method to the class `DVar` that allows reading the field `origin`. Our motivation here is to transform the representation of a statement into a more user-friendly form. For example, if we have an assignment, we would like to have someting like `"var" + assgin.targetVar.originatedAt + " = " + [...]`. We can then use the origin to distinguish different variables from different assignments.

I hope it is clear what our motivation is behind adding these changes!