### PR TITLE
Fixed exception when scheduling the purity analysis with all analyses in one phase

### DIFF
--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/FieldLocalityAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/FieldLocalityAnalysis.scala
@@ -714,7 +714,7 @@ class FieldLocalityAnalysis private[analyses] (
         state.addCallersDependee(newEP)
 
         val tacDependee = state.getTACDependee(definedMethod.definedMethod)
-        val oldCallers = oldEP.map(ep => if (ep.hasUBP) ep.ub else null).get
+        val oldCallers = if (oldEP != null && oldEP.get.hasUBP) oldEP.get.ub else null
 
         if (newEP.hasUBP && tacDependee.isDefined && tacDependee.get.hasUBP && tacDependee.get.ub.tac.isDefined) {
             val callers = newEP.ub

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/FieldLocalityAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/FieldLocalityAnalysis.scala
@@ -714,7 +714,7 @@ class FieldLocalityAnalysis private[analyses] (
         state.addCallersDependee(newEP)
 
         val tacDependee = state.getTACDependee(definedMethod.definedMethod)
-        val oldCallers = oldEP.map(_.ub).orNull
+        val oldCallers = oldEP.map(ep => if (ep.hasUBP) ep.ub else null).get
 
         if (newEP.hasUBP && tacDependee.isDefined && tacDependee.get.hasUBP && tacDependee.get.ub.tac.isDefined) {
             val callers = newEP.ub

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/FieldLocalityAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/FieldLocalityAnalysis.scala
@@ -714,7 +714,10 @@ class FieldLocalityAnalysis private[analyses] (
         state.addCallersDependee(newEP)
 
         val tacDependee = state.getTACDependee(definedMethod.definedMethod)
-        val oldCallers = if (oldEP != null && oldEP.get.hasUBP) oldEP.get.ub else null
+        val oldCallers = oldEP match {
+            case Some(ep) if ep.hasUBP => ep.ub
+            case _                     => null
+        }
 
         if (newEP.hasUBP && tacDependee.isDefined && tacDependee.get.hasUBP && tacDependee.get.ub.tac.isDefined) {
             val callers = newEP.ub


### PR DESCRIPTION
By scheduling the PurityAnalysis with all analyses in one phase, an exception is thrown in the FieldLocalityAnalysis if new callers are processed by the handleNewCallers method.