### PR TITLE
Fix isIdle in PKESequentialPropertyStore

### DIFF
--- a/OPAL/si/src/main/scala/org/opalj/fpcf/seq/PKESequentialPropertyStore.scala
+++ b/OPAL/si/src/main/scala/org/opalj/fpcf/seq/PKESequentialPropertyStore.scala
@@ -677,7 +677,8 @@ final class PKESequentialPropertyStore protected (
         }
     }
 
-    override def isIdle: Boolean = tasksManager.isEmpty
+    var idle: Boolean = true
+    override def isIdle: Boolean = idle
 
     protected[this] def processTasks(): Unit = {
         while (!tasksManager.isEmpty) {
@@ -691,6 +692,7 @@ final class PKESequentialPropertyStore protected (
     }
 
     override def waitOnPhaseCompletion(): Unit = handleExceptions {
+        idle = false
         require(subPhaseId == 0, "unpaired waitOnPhaseCompletion call")
 
         if (triggeredComputations.exists(_.nonEmpty)) {
@@ -822,6 +824,8 @@ final class PKESequentialPropertyStore protected (
                 )
             }
         } while (continueComputation)
+
+        idle = true
 
         if (exception != null) throw exception;
     }


### PR DESCRIPTION
The previous implementation forced registering eager computations after lazy ones as they fill the task queue. This implementation, which matches the one in PKECPropertyStore, does not have that limitation.