### PR TITLE
Move non-Java-specific code out of br subproject (cont'd)

### DIFF
--- a/OPAL/br/src/main/scala/org/opalj/br/fpcf/properties/AllocationFreeness.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/fpcf/properties/AllocationFreeness.scala
@@ -21,6 +21,7 @@ import org.opalj.br.instructions.NEWARRAY
 import org.opalj.br.instructions.PUTFIELD
 import org.opalj.fpcf.Entity
 import org.opalj.fpcf.FallbackReason
+import org.opalj.fpcf.IndividualProperty
 import org.opalj.fpcf.OrderedProperty
 import org.opalj.fpcf.PropertyKey
 import org.opalj.fpcf.PropertyMetaInformation

--- a/OPAL/br/src/main/scala/org/opalj/br/fpcf/properties/Purity.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/fpcf/properties/Purity.scala
@@ -20,6 +20,7 @@ import org.opalj.collection.immutable.EmptyIntTrieSet
 import org.opalj.collection.immutable.IntTrieSet
 import org.opalj.fpcf.Entity
 import org.opalj.fpcf.FallbackReason
+import org.opalj.fpcf.IndividualProperty
 import org.opalj.fpcf.PropertyKey
 import org.opalj.fpcf.PropertyMetaInformation
 import org.opalj.fpcf.PropertyStore

--- a/OPAL/br/src/main/scala/org/opalj/br/fpcf/properties/StaticDataUsage.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/fpcf/properties/StaticDataUsage.scala
@@ -5,6 +5,7 @@ package fpcf
 package properties
 
 import org.opalj.fpcf.Entity
+import org.opalj.fpcf.IndividualProperty
 import org.opalj.fpcf.OrderedProperty
 import org.opalj.fpcf.PropertyKey
 import org.opalj.fpcf.PropertyMetaInformation

--- a/OPAL/br/src/main/scala/org/opalj/br/fpcf/properties/VirtualMethodAllocationFreeness.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/fpcf/properties/VirtualMethodAllocationFreeness.scala
@@ -4,6 +4,7 @@ package br
 package fpcf
 package properties
 
+import org.opalj.fpcf.AggregatedProperty
 import org.opalj.fpcf.PropertyKey
 import org.opalj.fpcf.PropertyMetaInformation
 

--- a/OPAL/br/src/main/scala/org/opalj/br/fpcf/properties/VirtualMethodPurity.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/fpcf/properties/VirtualMethodPurity.scala
@@ -4,6 +4,7 @@ package br
 package fpcf
 package properties
 
+import org.opalj.fpcf.AggregatedProperty
 import org.opalj.fpcf.PropertyKey
 import org.opalj.fpcf.PropertyMetaInformation
 

--- a/OPAL/br/src/main/scala/org/opalj/br/fpcf/properties/VirtualMethodStaticDataUsage.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/fpcf/properties/VirtualMethodStaticDataUsage.scala
@@ -4,6 +4,7 @@ package br
 package fpcf
 package properties
 
+import org.opalj.fpcf.AggregatedProperty
 import org.opalj.fpcf.PropertyKey
 import org.opalj.fpcf.PropertyMetaInformation
 

--- a/OPAL/si/src/main/scala/org/opalj/fpcf/AggregatableValueProperty.scala
+++ b/OPAL/si/src/main/scala/org/opalj/fpcf/AggregatableValueProperty.scala
@@ -1,10 +1,6 @@
 /* BSD 2-Clause License - see OPAL/LICENSE for details. */
 package org.opalj
-package br
 package fpcf
-package properties
-
-import org.opalj.fpcf.Property
 
 /**
  * A trait to conveniently implement properties that need aggregated values.

--- a/OPAL/si/src/main/scala/org/opalj/fpcf/PropertyStoreKey.scala
+++ b/OPAL/si/src/main/scala/org/opalj/fpcf/PropertyStoreKey.scala
@@ -48,7 +48,9 @@ object PropertyStoreKey
         implicit val logContext: LogContext = project.logContext
 
         val context: List[PropertyStoreContext[AnyRef]] = List(
+            // The project is stored twice, once as a generic [[org.opalj.si.Project]] and once for its concrete class
             PropertyStoreContext(classOf[Project], project),
+            PropertyStoreContext(project.getClass.asInstanceOf[Class[Project]], project),
             PropertyStoreContext(classOf[Config], project.config)
         )
         project.getProjectInformationKeyInitializationData(this) match {

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/L0TACAIAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/L0TACAIAnalysis.scala
@@ -13,9 +13,9 @@ import org.opalj.ai.fpcf.properties.ProjectSpecificAIExecutor
 import org.opalj.br.Method
 import org.opalj.br.analyses.ProjectInformationKeys
 import org.opalj.br.analyses.SomeProject
-import org.opalj.br.fpcf.BasicFPCFEagerAnalysisScheduler
-import org.opalj.br.fpcf.BasicFPCFLazyAnalysisScheduler
 import org.opalj.br.fpcf.FPCFAnalysis
+import org.opalj.br.fpcf.FPCFEagerAnalysisScheduler
+import org.opalj.br.fpcf.FPCFLazyAnalysisScheduler
 import org.opalj.fpcf.Entity
 import org.opalj.fpcf.EOptionP
 import org.opalj.fpcf.EPK
@@ -103,9 +103,16 @@ sealed trait L0TACAIAnalysisScheduler extends TACAIInitializer {
 
     override def beforeSchedule(p: SomeProject, ps: PropertyStore): Unit = {}
 
+    override def afterPhaseScheduling(ps: PropertyStore, analysis: org.opalj.fpcf.FPCFAnalysis): Unit = {}
+
+    override def afterPhaseCompletion(
+        p:        SomeProject,
+        ps:       PropertyStore,
+        analysis: org.opalj.fpcf.FPCFAnalysis
+    ): Unit = {}
 }
 
-object EagerL0TACAIAnalysis extends L0TACAIAnalysisScheduler with BasicFPCFEagerAnalysisScheduler {
+object EagerL0TACAIAnalysis extends L0TACAIAnalysisScheduler with FPCFEagerAnalysisScheduler {
 
     override def derivesCollaboratively: Set[PropertyBounds] = Set.empty
 
@@ -119,7 +126,7 @@ object EagerL0TACAIAnalysis extends L0TACAIAnalysisScheduler with BasicFPCFEager
     }
 }
 
-object LazyL0TACAIAnalysis extends L0TACAIAnalysisScheduler with BasicFPCFLazyAnalysisScheduler {
+object LazyL0TACAIAnalysis extends L0TACAIAnalysisScheduler with FPCFLazyAnalysisScheduler {
 
     override def derivesLazily: Some[PropertyBounds] = Some(derivedProperty)
 

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/TACAIProvider.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/TACAIProvider.scala
@@ -11,9 +11,9 @@ import org.opalj.ai.fpcf.properties.ProjectSpecificAIExecutor
 import org.opalj.br.Method
 import org.opalj.br.analyses.ProjectInformationKeys
 import org.opalj.br.analyses.SomeProject
-import org.opalj.br.fpcf.BasicFPCFEagerAnalysisScheduler
-import org.opalj.br.fpcf.BasicFPCFLazyAnalysisScheduler
 import org.opalj.br.fpcf.FPCFAnalysis
+import org.opalj.br.fpcf.FPCFEagerAnalysisScheduler
+import org.opalj.br.fpcf.FPCFLazyAnalysisScheduler
 import org.opalj.fpcf.Entity
 import org.opalj.fpcf.FinalEP
 import org.opalj.fpcf.ProperPropertyComputationResult
@@ -47,9 +47,19 @@ sealed trait TACAIProviderScheduler extends TACAIInitializer with DomainBasedFPC
     override def requiredProjectInformation: ProjectInformationKeys = Seq(AIDomainFactoryKey)
 
     final def derivedProperty: PropertyBounds = PropertyBounds.finalP(TACAI)
+
+    override def beforeSchedule(p: SomeProject, ps: PropertyStore): Unit = {}
+
+    override def afterPhaseScheduling(ps: PropertyStore, analysis: org.opalj.fpcf.FPCFAnalysis): Unit = {}
+
+    override def afterPhaseCompletion(
+        p:        SomeProject,
+        ps:       PropertyStore,
+        analysis: org.opalj.fpcf.FPCFAnalysis
+    ): Unit = {}
 }
 
-object EagerTACAIProvider extends TACAIProviderScheduler with BasicFPCFEagerAnalysisScheduler {
+object EagerTACAIProvider extends TACAIProviderScheduler with FPCFEagerAnalysisScheduler {
 
     override def derivesCollaboratively: Set[PropertyBounds] = Set.empty
 
@@ -63,7 +73,7 @@ object EagerTACAIProvider extends TACAIProviderScheduler with BasicFPCFEagerAnal
     }
 }
 
-object LazyTACAIProvider extends TACAIProviderScheduler with BasicFPCFLazyAnalysisScheduler {
+object LazyTACAIProvider extends TACAIProviderScheduler with FPCFLazyAnalysisScheduler {
 
     override def derivesLazily: Some[PropertyBounds] = Some(derivedProperty)
 

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/AbstractPointsToAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/AbstractPointsToAnalysis.scala
@@ -803,8 +803,6 @@ trait AbstractPointsToAnalysisScheduler extends BasicFPCFTriggeredAnalysisSchedu
     def propertyKind: PropertyMetaInformation
     def createAnalysis: SomeProject => AbstractPointsToAnalysis
 
-    override type InitializationData = Null
-
     override def requiredProjectInformation: ProjectInformationKeys =
         super.requiredProjectInformation :+ DeclaredMethodsKey
 
@@ -820,12 +818,6 @@ trait AbstractPointsToAnalysisScheduler extends BasicFPCFTriggeredAnalysisSchedu
     override def derivesCollaboratively: Set[PropertyBounds] = Set(PropertyBounds.ub(propertyKind))
 
     override def derivesEagerly: Set[PropertyBounds] = Set.empty
-
-    override def init(p: SomeProject, ps: PropertyStore): Null = {
-        null
-    }
-
-    override def beforeSchedule(p: SomeProject, ps: PropertyStore): Unit = {}
 
     override def register(
         p:      SomeProject,


### PR DESCRIPTION
Follow up on #277 
- Fixes an bug introduced in that PR
- Moves an additional class to SI
- Stores the `Project` twice in the `PropertyStore` context (just to be on the safe side)
- Further cleanup