### PR TITLE
Fix exception for empty parameters

### DIFF
--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/fieldaccess/reflection/ReflectionRelatedFieldAccessesAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/fieldaccess/reflection/ReflectionRelatedFieldAccessesAnalysis.scala
@@ -971,7 +971,7 @@ class MethodHandleInvokeAnalysis private[analyses] (
         if (definition.isMethodHandleConst) {
             definition.asMethodHandleConst.value match {
                 case handle: InstanceFieldAccessMethodHandle =>
-                    val receiver = actualParams.flatMap(_.head)
+                    val receiver = actualParams.flatMap(_.headOption).flatten
                     if (receiver.forall(r => r.value.isPrimitiveValue)) {
                         matchers = Set(NoFieldsMatcher)
                     } else {


### PR DESCRIPTION
An exception would occur here if the actualParams are Some(Seq.empty).