### PR TITLE
Adapt application entry points finder to adhere to JVM 25 specification

### DIFF
--- a/OPAL/br/src/main/resources/reference.conf
+++ b/OPAL/br/src/main/resources/reference.conf
@@ -62,6 +62,11 @@ org.opalj {
           analysis = "org.opalj.br.analyses.cg.ApplicationWithoutJREEntryPointsFinder"
           #analysis = "org.opalj.br.analyses.cg.LibraryEntryPointsFinder"
           #analysis = "org.opalj.br.analyses.cg.MetaEntryPointsFinder"
+
+          # Java 25 changed the definition of entry points to a program to allow non-static main methods which might even be inherited
+          # or have no string array parameter. If you want to enforce pre-Java-25 rules (i.e., an entry point is static and has one
+          # string array parameter), set this value to false.
+          useJava25Semantics = true
           entryPoints = [
             {declaringClass = "java/lang/System", name = "initializeSystemClass", descriptor = "()V"},
             {declaringClass = "java/lang/Thread", name = "<init>", descriptor = "(Ljava/lang/ThreadGroup;Ljava/lang/Runnable;)V"},

--- a/OPAL/br/src/main/scala/org/opalj/br/analyses/cg/EntryPointFinder.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/analyses/cg/EntryPointFinder.scala
@@ -46,7 +46,10 @@ trait EntryPointFinder {
  *
  * According to the JVM 25 specification, valid main methods must be named "main", must return void
  * and may not be private. They must have either one parameter, which must be an array of strings,
- * or no parameters at all. Main methods can be inherited from interfaces or superclasses.
+ * or no parameters at all. Main methods can be inherited from interfaces or superclasses. The old
+ * semantics before Java 25 can be applied by setting the following configuration value to false:
+ *
+ *  org.opalj.br.analyses.cg.InitialEntryPointsKey.useJava25Semantics
  *
  * @note If it is required to find only a specific main method as entry point, please use the
  *       configuration-based entry point finder.
@@ -55,11 +58,15 @@ trait EntryPointFinder {
  */
 trait ApplicationEntryPointsFinder extends EntryPointFinder {
 
+    private val java25ConfigKey = "org.opalj.br.analyses.cg.InitialEntryPointsKey.useJava25Semantics"
+
     override def collectEntryPoints(project: SomeProject): Iterable[DeclaredMethod] = {
+
+        val useJava25Semantics = project.config.getBoolean(java25ConfigKey)
 
         val declaredMethods = project.get(DeclaredMethodsKey)
 
-        val MAIN_METHOD_DESCRIPTOR_WITH_ARGS = MethodDescriptor.JustTakes(FieldType.apply("[Ljava/lang/String;"))
+        val MAIN_METHOD_DESCRIPTOR_WITH_ARGS = MethodDescriptor.JustTakes(ArrayType(ClassType.String))
         val MAIN_METHOD_DESCRIPTOR_WITHOUT_ARGS = MethodDescriptor.NoArgsAndReturnVoid
 
         def isMainMethodWithArgs(m: Method): Boolean = m.name == "main" &&
@@ -68,48 +75,61 @@ trait ApplicationEntryPointsFinder extends EntryPointFinder {
         def isMainMethodWithoutArgs(m: Method): Boolean = m.name == "main" &&
             !m.isPrivate && m.descriptor == MAIN_METHOD_DESCRIPTOR_WITHOUT_ARGS
 
-        val allEntryPoints = project.allClassFiles.flatMap { cf =>
-            // Note that static methods are NOT contained in the instance methods - they must be looked up on the
-            // class file's method definitions.
-            val classTypeInstanceMethods = project.instanceMethods(cf.thisType)
+        if (useJava25Semantics) {
+            val allEntryPoints = project.allClassFiles.flatMap { cf =>
+                // Note that static methods are NOT contained in the instance methods - they must be looked up on the
+                // class file's method definitions.
+                val classTypeInstanceMethods = project.instanceMethods(cf.thisType)
 
-            // For any given class, a main method with the string array parameter takes precedence over the one with
-            // no parameters, as per the JVM 25 specification.
+                // For any given class, a main method with the string array parameter takes precedence over the one with
+                // no parameters, as per JLS 25 §12.1.4 (and JVM Specification 25 §5.2).
 
-            // We start by looking up main methods with the string array parameter that are  defined by the current
-            // class itself - this includes static method definitions.
-            val theMainMethodOpt = cf.methods.find(isMainMethodWithArgs)
-                // If no matching method is found, we look for inherited main methods with string array parameter
-                .orElse(classTypeInstanceMethods.find(mDecl => isMainMethodWithArgs(mDecl.method)).map(_.method))
-                // If no matching method is found, we look for direct definitions of no parameter main methods
-                .orElse(cf.methods.find(isMainMethodWithoutArgs))
-                // If no matching method is found, we look for inherited main methods with no parameters
-                .orElse(classTypeInstanceMethods.find(mDecl => isMainMethodWithoutArgs(mDecl.method)).map(_.method))
+                // We start by looking up main methods with the string array parameter that are defined by the current
+                // class itself - this includes static method definitions.
+                val theMainMethodOpt = cf.methods.find(isMainMethodWithArgs)
+                    // If no matching method is found, we look for inherited main methods with string array parameter
+                    .orElse(classTypeInstanceMethods.find(mDecl => isMainMethodWithArgs(mDecl.method)).map(_.method))
+                    // If no matching method is found, we look for direct definitions of no parameter main methods
+                    .orElse(cf.methods.find(isMainMethodWithoutArgs))
+                    // If no matching method is found, we look for inherited main methods with no parameters
+                    .orElse(classTypeInstanceMethods.find(mDecl => isMainMethodWithoutArgs(mDecl.method)).map(_.method))
 
-            // At this point, theMainMethodOpt contains the main method with the highest precedence for the current
-            // class, or None if no main method exists.
+                // At this point, theMainMethodOpt contains the main method with the highest precedence for the current
+                // class, or None if no main method exists.
 
-            // If the selected main method is not static, the JVM will invoke a default constructor for the current
-            // class before invoking the main method itself. This constructor must also be treated as an entry point.
-            if (theMainMethodOpt.isDefined && !theMainMethodOpt.get.isStatic) {
+                // If the selected main method is not static, the JVM will invoke a default constructor for the current
+                // class before invoking the main method itself. This constructor must also be treated as an entry point.
+                if (theMainMethodOpt.isDefined && !theMainMethodOpt.get.isStatic) {
 
-                // We search for a default constructor
-                val defaultConstructor = project
-                    .instanceMethods(cf.thisType)
-                    .map(_.method)
-                    .find(m => m.isConstructor && m.descriptor == MethodDescriptor.NoArgsAndReturnVoid)
+                    // We search for a default constructor
+                    val defaultConstructor = cf
+                        .methods
+                        .find(m => m.isConstructor && m.descriptor == MethodDescriptor.NoArgsAndReturnVoid)
 
-                // If no default constructor exists, we cannot consider the selected main method - as per the JVM 25
-                // specification the execution will fail if no default constructor is available
-                if (defaultConstructor.isEmpty) Seq.empty
-                else theMainMethodOpt.toSeq ++ defaultConstructor
-            } else {
-                theMainMethodOpt.toSeq
+                    // If no default constructor exists, we cannot consider the selected main method - as per the JVM 25
+                    // specification the execution will fail if no default constructor is available
+                    if (defaultConstructor.isEmpty) Seq.empty
+                    else Seq(theMainMethodOpt.get, defaultConstructor.get)
+                } else {
+                    theMainMethodOpt.toSeq
+                }
+
             }
 
+            super.collectEntryPoints(project) ++ allEntryPoints.map(declaredMethods.apply)
+        } else {
+            // Before Java 25, entry points must be methods named "main" that are public and static, and have one
+            // parameter of type String[].
+            super.collectEntryPoints(project) ++ project.allMethodsWithBody.iterator.collect {
+                case m: Method
+                    if m.isStatic
+                        && (m.descriptor == MAIN_METHOD_DESCRIPTOR_WITH_ARGS)
+                        && (m.name == "main")
+                        && m.isPublic =>
+                    declaredMethods(m)
+            }
         }
 
-        super.collectEntryPoints(project) ++ allEntryPoints.map(declaredMethods.apply)
     }
 }
 


### PR DESCRIPTION
With this PR, the `ApplicationEntryPointsFinder` is adapted so it adheres to the changes outlined by the JVM 25 specification. See #329 for details.