### PR TITLE
Fix post-dominator tree construction

### DIFF
--- a/OPAL/ai/src/main/scala/org/opalj/ai/domain/RecordCFG.scala
+++ b/OPAL/ai/src/main/scala/org/opalj/ai/domain/RecordCFG.scala
@@ -766,7 +766,7 @@ trait RecordCFG
                     if (remainingPotentialInfiniteLoopHeaders.size == 1)
                         return remainingPotentialInfiniteLoopHeaders;
                 } else if (dt.strictlyDominates(pc1, pc2)) {
-                    // 2. Given (due to the first checkt) that both pcs do not identify
+                    // 2. Given (due to the first checks) that both pcs do not identify
                     //    nested loops (in which case we keep the outer one!), we now have
                     //    to check if one loops calls the other loop; in that case we just
                     //    keep the final loop (the one where the loop header is dominated).
@@ -795,7 +795,7 @@ trait RecordCFG
     }
 
     /**
-     * Returns the basic block based representation of the cfg. This CFG may have less nodes
+     * Returns the basic block based representation of the cfg. This CFG may have fewer nodes
      * than the CFG computed using the naive bytecode representation because it was possible
      * (a) to detect dead paths or (b) to identify that a method call may never throw an exception
      * (in the given situation).
@@ -821,7 +821,7 @@ trait RecordCFG
                 if ( // 1.1.    Let's check if the handler was executed at all.
                      unsafeWasExecuted(handlerPC) &&
                      // 1.2.    The handler may be shared by multiple try blocks, hence, we have
-                     //         to ensure the we have at least one instruction in the try block
+                     //         to ensure that we have at least one instruction in the try block
                      //         that jumps to the handler.
                      handlesException(exceptionHandler)
                 ) {

--- a/OPAL/br/src/main/scala/org/opalj/br/cfg/BasicBlock.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/cfg/BasicBlock.scala
@@ -51,7 +51,7 @@ final class BasicBlock(
     /**
      * The pc of the last instruction belonging to this basic block.
      */
