### PR TITLE
Use PCs instead of TAC indices

### DIFF
--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/TypeIterator.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/TypeIterator.scala
@@ -115,8 +115,7 @@ abstract class TypeIterator(val project: SomeProject) extends ContextProvider {
         field:           DeclaredField,
         fieldAllocation: DefinitionSite,
         depender:        Entity,
-        context:         Context,
-        stmts:           Array[Stmt[V]]
+        context:         Context
     )(
         implicit
         propertyStore: PropertyStore,
@@ -704,7 +703,7 @@ trait PointsToTypeIterator[ElementType, PointsToSet >: Null <: PointsToSetLike[E
             } else {
                 combine(
                     result,
-                    currentPointsTo(depender, pointsto.toEntity(defSite, context, stmts))
+                    currentPointsTo(depender, pointsto.toEntity(pc, context))
                 )
             }
         }
@@ -714,8 +713,7 @@ trait PointsToTypeIterator[ElementType, PointsToSet >: Null <: PointsToSetLike[E
         field:           DeclaredField,
         fieldAllocation: DefinitionSite,
         depender:        Entity,
-        context:         Context,
-        stmts:           Array[Stmt[V]]
+        context:         Context
     )(
         implicit
         propertyStore: PropertyStore,
@@ -723,7 +721,7 @@ trait PointsToTypeIterator[ElementType, PointsToSet >: Null <: PointsToSetLike[E
     ): PointsToSet = {
         val objects = currentPointsTo(
             depender,
-            pointsto.toEntity(fieldAllocation.pc, context, stmts)
+            pointsto.toEntity(fieldAllocation.pc, context)
         )
         var pointsTo = emptyPointsToSet
         objects.forNewestNElements(objects.numElements) { as =>
@@ -999,13 +997,7 @@ class AllocationSitesPointsToTypeIterator(project: SomeProject)
 
                 result = combine(
                     result,
-                    typesProperty(
-                        field,
-                        DefinitionSite(method, defPC),
-                        depender,
-                        newContext(definedMethod),
-                        theTAC.stmts
-                    )
+                    typesProperty(field, DefinitionSite(method, defPC), depender, newContext(definedMethod))
                 )
             }
 
@@ -1039,7 +1031,7 @@ class AllocationSitesPointsToTypeIterator(project: SomeProject)
             val defPC = if (defSite < 0) defSite else theTAC.stmts(defSite).pc
             val objects = currentPointsTo(
                 depender,
-                pointsto.toEntity(defPC, newContext(definedMethod), theTAC.stmts)(
+                pointsto.toEntity(defPC, newContext(definedMethod))(
                     formalParameters,
                     definitionSites,
                     this
@@ -1245,7 +1237,7 @@ class CFA_k_l_TypeIterator(project: SomeProject, val k: Int, val l: Int)
 
                 result = combine(
                     result,
-                    typesProperty(field, DefinitionSite(method, defPC), depender, calleeContext, theTAC.stmts)
+                    typesProperty(field, DefinitionSite(method, defPC), depender, calleeContext)
                 )
             }
 

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/PointsToAnalysisBase.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/PointsToAnalysisBase.scala
@@ -72,7 +72,7 @@ trait PointsToAnalysisBase extends AbstractPointsToBasedAnalysis with TypeConsum
     }
 
     @inline protected[this] def toEntity(defSite: Int)(implicit state: State): Entity = {
-        pointsto.toEntity(defSite, state.callContext, state.tac.stmts)
+        pointsto.toEntity(if (defSite < 0) defSite else state.tac.stmts(defSite).pc, state.callContext)
     }
 
     @inline protected[this] def getDefSite(pc: Int)(implicit state: State): Entity = {

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/package.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/package.scala
@@ -10,34 +10,32 @@ import org.opalj.br.fpcf.analyses.SimpleContextProvider
 import org.opalj.br.fpcf.properties.Context
 import org.opalj.fpcf.Entity
 import org.opalj.tac.common.DefinitionSites
-import org.opalj.value.ValueInformation
 
 package object pointsto {
 
     /**
-     * Given a definition site (value origin) in a certain method, this returns the
+     * Given a definition site PC (value origin) in a certain method, this returns the
      * entity to be used to attach/retrieve points-to information from.
      */
     def toEntity(
-        defSite: Int,
-        context: Context,
-        stmts:   Array[Stmt[DUVar[ValueInformation]]]
+        defSitePC: Int,
+        context:   Context
     )(
         implicit
         formalParameters: VirtualFormalParameters,
         definitionSites:  DefinitionSites,
         contextProvider:  ContextProvider
     ): Entity = {
-        val entity = if (ai.isMethodExternalExceptionOrigin(defSite)) {
-            val pc = ai.pcOfMethodExternalException(defSite)
-            CallExceptions(definitionSites(context.method.definedMethod, stmts(pc).pc))
-        } else if (ai.isImmediateVMException(defSite)) {
-            val pc = ai.pcOfImmediateVMException(defSite)
-            definitionSites(context.method.definedMethod, stmts(pc).pc)
-        } else if (defSite < 0) {
-            formalParameters.apply(context.method)(-1 - defSite)
+        val entity = if (ai.isMethodExternalExceptionOrigin(defSitePC)) {
+            val pc = ai.pcOfMethodExternalException(defSitePC)
+            CallExceptions(definitionSites(context.method.definedMethod, pc))
+        } else if (ai.isImmediateVMException(defSitePC)) {
+            val pc = ai.pcOfImmediateVMException(defSitePC)
+            definitionSites(context.method.definedMethod, pc)
+        } else if (defSitePC < 0) {
+            formalParameters.apply(context.method)(-1 - defSitePC)
         } else {
-            definitionSites(context.method.definedMethod, stmts(defSite).pc)
+            definitionSites(context.method.definedMethod, defSitePC)
         }
         contextProvider match {
             case _: SimpleContextProvider => entity


### PR DESCRIPTION
Changes `pointsto.toEntity` to take a program counter instead of a TAC index, since that is more general and more easily available. In particular, this fixes an issue in the `PointsToTypeIterator` where we accidentally already supplied a PC (the definition PC of a DefinitionSite) to `toEntity`