### PR TITLE
Add framework for data-flow analysis based on structural analysis

### DIFF
--- a/OPAL/si/src/main/resources/reference.conf
+++ b/OPAL/si/src/main/resources/reference.conf
@@ -18,4 +18,8 @@ org.opalj {
   fpcf.par.PKECPropertyStore.MaxEvaluationDepth = 32
 
   fpcf.AnalysisScenario.AnalysisAutoConfig = false
+
+  si.flowanalysis.StructuralAnalysis {
+    maxIterations = 1000
+  }
 }

--- a/OPAL/si/src/main/scala/org/opalj/si/flowanalysis/DataFlowAnalysis.scala
+++ b/OPAL/si/src/main/scala/org/opalj/si/flowanalysis/DataFlowAnalysis.scala
@@ -1,0 +1,217 @@
+/* BSD 2-Clause License - see OPAL/LICENSE for details. */
+package org.opalj
+package si
+package flowanalysis
+
+import scala.collection.mutable
+
+import scalax.collection.GraphTraversal.BreadthFirst
+import scalax.collection.GraphTraversal.Parameters
+
+/**
+ * Performs structural data flow analysis based on the results of a [[StructuralAnalysis]]. In more detail, this means
+ * that the control tree produced by the [[StructuralAnalysis]] is traversed recursively in a depth-first manner.
+ * Individual regions are processed by piping an [[Environment]] through their nodes and joining the
+ * environments where paths meet up. Thus, the individual flow functions defined at the statement PCs of a method are
+ * combined using region-type-specific patterns to effectively act as a flow function of the entire region, which is
+ * then processed itself due to the recursive nature of the algorithm.
+ *
+ * @param controlTree The control tree from the structural analysis.
+ * @param superFlowGraph The super flow graph from the structural analysis
+ * @param highSoundness Whether to use high soundness mode or not. Currently, this influences the handling of loops,
+ *                      i.e. whether they are approximated by one execution of the loop body (low soundness) or via
+ *                      a top value on all variables in the method (high soundness).
+ *
+ * @see [[StructuralAnalysis]], [[Environment]]
+ *
+ * @author Maximilian Rüsch
+ */
+class DataFlowAnalysis[Data, Environment <: DataFlowEnvironment[Data, Environment]](
+    private val controlTree:    ControlTree,
+    private val superFlowGraph: SuperFlowGraph,
+    private val highSoundness:  Boolean
+) {
+
+    type FlowFunction = (Environment => Environment)
+
+    private val _nodeOrderings = mutable.Map.empty[FlowGraphNode, Seq[SuperFlowGraph#NodeT]]
+    private val _removedBackEdgesGraphs = mutable.Map.empty[FlowGraphNode, (Boolean, SuperFlowGraph)]
+
+    /**
+     * Computes the resulting environment after the data flow analysis.
+     *
+     * @param flowFunctionByPc A mapping from PC to the flow functions to be used
+     * @param startEnv The base environment which is piped into the first region to be processed.
+     * @return The resulting [[Environment]] after execution of all flow functions using the region
+     *         hierarchy given in the control tree.
+     */
+    def compute(
+        flowFunctionByPc: Map[Int, FlowFunction]
+    )(startEnv: Environment): Environment = {
+        val startNodeCandidates = controlTree.nodes.filter(!_.hasPredecessors)
+        if (startNodeCandidates.size != 1) {
+            throw new IllegalStateException("Found more than one start node in the control tree!")
+        }
+
+        val startNode = startNodeCandidates.head.outer
+        pipeThroughNode(flowFunctionByPc)(startNode, startEnv)
+    }
+
+    private def pipeThroughNode(flowFunctionByPc: Map[Int, FlowFunction])(
+        node: FlowGraphNode,
+        env:  Environment
+    ): Environment = {
+        val pipe = pipeThroughNode(flowFunctionByPc) _
+        val innerChildNodes = controlTree.get(node).diSuccessors.map(n => superFlowGraph.get(n.outer))
+
+        def processBlock(entry: FlowGraphNode): Environment = {
+            var currentEnv = env
+            for {
+                currentNode <- superFlowGraph.innerNodeTraverser(
+                    superFlowGraph.get(entry),
+                    subgraphNodes = innerChildNodes.contains
+                )
+            } {
+                currentEnv = pipe(currentNode.outer, currentEnv)
+            }
+            currentEnv
+        }
+
+        def processIfThenElse(entry: FlowGraphNode): Environment = {
+            val entryNode = superFlowGraph.get(entry)
+            val successors = entryNode.diSuccessors.intersect(innerChildNodes).map(_.outer).toList.sorted
+            val branches = (successors.head, successors.tail.head)
+
+            val envAfterEntry = pipe(entry, env)
+            val envAfterBranches = (pipe(branches._1, envAfterEntry), pipe(branches._2, envAfterEntry))
+
+            envAfterBranches._1.join(envAfterBranches._2)
+        }
+
+        def processIfThen(entry: FlowGraphNode): Environment = {
+            val limitedFlowGraph = superFlowGraph.filter(innerChildNodes.contains)
+            val entryNode = limitedFlowGraph.get(entry)
+            val (yesBranch, noBranch) = if (entryNode.diSuccessors.head.diSuccessors.nonEmpty) {
+                (entryNode.diSuccessors.head, entryNode.diSuccessors.tail.head)
+            } else {
+                (entryNode.diSuccessors.tail.head, entryNode.diSuccessors.head)
+            }
+
+            val envAfterEntry = pipe(entry, env)
+            val envAfterBranches = (
+                pipe(yesBranch.diSuccessors.head, pipe(yesBranch, envAfterEntry)),
+                pipe(noBranch, envAfterEntry)
+            )
+
+            envAfterBranches._1.join(envAfterBranches._2)
+        }
+
+        def handleProperSubregion[A <: FlowGraphNode, G <: SuperFlowGraph](
+            g:          G,
+            innerNodes: Set[G#NodeT],
+            entry:      A
+        ): Environment = {
+            val entryNode = g.get(entry)
+            val sortedNodes = _nodeOrderings.getOrElseUpdate(
+                node, {
+                    val ordering = g.NodeOrdering((in1, in2) => in1.compare(in2))
+                    val traverser = entryNode.innerNodeTraverser(Parameters(BreadthFirst))
+                        .withOrdering(ordering)
+                        .withSubgraph(nodes = innerNodes.contains)
+                    // We know that the graph is acyclic here, so we can be sure that the topological sort never fails
+                    traverser.topologicalSort().toOption.get.toSeq
+                }
+            )
+
+            val currentNodeEnvs = mutable.Map((entryNode, pipe(entry, env)))
+            for {
+                _currentNode <- sortedNodes.filter(_ != entryNode)
+                currentNode = _currentNode.asInstanceOf[g.NodeT]
+            } {
+                val previousEnvs = currentNode.diPredecessors.toList.map { dp =>
+                    pipe(currentNode.outer, currentNodeEnvs(dp))
+                }
+                currentNodeEnvs.update(currentNode, env.joinMany(previousEnvs))
+            }
+
+            currentNodeEnvs(sortedNodes.last.asInstanceOf[g.NodeT])
+        }
+
+        def processProper(entry: FlowGraphNode): Environment = {
+            handleProperSubregion[FlowGraphNode, superFlowGraph.type](superFlowGraph, innerChildNodes, entry)
+        }
+
+        def processSelfLoop(entry: FlowGraphNode): Environment = {
+            val resultEnv = pipe(entry, env)
+            // IMPROVE only update affected variables instead of all
+            if (resultEnv != env && highSoundness) env.updateAll(env.top)
+            else resultEnv
+        }
+
+        def processWhileLoop(entry: FlowGraphNode): Environment = {
+            val entryNode = superFlowGraph.get(entry)
+            val envAfterEntry = pipe(entry, env)
+
+            superFlowGraph.innerNodeTraverser(entryNode, subgraphNodes = innerChildNodes)
+
+            var resultEnv = env
+            for {
+                currentNode <- superFlowGraph
+                    .innerNodeTraverser(entryNode)
+                    .withSubgraph(n => n != entryNode && innerChildNodes.contains(n))
+            } {
+                resultEnv = pipe(currentNode.outer, resultEnv)
+            }
+
+            // IMPROVE only update affected variables instead of all
+            if (resultEnv != envAfterEntry && highSoundness) envAfterEntry.updateAll(env.top)
+            else resultEnv
+        }
+
+        def processNaturalLoop(entry: FlowGraphNode): Environment = {
+            val (isCyclic, removedBackEdgesGraph) = _removedBackEdgesGraphs.getOrElseUpdate(
+                node, {
+                    val limitedFlowGraph = superFlowGraph.filter(innerChildNodes.contains)
+                    val entryPredecessors = limitedFlowGraph.get(entry).diPredecessors
+                    val computedRemovedBackEdgesGraph = limitedFlowGraph.filterNot(
+                        edgeP = edge =>
+                            edge.sources.toList.toSet.intersect(entryPredecessors).nonEmpty
+                                && edge.targets.contains(limitedFlowGraph.get(entry))
+                    )
+                    (computedRemovedBackEdgesGraph.isCyclic, computedRemovedBackEdgesGraph)
+                }
+            )
+
+            if (isCyclic) {
+                // IMPROVE only update affected variables instead of all
+                if (highSoundness) env.updateAll(env.top)
+                else env.updateAll(env.bottom)
+            } else {
+                // Handle resulting acyclic region
+                val resultEnv = handleProperSubregion[FlowGraphNode, removedBackEdgesGraph.type](
+                    removedBackEdgesGraph,
+                    removedBackEdgesGraph.nodes.toSet,
+                    entry
+                )
+                // IMPROVE only update affected variables instead of all
+                if (resultEnv != env && highSoundness) env.updateAll(env.top)
+                else resultEnv
+            }
+        }
+
+        node match {
+            case Statement(pc) if pc >= 0 => flowFunctionByPc(pc)(env)
+            case Statement(_)             => env
+
+            case Region(Block, _, entry)       => processBlock(entry)
+            case Region(IfThenElse, _, entry)  => processIfThenElse(entry)
+            case Region(IfThen, _, entry)      => processIfThen(entry)
+            case Region(Proper, _, entry)      => processProper(entry)
+            case Region(SelfLoop, _, entry)    => processSelfLoop(entry)
+            case Region(WhileLoop, _, entry)   => processWhileLoop(entry)
+            case Region(NaturalLoop, _, entry) => processNaturalLoop(entry)
+
+            case _ => env
+        }
+    }
+}

--- a/OPAL/si/src/main/scala/org/opalj/si/flowanalysis/DataFlowEnvironment.scala
+++ b/OPAL/si/src/main/scala/org/opalj/si/flowanalysis/DataFlowEnvironment.scala
@@ -1,0 +1,23 @@
+/* BSD 2-Clause License - see OPAL/LICENSE for details. */
+package org.opalj
+package si
+package flowanalysis
+
+/**
+ * A mapping from [[PDUWeb]] to [[Data]], used to identify the state of variables during a given fixed point of the
+ * [[org.opalj.si.flowanalysis.DataFlowAnalysis]].
+ *
+ * @author Dominik Helm
+ */
+trait DataFlowEnvironment[Data, T <: DataFlowEnvironment[Data, T]] { self =>
+
+    val top: Data
+    val bottom: Data
+
+    def join(other: T): T
+
+    def joinMany(envs: Iterable[T]): T
+
+    def updateAll(value: Data): T
+
+}

--- a/OPAL/si/src/main/scala/org/opalj/si/flowanalysis/FlowGraphNode.scala
+++ b/OPAL/si/src/main/scala/org/opalj/si/flowanalysis/FlowGraphNode.scala
@@ -1,0 +1,82 @@
+/* BSD 2-Clause License - see OPAL/LICENSE for details. */
+package org.opalj
+package si
+package flowanalysis
+
+sealed trait RegionType extends Product
+
+sealed trait AcyclicRegionType extends RegionType
+sealed trait CyclicRegionType extends RegionType
+
+case object Block extends AcyclicRegionType
+case object IfThen extends AcyclicRegionType
+case object IfThenElse extends AcyclicRegionType
+case object Case extends AcyclicRegionType
+case object Proper extends AcyclicRegionType
+case object SelfLoop extends CyclicRegionType
+case object WhileLoop extends CyclicRegionType
+case object NaturalLoop extends CyclicRegionType
+case object Improper extends CyclicRegionType
+
+/**
+ * A node in a flow graph and control tree produced by the [[StructuralAnalysis]].
+ *
+ * @author Maximilian Rüsch
+ */
+sealed trait FlowGraphNode extends Ordered[FlowGraphNode] {
+
+    def nodeIds: Set[Int]
+
+    override def compare(that: FlowGraphNode): Int = nodeIds.toList.min.compare(that.nodeIds.toList.min)
+}
+
+/**
+ * Represents a region of nodes in a [[FlowGraph]], consisting of multiple sub-nodes. Can identify general acyclic and
+ * cyclic structures or more specialised instances of such structures such as [[IfThenElse]] or [[WhileLoop]].
+ *
+ * @param regionType The type of the region.
+ * @param nodeIds The union of all ids the leafs that are contained in this region.
+ * @param entry The direct child of this region that contains the first leaf to be executed when entering the region.
+ */
+case class Region(regionType: RegionType, override val nodeIds: Set[Int], entry: FlowGraphNode) extends FlowGraphNode {
+
+    override def toString: String =
+        s"Region(${regionType.productPrefix}; ${nodeIds.toList.sorted.mkString(",")}; ${entry.toString})"
+
+    // Performance optimizations
+    private lazy val _hashCode = scala.util.hashing.MurmurHash3.productHash(this)
+    override def hashCode(): Int = _hashCode
+    override def canEqual(obj: Any): Boolean = obj.hashCode() == _hashCode
+}
+
+/**
+ * Represents a single statement in a methods [[FlowGraph]] and is one of the leaf nodes to be grouped by a [[Region]].
+ *
+ * @param pc The PC that the statement is given at.
+ */
+case class Statement(pc: Int) extends FlowGraphNode {
+
+    override val nodeIds: Set[Int] = Set(pc)
+
+    override def toString: String = s"Statement($pc)"
+}
+
+/**
+ * An additional global entry node to a methods [[FlowGraph]] to ensure only one entry node exists.
+ */
+object GlobalEntry extends FlowGraphNode {
+
+    override val nodeIds: Set[Int] = Set(Int.MinValue + 1)
+
+    override def toString: String = "GlobalEntry"
+}
+
+/**
+ * An additional global exit node to a methods [[FlowGraph]] to ensure only one exit node exists.
+ */
+object GlobalExit extends FlowGraphNode {
+
+    override val nodeIds: Set[Int] = Set(Int.MinValue)
+
+    override def toString: String = "GlobalExit"
+}

--- a/OPAL/si/src/main/scala/org/opalj/si/flowanalysis/StructuralAnalysis.scala
+++ b/OPAL/si/src/main/scala/org/opalj/si/flowanalysis/StructuralAnalysis.scala
@@ -1,0 +1,459 @@
+/* BSD 2-Clause License - see OPAL/LICENSE for details. */
+package org.opalj
+package si
+package flowanalysis
+
+import scala.collection.mutable
+
+import com.typesafe.config.Config
+
+import org.opalj.graphs.DominatorTree
+
+import scalax.collection.GraphTraversal.DepthFirst
+import scalax.collection.GraphTraversal.Parameters
+import scalax.collection.OneOrMore
+import scalax.collection.OuterEdge
+import scalax.collection.edges.DiEdge
+import scalax.collection.generic.Edge
+import scalax.collection.hyperedges.DiHyperEdge
+import scalax.collection.immutable.Graph
+import scalax.collection.mutable.{Graph => MutableGraph}
+
+/**
+ * An algorithm that identifies several different types of flow regions in a given flow graph and reduces them to a
+ * single node iteratively. The algorithm terminates either when a single node is left in the flow graph or such a state
+ * could not be reached after [[maxIterations]].
+ *
+ * On termination, the [[analyze]] function returns:
+ * <ol>
+ *   <li>
+ *     The reduced flow graph, a single node equal to the root node of the control tree.
+ *   </li>
+ *   <li>
+ *     A <i>super flow graph</i> as a combination of the given source flow graph and the control tree. For each
+ *     node contained in the control tree, the super flow graph contains the node itself and edges to its children
+ *     as referenced the control tree. However, its children are still connected with edges as contained in the
+ *     source flow graph.
+ *     <br>
+ *     This representation eases traversal for data flow analysis such as by [[DataFlowAnalysis]].
+ *   </li>
+ *   <li>
+ *     The control tree, as a hierarchic representation of the control flow regions identified by the algorithm.
+ *   </li>
+ * </ol>
+ *
+ * This algorithm is adapted from Muchnick, S.S. (1997). Advanced Compiler Design and Implementation and optimized for
+ * performance.
+ *
+ * @see [[FlowGraphNode]], [[DataFlowAnalysis]]
+ *
+ * @author Maximilian Rüsch
+ */
+object StructuralAnalysis {
+
+    final val MaxIterationsKey = "org.opalj.si.flowanalysis.StructuralAnalysis.maxIterations"
+
+    private type MFlowGraph = MutableGraph[FlowGraphNode, DiEdge[FlowGraphNode]]
+    private type MControlTree = MutableGraph[FlowGraphNode, DiEdge[FlowGraphNode]]
+    private type MSuperFlowGraph = MutableGraph[FlowGraphNode, Edge[FlowGraphNode]]
+
+    def analyze(initialGraph: FlowGraph, entry: FlowGraphNode)(implicit
+        config: Config
+    ): (FlowGraph, SuperFlowGraph, ControlTree) = {
+        val flowGraph: MFlowGraph = MutableGraph.from(initialGraph.edges.outerIterable)
+        val superFlowGraph: MSuperFlowGraph =
+            MutableGraph.from(initialGraph.edges.outerIterable).asInstanceOf[MSuperFlowGraph]
+        var currentEntry = entry
+        val controlTree: MControlTree = MutableGraph.empty[FlowGraphNode, DiEdge[FlowGraphNode]]
+
+        var (immediateDominators, allDominators) = computeDominators(flowGraph, entry)
+        /**
+         * @return True when the given node n strictly dominates the node w.
+         */
+        def strictlyDominates(n: FlowGraphNode, w: FlowGraphNode): Boolean = n != w && allDominators(w).contains(n)
+
+        val knownPartOfNoCycle = mutable.Set.empty[FlowGraphNode]
+        def inCycle(n: FlowGraphNode): Boolean = {
+            if (knownPartOfNoCycle.contains(n)) {
+                false
+            } else {
+                // IMPROVE if no cycle is found, we can use the visitor of `findCycleContaining` to identify more nodes
+                // that are known to not be part of a cycle and add them to `knownPartOfNoCycle`.
+                val cycleOpt = flowGraph.findCycleContaining(flowGraph.get(n))
+                if (cycleOpt.isDefined) {
+                    true
+                } else {
+                    knownPartOfNoCycle.add(n)
+                    false
+                }
+            }
+        }
+
+        val maxIterations = config.getInt(MaxIterationsKey)
+
+        var iterations = 0
+        while (flowGraph.order > 1 && iterations < maxIterations) {
+            // Find post order depth first traversal order for nodes
+            var postCtr = 1
+            val post = mutable.ListBuffer.empty[FlowGraphNode]
+
+            def replace(subNodes: Set[FlowGraphNode], entry: FlowGraphNode, regionType: RegionType): Unit = {
+                val newRegion = Region(regionType, subNodes.flatMap(_.nodeIds), entry)
+
+                // Compact
+                // Note that adding the new region to the graph and superGraph is done anyways since we add edges later
+                val maxPost = post.indexOf(subNodes.maxBy(post.indexOf))
+                post(maxPost) = newRegion
+                // Removing old regions from the graph is done later
+                post.filterInPlace(r => !subNodes.contains(r))
+                postCtr = post.indexOf(newRegion)
+
+                if (subNodes.forall(knownPartOfNoCycle.contains)) {
+                    knownPartOfNoCycle.add(newRegion)
+                }
+                knownPartOfNoCycle.subtractAll(subNodes)
+
+                // Replace edges
+                val incomingEdges = flowGraph.edges.filter { e =>
+                    !subNodes.contains(e.outer.source) && subNodes.contains(e.outer.target)
+                }
+                val outgoingEdges = flowGraph.edges.filter { e =>
+                    subNodes.contains(e.outer.source) && !subNodes.contains(e.outer.target)
+                }
+
+                val newRegionEdges = incomingEdges.map { e =>
+                    OuterEdge[FlowGraphNode, DiEdge[FlowGraphNode]](DiEdge(e.outer.source, newRegion))
+                }.concat(outgoingEdges.map { e =>
+                    OuterEdge[FlowGraphNode, DiEdge[FlowGraphNode]](DiEdge(newRegion, e.outer.target))
+                })
+                flowGraph.addAll(newRegionEdges)
+                flowGraph.removeAll(subNodes, Set.empty)
+
+                superFlowGraph.addAll(newRegionEdges)
+                superFlowGraph.removeAll {
+                    incomingEdges.concat(outgoingEdges).map(e => DiEdge(e.outer.source, e.outer.target))
+                        .concat(Seq(DiHyperEdge(OneOrMore(newRegion), OneOrMore.from(subNodes).get)))
+                }
+
+                // Update dominator data
+                val commonDominators = subNodes.map(allDominators).reduce(_.intersect(_))
+                allDominators.subtractAll(subNodes).update(newRegion, commonDominators)
+                allDominators = allDominators.map(kv =>
+                    (
+                        kv._1, {
+                            val index = kv._2.indexWhere(subNodes.contains)
+                            if (index != -1)
+                                kv._2.patch(index, Seq(newRegion), kv._2.lastIndexWhere(subNodes.contains) - index + 1)
+                            else
+                                kv._2
+                        }
+                    )
+                )
+                immediateDominators = allDominators.map(kv => (kv._1, kv._2.head))
+
+                // Update remaining graph state
+                controlTree.addAll(subNodes.map(node =>
+                    OuterEdge[FlowGraphNode, DiEdge[FlowGraphNode]](DiEdge(newRegion, node))
+                ))
+                if (subNodes.contains(currentEntry)) {
+                    currentEntry = newRegion
+                }
+            }
+
+            // Determine post-order depth-first traversal in the given graph
+            val ordering = flowGraph.NodeOrdering((in1, in2) => in1.compare(in2))
+            flowGraph.innerNodeDownUpTraverser(
+                flowGraph.get(currentEntry),
+                Parameters(DepthFirst),
+                ordering = ordering
+            ).foreach {
+                case (down, in) if !down => post.append(in.outer)
+                case _                   =>
+            }
+
+            while (flowGraph.order > 1 && postCtr < post.size) {
+                var n = post(postCtr)
+
+                val gPostMap =
+                    post.reverse.zipWithIndex.map(ni =>
+                        (flowGraph.get(ni._1).asInstanceOf[MFlowGraph#NodeT], ni._2)
+                    ).toMap
+                val (newStartingNode, acyclicRegionOpt) =
+                    locateAcyclicRegion[FlowGraphNode, MFlowGraph](flowGraph, gPostMap, allDominators)(n)
+                n = newStartingNode
+                if (acyclicRegionOpt.isDefined) {
+                    val (arType, nodes, entry) = acyclicRegionOpt.get
+                    replace(nodes, entry, arType)
+                } else if (inCycle(n)) {
+                    var reachUnder = Set(n)
+                    for {
+                        m <- flowGraph.nodes.outerIterator
+                        if m != n
+                        innerM = controlTree.find(m)
+                        if innerM.isEmpty || !innerM.get.hasPredecessors
+                        if StructuralAnalysis.pathBack[FlowGraphNode, MFlowGraph](flowGraph, strictlyDominates)(m, n)
+                    } {
+                        reachUnder = reachUnder.incl(m)
+                    }
+
+                    val cyclicRegionOpt = locateCyclicRegion[FlowGraphNode, MFlowGraph](flowGraph, n, reachUnder)
+                    if (cyclicRegionOpt.isDefined) {
+                        val (crType, nodes, entry) = cyclicRegionOpt.get
+                        replace(nodes, entry, crType)
+                    } else {
+                        postCtr += 1
+                    }
+                } else {
+                    postCtr += 1
+                }
+            }
+
+            iterations += 1
+        }
+
+        if (iterations >= maxIterations) {
+            throw new IllegalStateException(s"Could not reduce tree in $maxIterations iterations!")
+        }
+
+        (
+            Graph.from(flowGraph.edges.outerIterable),
+            Graph.from(superFlowGraph.edges.outerIterable),
+            Graph.from(controlTree.edges.outerIterable)
+        )
+    }
+
+    /**
+     * Computes the immediate and global dominators for each of the nodes in the given graph.
+     *
+     * @param graph The graph to compute dominators for.
+     * @param entry The entry node to the graph under analysis.
+     * @return (A map for immediate dominators by graph node, A map for all dominators of a graph node by graph node)
+     */
+    private def computeDominators[A, G <: MutableGraph[A, DiEdge[A]]](
+        graph: G,
+        entry: A
+    ): (mutable.Map[A, A], mutable.Map[A, Seq[A]]) = {
+        val indexedNodes = graph.nodes.toIndexedSeq
+        val indexOf = indexedNodes.zipWithIndex.toMap
+        val domTree = DominatorTree(
+            indexOf(graph.get(entry)),
+            graph.get(entry).hasPredecessors,
+            index => { f => indexedNodes(index).diSuccessors.foreach(ds => f(indexOf(ds))) },
+            index => { f => indexedNodes(index).diPredecessors.foreach(ds => f(indexOf(ds))) },
+            indexedNodes.size - 1
+        )
+        val outerIndexedNodes = indexedNodes.map(_.outer)
+        val immediateDominators = mutable.Map.from {
+            domTree.immediateDominators.zipWithIndex.map(iDomWithIndex => {
+                (outerIndexedNodes(iDomWithIndex._2), outerIndexedNodes(iDomWithIndex._1))
+            })
+        }
+        immediateDominators.update(entry, entry)
+
+        def getAllDominators(n: A): Seq[A] = {
+            val builder = Seq.newBuilder[A]
+            var c = n
+            while (c != entry) {
+                builder.addOne(c)
+                c = immediateDominators(c)
+            }
+            builder.addOne(entry)
+            builder.result()
+        }
+        val allDominators = immediateDominators.map(kv => (kv._1, getAllDominators(kv._2)))
+
+        (immediateDominators, allDominators)
+    }
+
+    /**
+     * Determines if a path exists from the given node m to some other node k that does not contain the node n AND an
+     * edge k -> n exists that is a back edge in the given graph. The latter is realized by using predecessors to find
+     * eligible edges and using a strict domination predicate to determine a back edge from it.
+     *
+     * @param graph The graph under analysis.
+     * @param strictlyDominates Predicate if a given first node strictly dominates the given second nodes in the given graph.
+     * @param m The node that forms the starting node of the path.
+     * @param n The node that forms the ending node of the path.
+     * @return True if there is path back from m to n over some intermediate node k where m -> k does not contain n.
+     */
+    private def pathBack[A, G <: MutableGraph[A, DiEdge[A]]](graph: G, strictlyDominates: (A, A) => Boolean)(
+        m: A,
+        n: A
+    ): Boolean = {
+        val innerN = graph.get(n)
+        val nonNFromMTraverser = graph.innerNodeTraverser(graph.get(m), subgraphNodes = _ != innerN)
+        val predecessorsOfN = innerN.diPredecessors
+        graph.nodes.exists { innerK =>
+            innerK.outer != n &&
+            predecessorsOfN.contains(innerK) &&
+            strictlyDominates(n, innerK.outer) &&
+            nonNFromMTraverser.pathTo(innerK).isDefined
+        }
+    }
+
+    /**
+     * Identifies a candidate acyclic region if one can be found starting the identification at the given start node.
+     * If no region can be found, a new starting node is returned that can be used to resume searching for other region
+     * types. If a region can be found, all information needed to replace the contained nodes with a new region node in
+     * the graph is returned.
+     *
+     * @param graph The graph under analysis.
+     * @param postOrderTraversal A post order DFS traversal of the given graph as a mapping from node to its DF position.
+     * @param allDominators A dominator index as produced by [[computeDominators]].
+     * @param startingNode The node to start locating the acyclic region at.
+     * @return The new starting node of a candidate region as well as an option of: 1. The type of the found acyclic
+     *         region, 2. a set containing all region nodes and 3. the entry node to the region.
+     */
+    private def locateAcyclicRegion[A <: FlowGraphNode, G <: MutableGraph[A, DiEdge[A]]](
+        graph:              G,
+        postOrderTraversal: Map[G#NodeT, Int],
+        allDominators:      mutable.Map[A, Seq[A]]
+    )(startingNode: A): (A, Option[(AcyclicRegionType, Set[A], A)]) = {
+        var nSet = Set.empty[graph.NodeT]
+        var entry: graph.NodeT = graph.get(startingNode)
+
+        // Expand nSet down
+        var n = graph.get(startingNode)
+        while ((n.outer == startingNode || n.diPredecessors.size == 1) && n.diSuccessors.size == 1) {
+            nSet += n
+            n = n.diSuccessors.head
+        }
+        if (n.diPredecessors.size == 1) {
+            nSet += n
+        }
+
+        // Expand nSet up
+        n = graph.get(startingNode)
+        while (n.diPredecessors.size == 1 && (n.outer == startingNode || n.diSuccessors.size == 1)) {
+            nSet += n
+            entry = n
+            n = n.diPredecessors.head
+        }
+        if (n.diSuccessors.size == 1) {
+            nSet += n
+            entry = n
+        }
+
+        def isAcyclic(nodes: Set[graph.NodeT]): Boolean = {
+            nodes.forall { node =>
+                val postOrderIndex = postOrderTraversal(node)
+                node.diSuccessors.forall { successor =>
+                    !nodes.contains(successor) || postOrderTraversal(successor) >= postOrderIndex
+                }
+            }
+        }
+
+        def locateProperAcyclicInterval: Option[AcyclicRegionType] = {
+            val dominatedNodes = allDominators.filter(_._2.contains(n.outer)).map(kv => graph.get(kv._1)).toSet ++ Set(n)
+            if (dominatedNodes.size == 1 ||
+                !isAcyclic(dominatedNodes) ||
+                // Check if no dominated node is reached from a non-dominated node
+                !dominatedNodes.excl(n).forall(_.diPredecessors.subsetOf(dominatedNodes)) ||
+                // Check if all dominated nodes agree on a single successor outside the set (if it exists)
+                dominatedNodes.flatMap(node => node.diSuccessors.diff(dominatedNodes)).size > 1
+            ) {
+                None
+            } else {
+                nSet = dominatedNodes
+                entry = n
+
+                Some(Proper)
+            }
+        }
+
+        val newDirectSuccessors = n.diSuccessors
+        val rType = if (nSet.size > 1) {
+            // Condition is added to ensure chosen bb does not contain any self loops or other cyclic regions
+            // IMPROVE weaken to allow back edges from the "last" nSet member to the first to enable reductions to self loops
+            if (isAcyclic(nSet))
+                Some(Block)
+            else
+                None
+        } else if (newDirectSuccessors.size == 2) {
+            val m = newDirectSuccessors.head
+            val k = newDirectSuccessors.tail.head
+            if (m.diSuccessors.headOption == k.diSuccessors.headOption
+                && m.diSuccessors.size == 1
+                && m.diPredecessors.size == 1
+                && k.diPredecessors.size == 1
+            ) {
+                nSet = Set(n, m, k)
+                entry = n
+                Some(IfThenElse)
+            } else if ((
+                           m.diSuccessors.size == 1
+                               && m.diSuccessors.head == k
+                               && m.diPredecessors.size == 1
+                               && k.diPredecessors.size == 2
+                       ) || (
+                           k.diSuccessors.size == 1
+                           && k.diSuccessors.head == m
+                           && k.diPredecessors.size == 1
+                           && m.diPredecessors.size == 2
+                       )
+            ) {
+                nSet = Set(n, m, k)
+                entry = n
+                Some(IfThen)
+            } else {
+                locateProperAcyclicInterval
+            }
+        } else if (newDirectSuccessors.size > 2) {
+            locateProperAcyclicInterval
+        } else {
+            None
+        }
+
+        (n.outer, rType.map((_, nSet.map(_.outer), entry.outer)))
+    }
+
+    /**
+     * Identifies a candidate cyclic region if one can be found starting the identification at the given start node.
+     *
+     * @param graph The graph under analysis.
+     * @param startingNode The node to start identifying cyclic regions at.
+     * @param reachUnder A set of all nodes that can be reached starting from the given starting node that have a path
+     *                   back to the given start node.
+     * @return An option of: 1. The cyclic region type, 2. the nodes contained in the region and 3. the entry node of
+     *         the region.
+     *
+     * @note This implementation does not yet support improper regions and their reduction and will throw upon their
+     *       detection.
+     */
+    private def locateCyclicRegion[A, G <: MutableGraph[A, DiEdge[A]]](
+        graph:        G,
+        startingNode: A,
+        reachUnder:   Set[A]
+    ): Option[(CyclicRegionType, Set[A], A)] = {
+        if (reachUnder.size == 1) {
+            return if (graph.find(DiEdge(startingNode, startingNode)).isDefined)
+                Some((SelfLoop, reachUnder, reachUnder.head))
+            else None
+        }
+
+        if (reachUnder.exists(m => graph.get(startingNode).pathTo(graph.get(m)).isEmpty)) {
+            // IMPROVE reliably detect size of improper regions and reduce
+            throw new IllegalStateException("This implementation of structural analysis cannot handle improper regions!")
+        }
+
+        val m = reachUnder.excl(startingNode).head
+        if (graph.get(startingNode).diPredecessors.size == 2
+            && graph.get(startingNode).diSuccessors.size == 2
+            && graph.get(m).diPredecessors.size == 1
+            && graph.get(m).diSuccessors.size == 1
+        ) {
+            Some((WhileLoop, reachUnder, startingNode))
+        } else {
+            val enteringNodes =
+                reachUnder.filter(graph.get(_).diPredecessors.exists(dp => !reachUnder.contains(dp.outer)))
+
+            if (enteringNodes.size > 1) {
+                throw new IllegalStateException("Found more than one entering node for a natural loop!")
+            } else if (enteringNodes.isEmpty) {
+                throw new IllegalStateException("Found no entering node for a natural loop!")
+            }
+
+            Some((NaturalLoop, reachUnder, enteringNodes.head))
+        }
+    }
+}

--- a/OPAL/si/src/main/scala/org/opalj/si/flowanalysis/package.scala
+++ b/OPAL/si/src/main/scala/org/opalj/si/flowanalysis/package.scala
@@ -1,0 +1,29 @@
+/* BSD 2-Clause License - see OPAL/LICENSE for details. */
+package org.opalj
+package si
+
+import scalax.collection.edges.DiEdge
+import scalax.collection.generic.Edge
+import scalax.collection.immutable.Graph
+
+/**
+ * @author Maximilian Rüsch
+ */
+package object flowanalysis {
+
+    /**
+     * Region control tree representing nesting of control structures; obtained from structural analysis.
+     */
+    type ControlTree = Graph[FlowGraphNode, DiEdge[FlowGraphNode]]
+
+    /**
+     * CFG-like basis for data-flow analysis and super flow graph.
+     */
+    type FlowGraph = Graph[FlowGraphNode, DiEdge[FlowGraphNode]]
+
+    /**
+     * Flow graph with including region control tree information from structural analysis.
+     */
+    type SuperFlowGraph = Graph[FlowGraphNode, Edge[FlowGraphNode]]
+
+}

--- a/OPAL/tac/src/main/scala/org/opalj/tac/common/FlowGraph.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/common/FlowGraph.scala
@@ -1,0 +1,171 @@
+/* BSD 2-Clause License - see OPAL/LICENSE for details. */
+package org.opalj
+package tac
+package common
+
+import org.opalj.br.cfg.BasicBlock
+import org.opalj.br.cfg.CFG
+import org.opalj.si.flowanalysis.AcyclicRegionType
+import org.opalj.si.flowanalysis.CyclicRegionType
+import org.opalj.si.flowanalysis.FlowGraph
+import org.opalj.si.flowanalysis.FlowGraphNode
+import org.opalj.si.flowanalysis.GlobalEntry
+import org.opalj.si.flowanalysis.GlobalExit
+import org.opalj.si.flowanalysis.Region
+import org.opalj.si.flowanalysis.Statement
+
+import scalax.collection.edges.DiEdge
+import scalax.collection.generic.Edge
+import scalax.collection.immutable.Graph
+import scalax.collection.immutable.TypedGraphFactory
+import scalax.collection.io.dot.DotAttr
+import scalax.collection.io.dot.DotAttrStmt
+import scalax.collection.io.dot.DotEdgeStmt
+import scalax.collection.io.dot.DotGraph
+import scalax.collection.io.dot.DotNodeStmt
+import scalax.collection.io.dot.DotRootGraph
+import scalax.collection.io.dot.Elem
+import scalax.collection.io.dot.Graph2DotExport
+import scalax.collection.io.dot.Id
+import scalax.collection.io.dot.NodeId
+
+object FlowGraph extends TypedGraphFactory[FlowGraphNode, DiEdge[FlowGraphNode]] {
+
+    /**
+     * The entry point of all flow graphs.
+     *
+     * @see [[GlobalEntry]]
+     */
+    val entry: FlowGraphNode = GlobalEntry
+
+    private def mapInstrIndexToPC[V <: Var[V]](cfg: CFG[Stmt[V], TACStmts[V]])(index: Int): Int = {
+        if (index >= 0) cfg.code.instructions(index).pc
+        else index
+    }
+
+    /**
+     * Converts a given CFG to a flow graph with additional global entry and exit nodes.
+     *
+     * @see [[org.opalj.si.flowanalysis.FlowGraph]]
+     * @see [[FlowGraphNode]]
+     *
+     * @param cfg The CFG to convert to a flow graph.
+     * @return The flow graph obtained from the CFG.
+     */
+    def apply[V <: Var[V]](cfg: CFG[Stmt[V], TACStmts[V]]): FlowGraph = {
+        val toPC = mapInstrIndexToPC(cfg) _
+
+        val edges = cfg.allNodes.flatMap {
+            case bb: BasicBlock =>
+                val firstNode = Statement(toPC(bb.startPC))
+                var currentEdges = Seq.empty[DiEdge[FlowGraphNode]]
+                if (bb.startPC != bb.endPC) {
+                    Range.inclusive(bb.startPC, bb.endPC).tail.foreach { instrIndex =>
+                        currentEdges :+= DiEdge(
+                            currentEdges.lastOption.map(_.target).getOrElse(firstNode),
+                            Statement(toPC(instrIndex))
+                        )
+                    }
+                }
+
+                val lastNode = if (currentEdges.nonEmpty) currentEdges.last.target
+                else firstNode
+                currentEdges ++ bb.successors.map(s => DiEdge(lastNode, Statement(toPC(s.nodeId))))
+            case n =>
+                n.successors.map(s => DiEdge(Statement(toPC(n.nodeId)), Statement(toPC(s.nodeId))))
+        }.toSet
+        val g = Graph.from(edges + DiEdge(entry, entryFromCFG(cfg)))
+
+        val normalReturnNode = Statement(cfg.normalReturnNode.nodeId)
+        val abnormalReturnNode = Statement(cfg.abnormalReturnNode.nodeId)
+        val hasNormalReturn = cfg.normalReturnNode.predecessors.nonEmpty
+        val hasAbnormalReturn = cfg.abnormalReturnNode.predecessors.nonEmpty
+
+        (hasNormalReturn, hasAbnormalReturn) match {
+            case (true, true) =>
+                g.incl(DiEdge(normalReturnNode, GlobalExit)).incl(DiEdge(abnormalReturnNode, GlobalExit))
+
+            case (true, false) =>
+                g.excl(abnormalReturnNode)
+
+            case (false, true) =>
+                g.excl(normalReturnNode)
+
+            case _ =>
+                throw new IllegalStateException(
+                    "Cannot transform a CFG with neither normal nor abnormal return edges!"
+                )
+        }
+    }
+
+    private[this] def entryFromCFG[V <: Var[V]](cfg: CFG[Stmt[V], TACStmts[V]]): Statement =
+        Statement(mapInstrIndexToPC(cfg)(cfg.startBlock.nodeId))
+
+    /**
+     * @param graph The graph consisting of flow graph nodes to convert to DOT format.
+     * @return A DOT string of the graph.
+     */
+    def toDot[N <: FlowGraphNode, E <: Edge[N]](graph: Graph[N, E]): String = {
+        val root = DotRootGraph(
+            directed = true,
+            id = Some(Id("MyDot")),
+            attrStmts = List(DotAttrStmt(Elem.node, List(DotAttr(Id("shape"), Id("record"))))),
+            attrList = List(DotAttr(Id("attr_1"), Id(""""one"""")), DotAttr(Id("attr_2"), Id("<two>")))
+        )
+
+        def edgeTransformer(innerEdge: Graph[N, E]#EdgeT): Option[(DotGraph, DotEdgeStmt)] = {
+            val edge = innerEdge.outer
+            Some(
+                (
+                    root,
+                    DotEdgeStmt(NodeId(edge.sources.head.toString), NodeId(edge.targets.head.toString))
+                )
+            )
+        }
+
+        def hEdgeTransformer(innerHEdge: Graph[N, E]#EdgeT): Iterable[(DotGraph, DotEdgeStmt)] = {
+            val color = DotAttr(Id("color"), Id(s""""#%06x"""".format(scala.util.Random.nextInt(1 << 24))))
+
+            innerHEdge.outer.targets.toList map (target =>
+                (
+                    root,
+                    DotEdgeStmt(
+                        NodeId(innerHEdge.outer.sources.head.toString),
+                        NodeId(target.toString),
+                        Seq(color)
+                    )
+                )
+            )
+        }
+
+        def nodeTransformer(innerNode: Graph[N, E]#NodeT): Option[(DotGraph, DotNodeStmt)] = {
+            val node = innerNode.outer
+            val attributes = if (node.nodeIds.size == 1) Seq.empty
+            else Seq(
+                DotAttr(Id("style"), Id("filled")),
+                DotAttr(
+                    Id("fillcolor"),
+                    node match {
+                        case Region(_: AcyclicRegionType, _, _) => Id(""""green"""")
+                        case Region(_: CyclicRegionType, _, _)  => Id(""""purple"""")
+                        case _                                  => Id(""""white"""")
+                    }
+                )
+            )
+            Some(
+                (
+                    root,
+                    DotNodeStmt(NodeId(node.toString), attributes)
+                )
+            )
+        }
+
+        graph.toDot(
+            root,
+            edgeTransformer,
+            hEdgeTransformer = Some(hEdgeTransformer),
+            cNodeTransformer = Some(nodeTransformer),
+            iNodeTransformer = Some(nodeTransformer)
+        )
+    }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -308,7 +308,8 @@ lazy val `ThreeAddressCode` = (project in file("OPAL/tac"))
       .title("OPAL - Three Address Code") ++ Seq("-groups", "-implicits")),
     assembly / assemblyJarName := "OPALTACDisassembler.jar",
     assembly / mainClass := Some("org.opalj.tac.TAC"),
-    run / fork := true
+    run / fork := true,
+    libraryDependencies ++= Dependencies.tac
   )
   .dependsOn(ai % "it->it;it->test;test->test;compile->compile")
   .dependsOn(ifds % "it->it;it->test;test->test;compile->compile")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -25,6 +25,8 @@ object Dependencies {
     val jacksonDF = "2.12.2"
     val fastutil = "8.5.4"
     val apkparser = "2.6.10"
+    val scalagraphcore = "2.0.1"
+    val scalagraphdot = "2.0.0"
 
     val openjfx = "16"
   }
@@ -53,6 +55,8 @@ object Dependencies {
     val fastutil = "it.unimi.dsi"                           % "fastutil"                    % version.fastutil withSources () withJavadoc ()
     val javafxBase = "org.openjfx"                          % "javafx-base"                 % version.openjfx classifier osName
     val apkparser = "net.dongliu"                           % "apk-parser"                  % version.apkparser
+    val scalagraphcore = "org.scala-graph"                  %% "graph-core"                 % version.scalagraphcore
+    val scalagraphdot = "org.scala-graph"                   %% "graph-dot"                  % version.scalagraphdot
 
     // --- test related dependencies
 
@@ -68,9 +72,10 @@ object Dependencies {
 
   def common(scalaVersion: String) = Seq(reflect(scalaVersion), scalaparallelcollections, scalaxml, playjson, ficus, fastutil)
 
-  val si = Seq()
+  val si = Seq(scalagraphcore, scalagraphdot)
   val bi = Seq(commonstext)
   val br = Seq(scalaparsercombinators, scalaxml)
+  val tac = Seq()
   val ifds = Seq()
   val tools = Seq(txtmark, jacksonDF)
   val hermes = Seq(txtmark, jacksonDF, javafxBase)


### PR DESCRIPTION
Adds a generic framework for data-flow analysis that uses structural analysis, i.e., the recovery of the structure of nested control structures.

This is a spin-off from #1.