### PR TITLE
Escape spaces in jar/zip paths to avoid URISyntaxException

### DIFF
--- a/OPAL/bi/src/main/scala/org/opalj/bi/reader/ClassFileReader.scala
+++ b/OPAL/bi/src/main/scala/org/opalj/bi/reader/ClassFileReader.scala
@@ -504,7 +504,8 @@ trait ClassFileReader extends ClassFileReaderConfiguration with Constant_PoolAbs
                         val jarEntryName = jarEntry.getName
                         if (jarEntryName.endsWith(".class")) {
                             try {
-                                val url = URI.create(jarFileURL + jarEntry.getName).toURL
+                                val path = jarFileURL + jarEntryName
+                                val url = new URI(path.replace(" ", "%20")).toURL
                                 val classFiles = ClassFile(jarFile, jarEntry)
                                 classFiles foreach (classFile => classFileHandler(classFile, url))
                             } catch {


### PR DESCRIPTION
Fixes #233 