### PR TITLE
Move AndroidEntryPointsFinder to BR

### DIFF
--- a/OPAL/br/src/main/resources/reference.conf
+++ b/OPAL/br/src/main/resources/reference.conf
@@ -171,6 +171,32 @@ org.opalj {
       L0SelfReferenceLeakage {
         debug = true // default is "false"
       }
+    },
+
+    android {
+      AndroidEntryPointFinder {
+        # These methods are considered entry points for an Android app.
+        entryPoints = [
+          {cf = "android/app/Activity", name = "onCreate", desc = "(Landroid/os/Bundle;)V"}
+          {cf = "android/app/Activity", name = "onRestart", desc = "()V"},
+          {cf = "android/app/Activity", name = "onStart", desc = "()V"},
+          {cf = "android/app/Activity", name = "onResume", desc = "()V"},
+          {cf = "android/app/Activity", name = "onStop", desc = "()V"},
+          {cf = "android/app/Activity", name = "onDestroy", desc = "()V"},
+          {cf = "android/app/Activity", name = "onActivityResult", desc = "()V"},
+          {cf = "android/app/Service", name = "onCreate", desc = "()V"},
+          {cf = "android/app/Service", name = "onStartCommand", desc = "(Landroid/content/Intent;II)V"},
+          {cf = "android/app/Service", name = "onBind", desc = "(Landroid/content/Intent;)Landroid/os/IBinder;"},
+          {cf = "android/app/Service", name = "onRebind", desc = "(Landroid/content/Intent;)V"},
+          {cf = "android/app/Service", name = "onStart", desc = "(Landroid/content/Intent;I)V"},
+          {cf = "android/app/Service", name = "onDestroy", desc = "()V"},
+          {cf = "android/content/ContentProvider",name = "onCreate", desc = "()V"},
+          {cf = "android/location/LocationListener",name = "onProviderDisabled", desc = "(Ljava/lang/String;)V"},
+          {cf = "android/location/LocationListener",name = "onProviderEnabled", desc = "(Ljava/lang/String;)V"},
+          {cf = "android/location/LocationListener",name = "onStatusChanged", desc = "(Ljava/lang/String;ILandroid/os/Bundle;)V"},
+          {cf = "android/content/BroadcastReceiver",name = "onReceive",desc = "(Landroid/content/Context;Landroid/content/Intent;)V"}
+        ]
+      }
     }
   }
 

--- a/OPAL/br/src/main/scala/org/opalj/br/android/AndroidEntryPointFinder.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/android/AndroidEntryPointFinder.scala
@@ -1,11 +1,9 @@
 /* BSD 2-Clause License - see OPAL/LICENSE for details. */
 package org.opalj
-package tac
-package cg
+package br
 package android
 
 import scala.collection.mutable.ArrayBuffer
-import scala.jdk.CollectionConverters.CollectionHasAsScala
 
 import org.opalj.br.Method
 import org.opalj.br.MethodDescriptor
@@ -13,20 +11,19 @@ import org.opalj.br.ReferenceType
 import org.opalj.br.analyses.ProjectInformationKeys
 import org.opalj.br.analyses.SomeProject
 import org.opalj.br.analyses.cg.EntryPointFinder
-import org.opalj.br.android.AndroidManifest
-import org.opalj.br.android.AndroidManifestKey
-import org.opalj.tac.fpcf.analyses.MethodDescription
+
+import net.ceedubs.ficus.Ficus._
 
 /**
- * The AndroidEntryPointFinder considers specific methods of launcher Activity Clases as entry points.
+ * The AndroidEntryPointFinder considers specific methods of launcher Activity Classes as entry points.
  * An activity is a launcher activity if it contains an intent filter with action "android.intent.action.MAIN"
  * and category "android.intent.category.LAUNCHER". Requires Android Manifest to be loaded.
  *
  * @author Julius Naeumann
  */
