### PR TITLE
Fix incrementing PC after GOTO insertion

### DIFF
--- a/OPAL/br/src/main/scala/org/opalj/br/reader/BytecodeOptimizer.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/reader/BytecodeOptimizer.scala
@@ -294,8 +294,8 @@ trait BytecodeOptimizer extends MethodsBinding {
                             ) {
                                 // Replace it by a short goto, which has length 3 instead of length 5
                                 instructions(pc + 0) = GOTO(newBranchoffset)
-                                instructions(pc + 1) = NOP
-                                instructions(pc + 2) = NOP
+                                instructions(pc + 3) = NOP
+                                instructions(pc + 4) = NOP
                                 simplified = true
                             } else {
                                 // let's replace the original jump


### PR DESCRIPTION
We forgot to increment the PC. The test suite run in #312 was apparently run in an outdated setting.