### PR TITLE
Expand check for /it:test workflow to include other author roles

### DIFF
--- a/.github/workflows/run_it_test_on_comment.yml
+++ b/.github/workflows/run_it_test_on_comment.yml
@@ -8,7 +8,14 @@ jobs:
   build:
     runs-on: [self-hosted, it_test]
 
-    if: github.event.issue.pull_request && contains(github.event.comment.body, '/it:test') && github.event.comment.author_association == 'COLLABORATOR'
+    if: |
+      github.event.issue.pull_request && contains(github.event.comment.body, '/it:test') &&
+      (
+        (github.event.issue.author_association == 'OWNER') ||
+        (github.event.issue.author_association == 'COLLABORATOR') ||
+        (github.event.issue.author_association == 'CONTRIBUTOR') ||
+        (github.event.issue.author_association == 'MEMBER')
+      )
 
     steps:
       - name: Get Repo


### PR DESCRIPTION
This should hopefully solve the issue we had recently with the it:test action not running (see #238).