-    def endPC: Int = _endPC
+    override def endPC: Int = _endPC
 
     private[this] var _isStartOfSubroutine: Boolean = false // will be initialized at construction time
     def setIsStartOfSubroutine(): Unit = {

--- a/OPAL/br/src/main/scala/org/opalj/br/cfg/CFG.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/cfg/CFG.scala
@@ -566,11 +566,7 @@ case class CFG[I <: AnyRef, C <: CodeSequence[I]](
      * @see [[PostDominatorTree.apply]]
      */
     lazy val postDominatorTree: PostDominatorTree = {
-        val exitNodes = (normalReturnNode.predecessors ++ abnormalReturnNode.predecessors).map {
-            case bb: BasicBlock => bb.endPC
-            case cn: CatchNode  => cn.endPC
-            case _: ExitNode    => throw new IllegalArgumentException()
-        }
+        val exitNodes = (normalReturnNode.predecessors ++ abnormalReturnNode.predecessors).map(_.endPC)
 
         PostDominatorTree(
             if (exitNodes.size == 1) exitNodes.headOption else None,

--- a/OPAL/br/src/main/scala/org/opalj/br/cfg/CFG.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/cfg/CFG.scala
@@ -136,7 +136,7 @@ case class CFG[I <: AnyRef, C <: CodeSequence[I]](
             "predecessors and successors are inconsistent; e.g., " +
                 allBBsSet.find(bb => !bb.predecessors.forall { predBB => predBB.successors.contains(bb) }).map(bb =>
                     bb.predecessors.find(predBB => !predBB.successors.contains(bb)).map(predBB =>
-                        s"predBB is a predecessor of $bb, but does not list it as a successor"
+                        s"$predBB is a predecessor of $bb, but does not list it as a successor"
                     ).get
                 ).get
         )

--- a/OPAL/br/src/main/scala/org/opalj/br/cfg/CFG.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/cfg/CFG.scala
@@ -566,7 +566,11 @@ case class CFG[I <: AnyRef, C <: CodeSequence[I]](
      * @see [[PostDominatorTree.apply]]
      */
     lazy val postDominatorTree: PostDominatorTree = {
-        val exitNodes = normalReturnNode.predecessors.map(_.nodeId) ++ abnormalReturnNode.predecessors.map(_.nodeId)
+        val exitNodes = (normalReturnNode.predecessors ++ abnormalReturnNode.predecessors).map {
+            case bb: BasicBlock => bb.endPC
+            case cn: CatchNode  => cn.endPC
+            case _: ExitNode    => throw new IllegalArgumentException()
+        }
 
         PostDominatorTree(
             if (exitNodes.size == 1) exitNodes.headOption else None,

--- a/OPAL/br/src/main/scala/org/opalj/br/cfg/CFG.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/cfg/CFG.scala
@@ -424,9 +424,9 @@ case class CFG[I <: AnyRef, C <: CodeSequence[I]](
             // the set of successor can be (at the same time) a RegularBB or an ExitNode
             var successorPCs = IntTrieSet.empty
             bb.successors foreach {
-                case bb: BasicBlock => successorPCs += bb.startPC
-                case cb: CatchNode  => successorPCs += cb.handlerPC
-                case _              =>
+                case succ: BasicBlock => successorPCs += succ.startPC
+                case cb: CatchNode    => successorPCs += cb.handlerPC
+                case _                =>
             }
             successorPCs
         }
@@ -446,10 +446,10 @@ case class CFG[I <: AnyRef, C <: CodeSequence[I]](
         } else {
             // the set of successors can be (at the same time) a RegularBB or an ExitNode
             var visited = IntTrieSet.empty
-            bb.successors foreach { bb =>
+            bb.successors foreach { succ =>
                 val nextPC =
-                    if (bb.isBasicBlock) bb.asBasicBlock.startPC
-                    else if (bb.isCatchNode) bb.asCatchNode.handlerPC
+                    if (succ.isBasicBlock) succ.asBasicBlock.startPC
+                    else if (succ.isCatchNode) succ.asCatchNode.handlerPC
                     else -1
                 if (nextPC != -1 && !visited.contains(nextPC)) {
                     visited += nextPC
@@ -483,8 +483,8 @@ case class CFG[I <: AnyRef, C <: CodeSequence[I]](
             // The set of successors can be (at the same time) a RegularBB, a CatchBB or an ExitNode
             var visited = IntTrieSet.empty
             bb.successors foreach {
-                case bb: BasicBlock =>
-                    val nextPC = bb.startPC
+                case succ: BasicBlock =>
+                    val nextPC = succ.startPC
                     if (!visited.contains(nextPC)) {
                         visited += nextPC
                         f(nextPC)
@@ -509,10 +509,10 @@ case class CFG[I <: AnyRef, C <: CodeSequence[I]](
         if (bb.startPC == pc) {
             var predecessorPCs = IntTrieSet.empty
             bb.predecessors foreach {
-                case bb: BasicBlock =>
-                    predecessorPCs += bb.endPC
+                case pred: BasicBlock =>
+                    predecessorPCs += pred.endPC
                 case cn: CatchNode =>
-                    cn.predecessors.foreach { bb => predecessorPCs += bb.asBasicBlock.endPC }
+                    cn.predecessors.foreach { pred => predecessorPCs += pred.asBasicBlock.endPC }
             }
             predecessorPCs
         } else {
@@ -527,11 +527,11 @@ case class CFG[I <: AnyRef, C <: CodeSequence[I]](
         val bb = this.bb(pc)
         if (bb.startPC == pc) {
             var visited = IntTrieSet.empty
-            bb.predecessors foreach { bb =>
-                if (bb.isBasicBlock) {
-                    f(bb.asBasicBlock.endPC)
-                } else if (bb.isCatchNode) {
-                    bb.asCatchNode.predecessors foreach { predBB =>
+            bb.predecessors foreach { pred =>
+                if (pred.isBasicBlock) {
+                    f(pred.asBasicBlock.endPC)
+                } else if (pred.isCatchNode) {
+                    pred.asCatchNode.predecessors foreach { predBB =>
                         val nextPC = predBB.asBasicBlock.endPC
                         if (!visited.contains(nextPC)) {
                             visited += nextPC

--- a/OPAL/br/src/main/scala/org/opalj/br/cfg/CFGNode.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/cfg/CFGNode.scala
@@ -26,6 +26,8 @@ trait CFGNode extends Node {
 
     def isStartOfSubroutine: Boolean
 
+    def endPC: Int = throw new UnsupportedOperationException();
+
     //
     // MANAGING PREDECESSORS
     //

--- a/OPAL/br/src/main/scala/org/opalj/br/cfg/CatchNode.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/cfg/CatchNode.scala
@@ -20,11 +20,11 @@ package cfg
  * @author Michael Eichberg
  */
 final class CatchNode(
-    val index:     Int, // primarily used to compute a unique id
-    val startPC:   Int,
-    val endPC:     Int,
-    val handlerPC: Int,
-    val catchType: Option[ClassType]
+    val index:          Int, // primarily used to compute a unique id
+    val startPC:        Int,
+    override val endPC: Int,
+    val handlerPC:      Int,
+    val catchType:      Option[ClassType]
 ) extends CFGNode {
 
     /**

--- a/OPAL/br/src/main/scala/org/opalj/br/cfg/CatchNode.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/cfg/CatchNode.scala
@@ -8,7 +8,7 @@ package cfg
  *
  * @note   `CatchNode`s are made explicit to handle/identify situations where the same
  *         exception handlers is responsible for handling multiple different exceptions.
- *         This situation generally arises in case of Java`s multi-catch expressions.
+ *         This situation generally arises in case of Java's multi-catch expressions.
  *
  * @param  index The index of the underlying exception handler in the exception table.
  * @param  startPC The start pc of the try-block.

--- a/OPAL/common/src/main/scala/org/opalj/graphs/DominatorTree.scala
+++ b/OPAL/common/src/main/scala/org/opalj/graphs/DominatorTree.scala
@@ -179,7 +179,7 @@ object DominatorTree {
         while (vertexStack.nonEmpty) {
             val v = vertexStack.pop()
             // The following "if" is necessary, because the recursive DFS impl. in the paper
-            // performs an eager decent. This may already initialize a node that is also pushed
+            // performs an eager descent. This may already initialize a node that is also pushed
             // on the stack and, hence, must not be visited again.
             if (semi(v) == 0) {
                 n = n + 1


### PR DESCRIPTION
Our CFGs and (post-)dominator trees are based on instructions, not basic blocks. Thus, the previous code was wrong and resulted in broken post-dominator trees.