### PR TITLE
Add argument to provide config values

### DIFF
--- a/OPAL/br/src/main/scala/org/opalj/br/fpcf/cli/ProjectBasedCommandLineConfig.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/fpcf/cli/ProjectBasedCommandLineConfig.scala
@@ -150,7 +150,7 @@ trait ProjectBasedCommandLineConfig extends OPALCommandLineConfig {
                 info("project configuration", effectiveConfiguration)
             }
         } { t =>
-            OPALLogger.info("analysis progress", s"setting up project took ${t.toSeconds} ")(project.logContext)
+            OPALLogger.info("analysis progress", s"setting up project took ${t.toSeconds} ")(GlobalLogContext)
             projectTime = t.toSeconds
         }
         (project, projectTime)

--- a/OPAL/common/src/main/scala/org/opalj/cli/Arg.scala
+++ b/OPAL/common/src/main/scala/org/opalj/cli/Arg.scala
@@ -6,7 +6,7 @@ import com.typesafe.config.Config
 
 import org.rogach.scallop.ValueConverter
 
-trait Arg[T, R] {
+trait Arg[+T, R] {
     def name: String
     def argName: String = name
     def description: String
@@ -31,11 +31,24 @@ abstract class ConvertedArg[T: ValueConverter, R] extends Arg[T, R] {
 }
 
 abstract class PlainArg[T: ValueConverter] extends ConvertedArg[T, T] {
-    override final val choices = Seq.empty
+    override final val choices: Seq[String] = Seq.empty
 }
 
 abstract class ParsedArg[T: ValueConverter, R] extends ConvertedArg[T, R] {
     def parse(arg: T): R
+}
+
+abstract class PropertyArg[T: ValueConverter] extends ConvertedArg[T, Map[String, T]] {
+    def char: Char
+    def keyName: String = "key"
+    def valueName: String = "value"
+
+    override final val name = char.toString
+    override final val argName: String = null
+    override final val defaultValue: Option[T] = None
+    override final val short: Char = '\u0000'
+    override final val noshort: Boolean = true
+    override final val choices: Seq[String] = Seq.empty
 }
 
 trait ChoiceArg[R] extends Arg[String, R] {

--- a/OPAL/common/src/main/scala/org/opalj/cli/ConfigOverrideArg.scala
+++ b/OPAL/common/src/main/scala/org/opalj/cli/ConfigOverrideArg.scala
@@ -1,0 +1,26 @@
+/* BSD 2-Clause License - see OPAL/LICENSE for details. */
+package org.opalj
+package cli
+
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+
+import org.rogach.scallop.stringConverter
+
+object ConfigOverrideArg extends PropertyArg[String] {
+    override val char: Char = 'C'
+    override val description: String =
+        "Individual configuration values to be set (lists and objects supported: escape , and = with \\)"
+
+    override def apply(config: Config, value: Option[Map[String, String]]): Config = {
+
+        if (value.isDefined) {
+            var newConfig = config
+            for { (configKey, configValue) <- value.get } {
+                val parsedValue = ConfigFactory.parseString(configKey + "=" + configValue).getValue(configKey)
+                newConfig = newConfig.withValue(configKey, parsedValue)
+            }
+            newConfig
+        } else config
+    }
+}


### PR DESCRIPTION
Adds a generic command-line argument that allows overwriting/setting arbitrary config values.

Syntax is `-Ckey1=value1,key2=value2` (the comma can optionally be replaced with a blank and a blank after the initial 'C' is also valid). Arbitrarily nested lists and objects are possible as values, but any `,` or `=` must be escaped by `\` for the argument to be parsed correctly.

I opted for `-C` for the config, please comment if you would prefer a different character. Instead of a single character, we could also have this as a long version, e.g., `--config key1=value1 key2=value2` if that seems more intuitive.

Closes #328 