-object AndroidEntryPointsFinder extends EntryPointFinder {
+object AndroidEntryPointFinder extends EntryPointFinder {
 
-    val configKey = "org.opalj.tac.cg.android.AndroidEntryPointsFinder.entryPoints"
+    val configKey = "org.opalj.fpcf.android.AndroidEntryPointFinder.entryPoints"
 
     override def requirements(project: SomeProject): ProjectInformationKeys = {
         super.requirements(project) ++ Seq(AndroidManifestKey)
@@ -44,8 +41,12 @@ object AndroidEntryPointsFinder extends EntryPointFinder {
         // iterate over launchable classes, collect their respective entry point methods according to config
         for (componentClass <- launchableClasses) {
             for (epd <- entryPointDescriptions) {
-                if (classHierarchy.isASubtypeOf(ReferenceType(componentClass.fqn), ReferenceType(epd.cf)).isYesOrUnknown) {
-                    entryPoints ++= componentClass.findMethod(epd.name, MethodDescriptor(epd.desc))
+                if (classHierarchy.isASubtypeOf(
+                        ReferenceType(componentClass.fqn),
+                        ReferenceType(epd.declaringClass)
+                    ).isYesOrUnknown
+                ) {
+                    entryPoints ++= componentClass.findMethod(epd.name, MethodDescriptor(epd.descriptor))
                 }
             }
         }
@@ -54,8 +55,15 @@ object AndroidEntryPointsFinder extends EntryPointFinder {
     }
 
     private def getConfiguredEntryPoints(project: SomeProject) = {
-        val entryPointDescriptionsConfig = project.config.getConfigList(configKey).asScala.toArray
-        val entryPointDescriptions = entryPointDescriptionsConfig.map(c => MethodDescription.reader.read(c, ""))
-        entryPointDescriptions
+        import net.ceedubs.ficus.readers.ArbitraryTypeReader._
+        project.config.as[List[EntryPointContainer]](configKey)
+
     }
+
+    /* Required by Ficus' `ArbitraryTypeReader`*/
+    private case class EntryPointContainer(
+        declaringClass: String,
+        name:           String,
+        descriptor:     String
+    )
 }

--- a/OPAL/br/src/main/scala/org/opalj/br/android/AndroidManifestArg.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/android/AndroidManifestArg.scala
@@ -24,7 +24,7 @@ object AndroidManifestArg extends PlainArg[File] with ProjectBasedArg[File, File
         if (value.isDefined) {
             opalConfig.withValue(
                 InitialEntryPointsKey.ConfigKey,
-                ConfigValueFactory.fromAnyRef("org.opalj.tac.cg.android.AndroidEntryPointsFinder")
+                ConfigValueFactory.fromAnyRef("org.opalj.br.android.AndroidEntryPointFinder")
             )
         } else opalConfig
     }

--- a/OPAL/tac/src/main/resources/reference.conf
+++ b/OPAL/tac/src/main/resources/reference.conf
@@ -1589,32 +1589,6 @@ org.opalj {
         "org.opalj.tac.fpcf.analyses.fieldaccess.TriggeredFieldAccessInformationAnalysis",
         "org.opalj.tac.fpcf.analyses.fieldaccess.reflection.ReflectionRelatedFieldAccessesAnalysisScheduler",
       ]
-    },
-
-    android {
-      AndroidEntryPointsFinder {
-        # These methods are considered entry points for an Android app.
-        entryPoints = [
-          {cf = "android/app/Activity", name = "onCreate", desc = "(Landroid/os/Bundle;)V"}
-          {cf = "android/app/Activity", name = "onRestart", desc = "()V"},
-          {cf = "android/app/Activity", name = "onStart", desc = "()V"},
-          {cf = "android/app/Activity", name ="onResume", desc = "()V"},
-          {cf = "android/app/Activity", name = "onStop", desc = "()V"},
-          {cf = "android/app/Activity", name = "onDestroy", desc = "()V"},
-          {cf = "android/app/Activity", name = "onActivityResult", desc = "()V"},
-          {cf = "android/app/Service", name = "onCreate", desc = "()V"},
-          {cf = "android/app/Service", name ="onStartCommand", desc = "(Landroid/content/Intent;II)V")},
-          {cf = "android/app/Service", name ="onBind", desc = "(Landroid/content/Intent;)Landroid/os/IBinder;"},
-          {cf = "android/app/Service", name ="onRebind", desc = "(Landroid/content/Intent;)V"},
-          {cf = "android/app/Service", name ="onStart", desc = "(Landroid/content/Intent;I)V"},
-          {cf = "android/app/Service", name = "onDestroy", desc = "()V"},
-          {cf = "android/content/ContentProvider",name = "onCreate", desc = "()V"},
-          {cf = "android/location/LocationListener",name = "onProviderDisabled", desc = "(Ljava/lang/String;)V"},
-          {cf = "android/location/LocationListener",name = "onProviderEnabled", desc = "(Ljava/lang/String;)V"},
-          {cf = "android/location/LocationListener",name = "onStatusChanged", desc = "(Ljava/lang/String;ILandroid/os/Bundle;)V"},
-          {cf = "android/content/BroadcastReceiver",name = "onReceive",desc = "(Landroid/content/Context;Landroid/content/Intent;)V"}
-        ]
-      }
     }
   }
 }


### PR DESCRIPTION
Since it has no dependencies on TAC classes and could be used with bytecode-only analyses it seems sensible to move this closer to the other EntryPointFinder implementations.