### PR TITLE
Fix class cast exception

### DIFF
--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/fieldaccess/reflection/ReflectionRelatedFieldAccessesAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/fieldaccess/reflection/ReflectionRelatedFieldAccessesAnalysis.scala
@@ -971,16 +971,21 @@ class MethodHandleInvokeAnalysis private[analyses] (
         if (definition.isMethodHandleConst) {
             definition.asMethodHandleConst.value match {
                 case handle: InstanceFieldAccessMethodHandle =>
-                    matchers += MatcherUtil.retrieveSuitableNonEssentialMatcher[V](
-                        actualParams.flatMap(_.head),
-                        v => new ActualReceiverBasedFieldMatcher(v.value.asReferenceValue)
-                    )
-                    matchers ++= MethodHandlesUtil.retrieveMatchersForMethodHandleConst(
-                        handle.declaringClassType,
-                        handle.name,
-                        handle.fieldType,
-                        isStatic = false
-                    )
+                    val receiver = actualParams.flatMap(_.head)
+                    if (receiver.forall(r => r.value.isPrimitiveValue)) {
+                        matchers = Set(NoFieldsMatcher)
+                    } else {
+                        matchers += MatcherUtil.retrieveSuitableNonEssentialMatcher[V](
+                            receiver,
+                            v => new ActualReceiverBasedFieldMatcher(v.value.asReferenceValue)
+                        )
+                        matchers ++= MethodHandlesUtil.retrieveMatchersForMethodHandleConst(
+                            handle.declaringClassType,
+                            handle.name,
+                            handle.fieldType,
+                            isStatic = false
+                        )
+                    }
 
                 case handle: StaticFieldAccessMethodHandle =>
                     matchers ++= MethodHandlesUtil.retrieveMatchersForMethodHandleConst(


### PR DESCRIPTION
An exception would occur if the value of the first parameter was not a reference value