### PR TITLE
Wrap support library paths in quotation marks

### DIFF
--- a/DEVELOPING_OPAL/plugins/sbt-java-fixture-compiler/src/main/scala/org/opalj/javacompilation/FixtureDiscovery.scala
+++ b/DEVELOPING_OPAL/plugins/sbt-java-fixture-compiler/src/main/scala/org/opalj/javacompilation/FixtureDiscovery.scala
@@ -78,7 +78,7 @@ object FixtureDiscovery {
                         requires
                             .map(librarySpec => librarySpec.substring(librarySpec.indexOf('=') + 1))
                             . /* support library name */
-                            map(libraryName => supportDir / libraryName)
+                            map(libraryName => s""""${supportDir / libraryName}"""")
                             . /* support library folder */
                             mkString(" "),
                         configurationOptions


### PR DESCRIPTION
Fixes the second issue recently discovered in #147.

The sourceFolder argument is actually already properly wrapped in quotation marks, but the support libaries were still printed into the command line literally.

Not a huge fan of how the solution works, but it's the best I could find right now.