### PR TITLE
Fix assertion on call-graph integrity

### DIFF
--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/xta/TypePropagationAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/xta/TypePropagationAnalysis.scala
@@ -266,10 +266,10 @@ final class TypePropagationAnalysis private[analyses] (
             // Methods with multiple defined methods should never appear as callees.
             assert(!callee.hasMultipleDefinedMethods)
             // Instances of DefinedMethod we see should only be those where the method is defined in the class file of
-            // the declaring class type (i.e., it is not a DefinedMethod instance of some inherited method).
+            // the declaring class type (i.e., it is not a DefinedMethod instance of some inherited method).  However,
+            // in inconsistent bytecode scenarios, the call graph may resolve to a non-implemented abstract method.
             assert(!callee.hasSingleDefinedMethod ||
                 (callee.declaringClassType == callee.asDefinedMethod.definedMethod.classFile.thisType) ||
-                // Happens in inconsistent bytecode scenarios where the call graph resolves to a non-implemented abstract method
                 callee.asDefinedMethod.definedMethod.isAbstract)
 
             // Remember callee (with PC) so we don't have to process it again later.

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/xta/TypePropagationAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/xta/TypePropagationAnalysis.scala
@@ -268,7 +268,9 @@ final class TypePropagationAnalysis private[analyses] (
             // Instances of DefinedMethod we see should only be those where the method is defined in the class file of
             // the declaring class type (i.e., it is not a DefinedMethod instance of some inherited method).
             assert(!callee.hasSingleDefinedMethod ||
-                (callee.declaringClassType == callee.asDefinedMethod.definedMethod.classFile.thisType))
+                (callee.declaringClassType == callee.asDefinedMethod.definedMethod.classFile.thisType) ||
+                // Happens in inconsistent bytecode scenarios where the call graph resolves to a non-implemented abstract method
+                callee.asDefinedMethod.definedMethod.isAbstract)
 
             // Remember callee (with PC) so we don't have to process it again later.
             state.addSeenCallee(pc, callee)


### PR DESCRIPTION
If the project is inconsistent (e.g., a class file has been compiled against a different version of an interface), the call-graph may resolve to abstract methods in a best-effort manor. This is to be expected and thus must not be ruled out by the assertion.