### PR TITLE
Format check command alias and git hook

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -95,6 +95,7 @@ addCommandAlias(
 addCommandAlias("cleanBuild", "; project OPAL ; cleanAll ; buildAll ")
 
 addCommandAlias("format", "; scalafmt; Test / scalafmt; IntegrationTest / scalafmt")
+addCommandAlias("checkFormat", "; scalafmtCheck; Test / scalafmtCheck; IntegrationTest / scalafmtCheck")
 
 lazy val IntegrationTest = config("it") extend Test
 

--- a/pre-commit
+++ b/pre-commit
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# Check OPAL formatting and reformat if necessary
+if ! sbt checkFormat
+then
+	sbt format
+	>&2 echo -e "\033[0;31mCommit aborted; offending files have been formatted"
+	exit 1
+fi


### PR DESCRIPTION
Adds a command alias `sbt checkFormat` similar to `sbt format` (see #272) which does not format files, but instead returns an error code if files need to be formatted. The main use case for this is for use in a git hook.

An example git hook is also included in the PR. If one wants to use it, the file has to be copied to `.git/hooks` (and potentially `chmod +x`). This will then check the formatting, and if necessary, format the files and abort the commit for the developer to review the formatting changes before retrying the commit. Note that due to the need to fire up sbt and scan many files, this significantly increases commit times, but at the same time, it prevents CI failures for incorrectly formatted files. If (local) commits need to be done without proper formatting applied, git commit can be used with `--no-verify` to skip the hook.