### PR TITLE
Fixed the CallGraph error where the call graph is not calculated beca…

### DIFF
--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/CallGraphAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/CallGraphAnalysis.scala
@@ -448,7 +448,7 @@ object CallGraphAnalysisScheduler extends BasicFPCFTriggeredAnalysisScheduler {
      * ([[org.opalj.br.analyses.cg.InitialEntryPointsKey]]) to be called from an unknown context.
      * This will trigger the computation of the callees for these methods (see `processMethod`).
      */
-    override def init(p: SomeProject, ps: PropertyStore): Null = {
+    override def register(p: SomeProject, ps: PropertyStore, unused: Null): CallGraphAnalysis = {
         val declaredMethods = p.get(DeclaredMethodsKey)
         val entryPoints = p.get(InitialEntryPointsKey).map(declaredMethods.apply)
 
@@ -468,10 +468,6 @@ object CallGraphAnalysisScheduler extends BasicFPCFTriggeredAnalysisScheduler {
             }
         }
 
-        null
-    }
-
-    override def register(p: SomeProject, ps: PropertyStore, unused: Null): CallGraphAnalysis = {
         val analysis = new CallGraphAnalysis(p)
         ps.registerTriggeredComputation(Callers.key, analysis.analyze)
         analysis


### PR DESCRIPTION
…use the analysis was not calculated in the first phase of the scheduling process.

When implementing an automatic scheduler, an error was detected that the call graph is not calculated because the call graph should be calculated in a later phase.

When the code was analyzed with the debugger, I discovered that the ReachableMethodAnalysis in the analyze method is aborted by a FinalP(NoCallers).

By changing the register method and deleting the init method, which is normally executed before scheduling, the call graph can also be calculated in later phases.