### PR TITLE
Trim class name

### DIFF
--- a/OPAL/tac/src/it/scala/org/opalj/tac/fpcf/analyses/FPCFAnalysesIntegrationTest.scala
+++ b/OPAL/tac/src/it/scala/org/opalj/tac/fpcf/analyses/FPCFAnalysesIntegrationTest.scala
@@ -173,7 +173,7 @@ class FPCFAnalysesIntegrationTest extends AnyFunSpec {
     }
 
     def getProperty(fqn: String): PropertyMetaInformation = {
-        getObjectReflectively[PropertyMetaInformation](fqn, this, "integration test").get
+        getObjectReflectively[PropertyMetaInformation](fqn.trim, this, "integration test").get
     }
 
     def getConfig: Seq[(String, Set[ComputationSpecification[FPCFAnalysis]], Seq[PropertyMetaInformation])] = {


### PR DESCRIPTION
The string must be trimmed to remove the blanks at the start (this used to be the case and was accidentally removed in #307). Fixes https://github.com/opalj/opal/actions/runs/17549630645