### PR TITLE
Update sonatype release process

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 BSD 2-Clause License:
-Copyright (c) 2009 - 2024
+Copyright (c) 2009 - 2025
 Software Technology Group
 Department of Computer Science
 Technische Universität Darmstadt

--- a/Release.md
+++ b/Release.md
@@ -10,7 +10,8 @@
  1. turn off assertions in `scalac.options.local`
  1. run tests and integration tests (to ensure that everything works without assertions)
  1. publish to maven (`sbt publishSigned`)
- 1. go to [Sonatype](https://oss.sonatype.org/) to release the build
+ 1. upload the build (`sbt sonatypeCentralUpload`)
+ 1. go to [Sonatype](https://central.sonatype.com/) to release the build
  1. generate the webpage (`sbt generateSite`)
  1. upload the new webpage to www.opal-project.de 
  1. upload the generated ScalaDoc to `library/api/SNAPSHOT`

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,7 @@
 import sbt.Test
 import sbtassembly.AssemblyPlugin.autoImport.*
 import sbtunidoc.ScalaUnidocPlugin
+import xerial.sbt.Sonatype.sonatypeCentralHost
 
 name := "OPAL Library"
 
@@ -14,7 +15,7 @@ ThisBuild / version := "5.0.1-SNAPSHOT"
 // RELEASED version in ThisBuild := "1.0.0" // October 25th, 2017
 // RELEASED version in ThisBuild := "0.8.15" // September 7th, 2017
 // RELEASED version in ThisBuild := "0.8.14" // June 23rd, 2017
-// RELEASED version in ThisBuild := "0.8.13" // MAY 19th, 2017
+// RELEASED version in ThisBuild := "0.8.13" // May 19th, 2017
 // RELEASED version in ThisBuild := "0.8.12" // April 28th, 2017
 // RELEASED version in ThisBuild := "0.8.11" // April 14th, 2017
 // RELEASED version in ThisBuild := "0.8.10"
@@ -543,6 +544,7 @@ runProjectDependencyGeneration := {
 //
 
 ThisBuild / publishMavenStyle.withRank(KeyRanks.Invisible) := true
+ThisBuild / sonatypeCredentialHost := sonatypeCentralHost
 Test / publishArtifact := false
-ThisBuild / publishTo := MavenPublishing.publishTo(isSnapshot.value)
+ThisBuild / publishTo := sonatypePublishToBundle.value
 ThisBuild / pomExtra := MavenPublishing.pomNodeSeq()

--- a/project/MavenPublishing.scala
+++ b/project/MavenPublishing.scala
@@ -36,6 +36,10 @@ object MavenPublishing {
           <id>roth</id>
           <name>Tobias Roth</name>
         </developer>
+        <developer>
+            <id>duesing</id>
+            <name>Johannes Düsing</name>
+        </developer>
     </developers>
   }
 

--- a/project/MavenPublishing.scala
+++ b/project/MavenPublishing.scala
@@ -1,6 +1,4 @@
 /* BSD 2-Clause License - see OPAL/LICENSE for details. */
-import sbt._
-
 import scala.xml.NodeSeq
 
 /**
@@ -11,19 +9,10 @@ import scala.xml.NodeSeq
  */
 object MavenPublishing {
 
-  // method populates sbt.publishTo = SettingKey[Option[Resolver]]
-  def publishTo(isSnapshot: Boolean): Option[Resolver] = {
-    val nexus = "https://oss.sonatype.org/"
-    if (isSnapshot)
-      Some("snapshots" at nexus + "content/repositories/snapshots")
-    else
-      Some("releases" at nexus + "service/local/staging/deploy/maven2")
-  }
-
   def pomNodeSeq(): NodeSeq = {
     <scm>
-        <url>git@github.com:stg-tud/opal.git</url>
-        <connection>scm:git:git@github.com:stg-tud/opal.git</connection>
+        <url>https://github.com/opalj/opal.git</url>
+        <connection>scm:git:git@github.com:opalj/opal.git</connection>
     </scm>
     <developers>
         <developer>

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -17,5 +17,5 @@ addSbtPlugin("com.eed3si9n"     % "sbt-dirty-money"      % "0.2.0")
 addSbtPlugin("com.timushev.sbt" % "sbt-updates"          % "0.5.2")
 
 // For the deployment to maven central:
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.7")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.12.2")
 addSbtPlugin("com.github.sbt" % "sbt-pgp"      % "2.1.2")

--- a/src/site/UsingOPAL.md
+++ b/src/site/UsingOPAL.md
@@ -6,7 +6,7 @@ The latest release is always found on [Maven Central](https://search.maven.org/#
 
 If you want to use the snapshot version do not forget to add the respective resolver:
 
-    resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
+    resolvers += "Sonatype Central Snapshots" at "https://central.sonatype.com/repository/maven-snapshots/"
 
 ## Using OPAL to Develop Analyses
 


### PR DESCRIPTION
Sonatype's OSSRH service shuts down on June 30th, requiring us to change our release process to the newer Sonatype Central service: https://central.sonatype.org/faq/what-is-different-between-central-portal-and-legacy-ossrh/

More information on https://github.com/xerial/sbt-sonatype

With the next release, we have to check whether more configuration, e.g., POM metadata, tokens, etc. need to be set up.

I took the chance to also include @johannesduesing as a developer in our POM metadata.