### PR TITLE
Fix two issues in invokedynamic rewriting

### DIFF
--- a/OPAL/br/src/main/scala/org/opalj/br/reader/InvokedynamicRewriting.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/reader/InvokedynamicRewriting.scala
@@ -385,10 +385,11 @@ trait InvokedynamicRewriting
                 MethodDescriptor.NoArgsAndReturnVoid
             )
 
-            def appendType(t: Type): FieldType = {
-                if (t.isBaseType) t.asBaseType
-                else if (t eq ObjectType.String) ObjectType.String
-                else ObjectType.Object
+            def appendType(t: Type): FieldType = t match {
+                case ShortType | ByteType => IntegerType
+                case bt: BaseType         => bt
+                case ObjectType.String    => ObjectType.String
+                case _                    => ObjectType.Object
             }
 
             // Generate instructions to append a parameter to the StringBuilder

--- a/OPAL/br/src/main/scala/org/opalj/br/reader/InvokedynamicRewriting.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/reader/InvokedynamicRewriting.scala
@@ -194,8 +194,8 @@ trait InvokedynamicRewriting
     ): String = {
         val descriptor = surroundingMethodDescriptor.toJVMDescriptor
         val sanitizedDescriptor = replaceChars(descriptor, "/[;", "$]:")
-        s"${surroundingType.packageName}/${surroundingType.simpleName}$$" +
-            s"$surroundingMethodName$sanitizedDescriptor:$pc$$Lambda"
+        val packageString = if (surroundingType.packageName.isEmpty) "" else s"${surroundingType.packageName}/"
+        s"$packageString${surroundingType.simpleName}$$$surroundingMethodName$sanitizedDescriptor:$pc$$Lambda"
     }
 
     override def deferredInvokedynamicResolution(


### PR DESCRIPTION
- There are no append methods on StringBuilder for shorts and bytes, they are appended as ints
- Invalid class names (starting with a `/`) would have been generated if class was in the unnamed package