### PR TITLE
Fix bug in detection of static initializers for classes

### DIFF
--- a/OPAL/br/src/main/scala/org/opalj/br/ClassFile.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/ClassFile.scala
@@ -702,7 +702,7 @@ final class ClassFile private (
                 (majorVersion < 51 || method.isStatic)
             )
                 return Some(method);
-            else if (methodNameComparison < 0)
+            else if (methodNameComparison > 0)
                 return None;
 
             i += 1


### PR DESCRIPTION
This is going to be the smallest PR to ever be posed on this Repo, it changes a whopping **one character** 😄

Nevertheless, there was an actual bug in `def staticInitializer: Option[Method]`, the piece of code that retrieves the static initializer for a `ClassFile`. Due to this bug, the code would only return the correct static initializer method if it was the first method in the Sequence of methods - this is not always the case, especially for Scala-Compiled JVM code, where many method names begin with "`$`", which is lexicographically smaller than `<clinit>`.

As a result, the analysis that normally marks static initializers as reachable during call graph construction missed some initializers - i confirmed that this issue is now fixed when applying this PR.