### PR TITLE
Fix offset for simplified collapsed GOTO_W instructions

### DIFF
--- a/OPAL/br/src/main/scala/org/opalj/br/reader/BytecodeOptimizer.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/reader/BytecodeOptimizer.scala
@@ -292,10 +292,10 @@ trait BytecodeOptimizer extends MethodsBinding {
                             if (newBranchoffset >= Short.MinValue &&
                                 newBranchoffset <= Short.MaxValue
                             ) {
-                                // Replace it by a short goto
-                                instructions(pc + 0) = NOP
+                                // Replace it by a short goto, which has length 3 instead of length 5
+                                instructions(pc + 0) = GOTO(newBranchoffset)
                                 instructions(pc + 1) = NOP
-                                instructions(pc + 2) = GOTO(newBranchoffset)
+                                instructions(pc + 2) = NOP
                                 simplified = true
                             } else {
                                 // let's replace the original jump


### PR DESCRIPTION
During reading of classfiles, the bytecode control flow is optimized, including collapsing chains of `GOTO` instructions. In some cases `GOTO_W` (which is `GOTO` but with longer-than-`short` branching offsets) is rewritten to the shorter and more efficient `GOTO`.

Since `GOTO_W` takes 5 cycles and `GOTO` takes 3, the PC is kept aligned by introducing noops before the new goto instruction. However, the total branching offset that is calculated when collapsing a goto chain is based on the original PC, and was not adjusted for noop insertion.

This PR fixes this behavior and introduces some clarifications in comments surrounding the change. I originally aimed to add some test cases for this, but the class does not seem to have any specific ones.

Bug found with @w-lfchen.