### PR TITLE
Add inline function for assertions that are elided in production builds

### DIFF
--- a/.github/workflows/run_it_test_on_comment.yml
+++ b/.github/workflows/run_it_test_on_comment.yml
@@ -60,9 +60,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           status: pending
 
-      - name: Enable Assertions
-        run: mv ./scalac.options.local.template ./scalac.options.local
-
       - name: Run Integration Tests
         run: sbt -J-Xmx40G "cleanBuild; IntegrationTest / test"
         

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -17,14 +17,8 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - name: Enable Assertions
-        run: mv ./scalac.options.local.template ./scalac.options.local
-
       - name: Build Opal
         run: sbt -J-Xmx20G cleanBuild
-
-      - name: Restore Scalac Options for Format Check
-        run: mv ./scalac.options.local ./scalac.options.local.template
       
       - name: Check formatting
         run: git diff --exit-code
@@ -40,9 +34,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-
-    - name: Enable Assertions
-      run: mv ./scalac.options.local.template ./scalac.options.local
 
     - name: Run Integration Tests
       run: sbt -J-Xmx40G cleanBuild it:test

--- a/DEVELOPING_OPAL/demos/src/main/scala/org/opalj/ai/InfiniteRecursions.scala
+++ b/DEVELOPING_OPAL/demos/src/main/scala/org/opalj/ai/InfiniteRecursions.scala
@@ -23,6 +23,7 @@ import org.opalj.br.instructions.INVOKESPECIAL
 import org.opalj.br.instructions.INVOKESTATIC
 import org.opalj.br.instructions.INVOKEVIRTUAL
 import org.opalj.br.instructions.NEW
+import org.opalj.util.elidedAssert
 
 import scala.collection.parallel.CollectionConverters.IterableIsParallelizable
 
@@ -95,8 +96,8 @@ object InfiniteRecursions extends ProjectsAnalysisApplication {
         method:            Method,
         pcs:               List[Int /*PC*/ ]
     ): Option[InfiniteRecursion] = boundary {
-        assert(maxRecursionDepth > 1)
-        assert(pcs.toSet.size == pcs.size, s"the seq $pcs contains duplicates")
+        elidedAssert(maxRecursionDepth > 1)
+        elidedAssert(pcs.toSet.size == pcs.size, s"the seq $pcs contains duplicates")
 
         val body = method.body.get
         val parametersCount =

--- a/OPAL/ai/src/main/scala/org/opalj/ai/AI.scala
+++ b/OPAL/ai/src/main/scala/org/opalj/ai/AI.scala
@@ -25,6 +25,7 @@ import org.opalj.log.GlobalLogContext
 import org.opalj.log.LogContext
 import org.opalj.log.OPALLogger
 import org.opalj.log.Warn
+import org.opalj.util.elidedAssert
 
 /**
  * A highly-configurable framework for the (abstract) interpretation of Java bytecode.
@@ -237,11 +238,11 @@ abstract class AI[D <: Domain](
         val locals = someLocals.map { l =>
             val maxLocals = method.body.get.maxLocals
 
-            assert(
+            elidedAssert(
                 l.size >= (method.parameterTypes.size + (if (method.isStatic) 0 else 1)),
                 "the number of initial locals is less than the number of parameters"
             )
-            assert(
+            elidedAssert(
                 l.size <= maxLocals,
                 s"the number of initial locals ${l.size} is larger than max locals $maxLocals"
             )
@@ -515,12 +516,12 @@ abstract class AI[D <: Domain](
         theSubroutinesLocalsArray:           theDomain.LocalsArray
     ): AIResult { val domain: theDomain.type } = {
 
-        assert(
+        elidedAssert(
             (theSubroutinesOperandsArray eq null) && (theSubroutinesLocalsArray eq null) ||
                 (theSubroutinesOperandsArray ne null) && (theSubroutinesLocalsArray ne null),
             "inconsistent subroutine information"
         )
-        assert(
+        elidedAssert(
             (theSubroutinesOperandsArray eq null) ||
                 theSubroutinesOperandsArray.zipWithIndex.forall { opsPC =>
                     val (ops, pc) = opsPC
@@ -926,7 +927,7 @@ abstract class AI[D <: Domain](
                     false
 
                 } else if (!forceJoin && !cfJoins.contains(targetPC)) {
-                    assert(abruptSubroutineTerminationCount == 0)
+                    elidedAssert(abruptSubroutineTerminationCount == 0)
 
                     // The instruction is not an instruction where multiple control-flow
                     // paths join; however, we may have a dangling computation.
@@ -1072,7 +1073,7 @@ abstract class AI[D <: Domain](
                     true
                 }
 
-            assert(
+            elidedAssert(
                 worklist.exists(_ == targetPC) == isTargetScheduled.isYesOrUnknown ||
                     worklist.forall(_ != targetPC) == isTargetScheduled.isNoOrUnknown,
                 s"worklist=$worklist; target=$targetPC; scheduled=$isTargetScheduled " +
@@ -1095,7 +1096,7 @@ abstract class AI[D <: Domain](
                     tracer
                 )
 
-            assert(
+            elidedAssert(
                 abruptSubroutineTerminationCount == 0 ||
                     !containsInPrefix(worklist, targetPC, SUBROUTINE_START),
                 "an exception handler that handles the abrupt termination of a subroutine " +
@@ -1219,7 +1220,7 @@ abstract class AI[D <: Domain](
                             if (pc >= 0) {
                                 val currentOperands = operandsArray(pc)
                                 val currentLocals = localsArray(pc)
-                                assert(currentOperands ne null)
+                                elidedAssert(currentOperands ne null)
 
                                 val mergedOperands = subroutinesOperandsArray(pc)
                                 if (mergedOperands eq null) {
@@ -3306,7 +3307,7 @@ abstract class AI[D <: Domain](
                                         )
                                     // The following assert may catch bugs in the
                                     // implementation of domains!
-                                    assert(
+                                    elidedAssert(
                                         {
                                             val castedValue = newOperands.head
                                             theDomain.isValueASubtypeOf(castedValue, supertype).isYes

--- a/OPAL/ai/src/main/scala/org/opalj/ai/InstructionCountBoundedAI.scala
+++ b/OPAL/ai/src/main/scala/org/opalj/ai/InstructionCountBoundedAI.scala
@@ -5,6 +5,7 @@ package ai
 import org.opalj.br.Code
 import org.opalj.log.LogContext
 import org.opalj.log.OPALLogger
+import org.opalj.util.elidedAssert
 
 /**
  * An abstract interpreter that interrupts itself after the evaluation of
@@ -44,7 +45,7 @@ class InstructionCountBoundedAI[D <: Domain](
         )
     }
 
-    assert(maxEvaluationCount > 0)
+    elidedAssert(maxEvaluationCount > 0)
 
     private val evaluationCount = new java.util.concurrent.atomic.AtomicInteger(0)
 

--- a/OPAL/ai/src/main/scala/org/opalj/ai/ValuesDomain.scala
+++ b/OPAL/ai/src/main/scala/org/opalj/ai/ValuesDomain.scala
@@ -8,6 +8,7 @@ import org.opalj.br.ClassHierarchy
 import org.opalj.br.PC
 import org.opalj.br.ReferenceType
 import org.opalj.br.Type
+import org.opalj.util.elidedAssert
 import org.opalj.value.IsIllegalValue
 import org.opalj.value.IsReferenceValue
 import org.opalj.value.IsReturnAddressValue
@@ -248,7 +249,7 @@ trait ValuesDomain { domain =>
          *          [[doJoin]].
          */
         def join(pc: Int, that: DomainValue): Update[DomainValue] = {
-            assert(that ne this, "join is only defined for objects that are different")
+            elidedAssert(that ne this, "join is only defined for objects that are different")
 
             if ((that eq TheIllegalValue) || (this.computationalType ne that.computationalType))
                 MetaInformationUpdateIllegalValue
@@ -312,7 +313,7 @@ trait ValuesDomain { domain =>
          * @see `abstractsOver`
          */
         def isMorePreciseThan(other: DomainValue): Boolean = {
-            assert(this.computationalType eq other.computationalType)
+            elidedAssert(this.computationalType eq other.computationalType)
 
             if (this eq other)
                 return false;

--- a/OPAL/ai/src/main/scala/org/opalj/ai/domain/PostEvaluationMemoryManagement.scala
+++ b/OPAL/ai/src/main/scala/org/opalj/ai/domain/PostEvaluationMemoryManagement.scala
@@ -4,6 +4,7 @@ package ai
 package domain
 
 import org.opalj.br.instructions.Instruction
+import org.opalj.util.elidedAssert
 
 /**
  * Provides the possibility to further update the memory layout (registers and operands)
@@ -28,12 +29,12 @@ trait PostEvaluationMemoryManagement extends CoreDomainFunctionality {
         newValueAfterEvaluation: DomainValue,
         newValueAfterException:  DomainValue
     ): Unit = {
-        assert(this.oldValue eq null, "another update is already registered")
+        elidedAssert(this.oldValue eq null, "another update is already registered")
 
-        assert(oldValue ne null)
-        assert((newValueAfterEvaluation ne null) || (newValueAfterException ne null))
-        assert(oldValue ne newValueAfterEvaluation, "useless self update")
-        assert(oldValue ne newValueAfterException, "useless self update")
+        elidedAssert(oldValue ne null)
+        elidedAssert((newValueAfterEvaluation ne null) || (newValueAfterException ne null))
+        elidedAssert(oldValue ne newValueAfterEvaluation, "useless self update")
+        elidedAssert(oldValue ne newValueAfterException, "useless self update")
 
         this.oldValue = oldValue
         this.newValueAfterEvaluation = newValueAfterEvaluation

--- a/OPAL/ai/src/main/scala/org/opalj/ai/domain/RecordCFG.scala
+++ b/OPAL/ai/src/main/scala/org/opalj/ai/domain/RecordCFG.scala
@@ -28,6 +28,7 @@ import org.opalj.graphs.DefaultMutableNode
 import org.opalj.graphs.DominanceFrontiers
 import org.opalj.graphs.DominatorTree
 import org.opalj.graphs.PostDominatorTree
+import org.opalj.util.elidedAssert
 
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap
 
@@ -326,8 +327,8 @@ trait RecordCFG
     ): Unit = {
         super.abstractInterpretationEnded(aiResult)
 
-        assert(exceptionHandlerSuccessors.forall(s => (s eq null) || s.nonEmpty))
-        assert(regularSuccessors.forall(s => (s eq null) || s.nonEmpty))
+        elidedAssert(exceptionHandlerSuccessors.forall(s => (s eq null) || s.nonEmpty))
+        elidedAssert(regularSuccessors.forall(s => (s eq null) || s.nonEmpty))
     }
 
     // ==================================== BASIC QUERIES ==========================================

--- a/OPAL/ai/src/main/scala/org/opalj/ai/domain/RecordDefUse.scala
+++ b/OPAL/ai/src/main/scala/org/opalj/ai/domain/RecordDefUse.scala
@@ -27,6 +27,7 @@ import org.opalj.collection.immutable.IntTrieSet1
 import org.opalj.collection.mutable.Locals as Registers
 import org.opalj.control.foreachNonNullValue
 import org.opalj.graphs.DefaultMutableNode
+import org.opalj.util.elidedAssert
 
 /**
  * Collects the definition/use information based on the abstract interpretation time cfg.
@@ -275,11 +276,11 @@ trait RecordDefUse extends RecordCFG { defUseDomain: Domain & TheCode =>
                 joinedDefOps:  mutable.Builder[ValueOrigins, List[ValueOrigins]] = List.newBuilder[ValueOrigins]
             ): List[ValueOrigins] = {
                 if (lDefOps.isEmpty) {
-                    // assert(rDefOps.isEmpty)
+                    // elidedAssert(rDefOps.isEmpty)
                     return if (oldIsSuperset) oldDefOps else joinedDefOps.result();
                 }
                 /*
-                assert(
+                elidedAssert(
                     rDefOps.nonEmpty,
                     s"unexpected (pc:$currentPC -> pc:$successorPC): $lDefOps vs. $rDefOps;"+
                      s" original: $oldDefOps"
@@ -300,12 +301,12 @@ trait RecordDefUse extends RecordCFG { defUseDomain: Domain & TheCode =>
                     // IMPROVE Consider using ++! (or !==!)
                     val joinedHead = newHead ++ oldHead
                     /*
-                    assert(newHead.subsetOf(joinedHead))
-                    assert(
+                    elidedAssert(newHead.subsetOf(joinedHead))
+                    elidedAssert(
                         oldHead.subsetOf(joinedHead),
                         s"$newHead ++ $oldHead is $joinedHead"
                     )
-                    assert(
+                    elidedAssert(
                         joinedHead.size > oldHead.size,
                         s"$newHead ++ $oldHead is $joinedHead"
                     )
@@ -324,7 +325,7 @@ trait RecordDefUse extends RecordCFG { defUseDomain: Domain & TheCode =>
             if (newDefOps ne oldDefOps) {
                 val joinedDefOps = joinDefOps(oldDefOps, newDefOps, oldDefOps)
                 if (joinedDefOps ne oldDefOps) {
-                    // assert(
+                    // elidedAssert(
                     //     joinedDefOps != oldDefOps,
                     //     s"$joinedDefOps is unexpectedly equal to $newDefOps join $oldDefOps"
                     // )
@@ -332,7 +333,7 @@ trait RecordDefUse extends RecordCFG { defUseDomain: Domain & TheCode =>
                     // joinedDefOps.foreach{vo =>
                     //    require(vo != null, s"$newDefOps join $oldDefOps == null")
                     // }
-                    // assert(joinedDefOps.forall(e => e.iterator.size == e.size))
+                    // elidedAssert(joinedDefOps.forall(e => e.iterator.size == e.size))
                     defOps(successorPC) = joinedDefOps
                 }
             }
@@ -390,7 +391,7 @@ trait RecordDefUse extends RecordCFG { defUseDomain: Domain & TheCode =>
                                 newUsage = true
                                 // IMPROVE Consider using ++!
                                 val joinedDefLocals = n ++ o
-                                // assert(
+                                // elidedAssert(
                                 //      joinedDefLocals.size > o.size,
                                 //      s"$n ++  $o is $joinedDefLocals"
                                 // )
@@ -399,7 +400,7 @@ trait RecordDefUse extends RecordCFG { defUseDomain: Domain & TheCode =>
                         }
                     )
                 if (joinedDefLocals ne oldDefLocals) {
-                    // assert(
+                    // elidedAssert(
                     //      joinedDefLocals != oldDefLocals,
                     //      s"$joinedDefLocals should not be equal to "+
                     //          s"$newDefLocals join $oldDefLocals"
@@ -412,8 +413,8 @@ trait RecordDefUse extends RecordCFG { defUseDomain: Domain & TheCode =>
 
             forceScheduling
         } else {
-            assert(newDefOps forall { vo => vo != null }, "null value origin found")
-            // assert(newDefOps.forall(e => e.iterator.size == e.size))
+            elidedAssert(newDefOps forall { vo => vo != null }, "null value origin found")
+            // elidedAssert(newDefOps.forall(e => e.iterator.size == e.size))
             defOps(successorPC) = newDefOps
             defLocals(successorPC) = newDefLocals
             true // <=> always schedule the execution of the next instruction
@@ -1006,8 +1007,8 @@ trait RecordDefUse extends RecordCFG { defUseDomain: Domain & TheCode =>
             // unless, we have a nested subroutine call - in that case, we have to
             // do the nested subroutine call first!
 
-            assert(currentSubroutineLevel == currentSubroutinePCs.size)
-            assert(currentSubroutineLevel == subroutineIDs.size)
+            elidedAssert(currentSubroutineLevel == currentSubroutinePCs.size)
+            elidedAssert(currentSubroutineLevel == subroutineIDs.size)
             if (jsrPCs.top.nonEmpty &&
                 // We have to check if we have a nested JSR call;
                 // if the current subroutine level (root = 0) is smaller than the
@@ -1056,13 +1057,13 @@ trait RecordDefUse extends RecordCFG { defUseDomain: Domain & TheCode =>
                 val lastSubroutinePCs = currentSubroutinePCs.pop()
                 currentSubroutineLevel -= 1
                 subroutineIDs = subroutineIDs.tail
-                assert(jsrPCs.head.isEmpty)
+                elidedAssert(jsrPCs.head.isEmpty)
                 val oldSubroutineJsrPCs = jsrPCs.pop() // drop empty IntTrieSet
-                assert(oldSubroutineJsrPCs.isEmpty)
+                elidedAssert(oldSubroutineJsrPCs.isEmpty)
                 val oldSubroutineNextPCs = nextPCs.pop() // drop empty IntTrieSet
-                assert(oldSubroutineNextPCs.isEmpty)
+                elidedAssert(oldSubroutineNextPCs.isEmpty)
                 val oldSubroutineNextJoinPCs = nextJoinPCs.pop() // drop empty IntTrieSet
-                assert(oldSubroutineNextJoinPCs.isEmpty)
+                elidedAssert(oldSubroutineNextJoinPCs.isEmpty)
 
                 // println(s"END OF A SUBROUTINE: $retPC ... $thisSubroutineRetTargetPCs: "+lastSubroutinePCs.mkString(", "))
 
@@ -1266,8 +1267,8 @@ trait RecordDefUse extends RecordCFG { defUseDomain: Domain & TheCode =>
             }
         }
 
-        assert(nextPCs.tail.isEmpty)
-        assert(nextJoinPCs.tail.isEmpty)
+        elidedAssert(nextPCs.tail.isEmpty)
+        elidedAssert(nextJoinPCs.tail.isEmpty)
 
         // Integrate the accumulated subroutine information (if available)
         if (subroutinePCs.nonEmpty) {

--- a/OPAL/ai/src/main/scala/org/opalj/ai/domain/l0/DefaultTypeLevelReferenceValues.scala
+++ b/OPAL/ai/src/main/scala/org/opalj/ai/domain/l0/DefaultTypeLevelReferenceValues.scala
@@ -12,6 +12,7 @@ import org.opalj.br.ClassType
 import org.opalj.br.ReferenceType
 import org.opalj.collection.immutable.UIDSet
 import org.opalj.collection.immutable.UIDSet1
+import org.opalj.util.elidedAssert
 import org.opalj.value.IsMObjectValue
 import org.opalj.value.IsPrimitiveValue
 import org.opalj.value.IsSArrayValue
@@ -75,7 +76,7 @@ trait DefaultTypeLevelReferenceValues
 
                 case elementValue @ TypeOfReferenceValue(EmptyUpperTypeBound) =>
                     // the elementValue is "null"
-                    assert(elementValue.isNull.isYes)
+                    elidedAssert(elementValue.isNull.isYes)
                     // e.g., it is possible to store null in the n-1 dimensions of
                     // a n-dimensional array of primitive values
                     if (theUpperTypeBound.componentType.isReferenceType)

--- a/OPAL/ai/src/main/scala/org/opalj/ai/domain/l1/ArrayValues.scala
+++ b/OPAL/ai/src/main/scala/org/opalj/ai/domain/l1/ArrayValues.scala
@@ -7,6 +7,7 @@ package l1
 import scala.reflect.ClassTag
 
 import org.opalj.br.ArrayType
+import org.opalj.util.elidedAssert
 
 /**
  * Enables the tracking of the length of arrays in the most common cases.
@@ -43,7 +44,7 @@ trait ArrayValues extends l1.ReferenceValues {
          */
         def theLength: Int
 
-        assert(length.get >= 0, "impossible length")
+        elidedAssert(length.get >= 0, "impossible length")
 
         override final def length: Option[Int] = Some(theLength)
 

--- a/OPAL/ai/src/main/scala/org/opalj/ai/domain/l1/ConcreteArrayValues.scala
+++ b/OPAL/ai/src/main/scala/org/opalj/ai/domain/l1/ConcreteArrayValues.scala
@@ -10,6 +10,7 @@ import org.opalj.br.ArrayType
 import org.opalj.br.ClassType
 import org.opalj.log.OPALLogger
 import org.opalj.log.Warn
+import org.opalj.util.elidedAssert
 
 /**
  * Enables the tracking of various properties related to arrays.
@@ -328,7 +329,7 @@ trait ConcreteArrayValues
         if (!reifyArray(pc, size, arrayType))
             return InitializedArrayValue(pc, arrayType, size);
 
-        assert(
+        elidedAssert(
             size <= ConcreteArrayValues.MaxPossibleArraySize,
             s"tracking arrays with $size elements is not supported by this domain"
         )

--- a/OPAL/ai/src/main/scala/org/opalj/ai/domain/l1/ConstraintsBetweenIntegerValues.scala
+++ b/OPAL/ai/src/main/scala/org/opalj/ai/domain/l1/ConstraintsBetweenIntegerValues.scala
@@ -11,6 +11,7 @@ import org.opalj.br.LiveVariables
 import org.opalj.br.instructions.Instruction
 import org.opalj.collection.immutable.IntTrieSet
 import org.opalj.constraints.NumericConstraints
+import org.opalj.util.elidedAssert
 
 /**
  * Domain that traces the relationship between integer values; currently, the domain only
@@ -64,7 +65,7 @@ trait ConstraintsBetweenIntegerValues
         c:     Constraint
     ): ConstraintsStore = {
 
-        assert(v1 ne v2)
+        elidedAssert(v1 ne v2)
 
         var m = store.get(v1)
         if (m == null) {

--- a/OPAL/ai/src/main/scala/org/opalj/ai/domain/l1/DefaultIntegerRangeValues.scala
+++ b/OPAL/ai/src/main/scala/org/opalj/ai/domain/l1/DefaultIntegerRangeValues.scala
@@ -8,6 +8,7 @@ import java.lang.Math.abs
 
 import org.opalj.br.ComputationalTypeInt
 import org.opalj.br.CTIntType
+import org.opalj.util.elidedAssert
 
 /**
  * This domain implements the tracking of integer values at the level of ranges.
@@ -68,7 +69,7 @@ trait DefaultIntegerRangeValues extends DefaultSpecialDomainValuesBinding with I
      */
     class IntegerRange(val lowerBound: Int, val upperBound: Int) extends super.IntegerRangeLike {
 
-        assert(
+        elidedAssert(
             lowerBound <= upperBound,
             s"the lower bound $lowerBound is larger than the upper bound $upperBound"
         )

--- a/OPAL/ai/src/main/scala/org/opalj/ai/domain/l1/DefaultIntegerSetValues.scala
+++ b/OPAL/ai/src/main/scala/org/opalj/ai/domain/l1/DefaultIntegerSetValues.scala
@@ -11,6 +11,7 @@ import java.lang.Math.min
 import scala.collection.immutable.SortedSet
 
 import org.opalj.br.CTIntType
+import org.opalj.util.elidedAssert
 import org.opalj.value.IsIntegerValue
 
 /**
@@ -50,7 +51,7 @@ trait DefaultIntegerSetValues extends DefaultSpecialDomainValuesBinding with Int
 
     class IntegerSet(val values: SortedSet[Int]) extends super.IntegerSetLike {
 
-        assert(values.nonEmpty)
+        elidedAssert(values.nonEmpty)
 
         override def doJoin(pc: Int, other: DomainValue): Update[DomainValue] = {
             val result = other match {

--- a/OPAL/ai/src/main/scala/org/opalj/ai/domain/l1/DefaultLongSetValues.scala
+++ b/OPAL/ai/src/main/scala/org/opalj/ai/domain/l1/DefaultLongSetValues.scala
@@ -7,6 +7,7 @@ package l1
 import scala.collection.immutable.SortedSet
 
 import org.opalj.br.ComputationalTypeLong
+import org.opalj.util.elidedAssert
 
 /**
  * This domain implements the tracking of long values at the level of sets.
@@ -49,7 +50,7 @@ trait DefaultLongSetValues
 
     class LongSet(val values: SortedSet[Long]) extends super.LongSetLike {
 
-        assert(values.nonEmpty)
+        elidedAssert(values.nonEmpty)
 
         override def constantValue: Option[Long] = {
             if (values.size == 1) Some(values.head) else None

--- a/OPAL/ai/src/main/scala/org/opalj/ai/domain/l1/IntegerRangeValues.scala
+++ b/OPAL/ai/src/main/scala/org/opalj/ai/domain/l1/IntegerRangeValues.scala
@@ -8,6 +8,7 @@ import scala.Int.MaxValue as MaxInt
 import scala.Int.MinValue as MinInt
 
 import org.opalj.br.CTIntType
+import org.opalj.util.elidedAssert
 import org.opalj.value.IsIntegerValue
 
 /**
@@ -464,7 +465,7 @@ trait IntegerRangeValues
             case _                          => (Int.MinValue, Int.MaxValue)
         }
         // establish new bounds // e.g. l=(0,0) & r=(-10,0)
-        assert(lb1 < ub2, s"the value $left cannot be less than $right")
+        elidedAssert(lb1 < ub2, s"the value $left cannot be less than $right")
 
         val newUB1 = Math.min(ub1, ub2 - 1)
         val newMemoryLayout @ (operands1, locals1) =

--- a/OPAL/ai/src/main/scala/org/opalj/ai/domain/l1/IntegerSetValues.scala
+++ b/OPAL/ai/src/main/scala/org/opalj/ai/domain/l1/IntegerSetValues.scala
@@ -10,6 +10,7 @@ import scala.collection.immutable.SortedSet
 
 import org.opalj.br.*
 import org.opalj.collection.SingletonSet
+import org.opalj.util.elidedAssert
 import org.opalj.value.IsIntegerValue
 
 /**
@@ -119,7 +120,7 @@ trait IntegerSetValues
         override final def upperBound: Int = Byte.MaxValue
 
         def fuse(pc: PC, other: BaseTypesBasedSetLike): domain.DomainValue = {
-            assert(this ne other)
+            elidedAssert(this ne other)
             other match {
                 case _: U7BitSetLike  => U7BitSet()
                 case _: U15BitSetLike => U15BitSet()
@@ -139,7 +140,7 @@ trait IntegerSetValues
         override final def upperBound: Int = Short.MaxValue
 
         def fuse(pc: PC, other: BaseTypesBasedSetLike): domain.DomainValue = {
-            assert(this ne other)
+            elidedAssert(this ne other)
             other match {
                 case _: U7BitSetLike | _: U15BitSetLike => U15BitSet()
                 case _: CharSetLike                     => CharValue(pc)
@@ -156,7 +157,7 @@ trait IntegerSetValues
         override final def upperBound: Int = Char.MaxValue
 
         def fuse(pc: PC, other: BaseTypesBasedSetLike): domain.DomainValue = {
-            assert(this ne other)
+            elidedAssert(this ne other)
             other match {
                 case _: U7BitSetLike | _: U15BitSetLike | _: CharSetLike => CharValue(pc)
                 case _                                                   => IntegerValue(pc)
@@ -168,7 +169,7 @@ trait IntegerSetValues
         override final def lowerBound: Int = Byte.MinValue
         override final def upperBound: Int = Byte.MaxValue
         def fuse(pc: PC, other: BaseTypesBasedSetLike): domain.DomainValue = {
-            assert(this ne other)
+            elidedAssert(this ne other)
             other match {
                 case _: U7BitSetLike  => ByteValue(pc)
                 case _: U15BitSetLike => ShortValue(pc)
@@ -183,7 +184,7 @@ trait IntegerSetValues
         override final def lowerBound: Int = Short.MinValue
         override final def upperBound: Int = Short.MaxValue
         def fuse(pc: PC, other: BaseTypesBasedSetLike): domain.DomainValue = {
-            assert(this ne other)
+            elidedAssert(this ne other)
             other match {
                 case _: U7BitSetLike  => ShortValue(pc)
                 case _: U15BitSetLike => ShortValue(pc)
@@ -233,7 +234,7 @@ trait IntegerSetValues
         lowerBound: Int,
         upperBound: Int
     ): DomainTypedValue[CTIntType] = {
-        assert(lowerBound <= upperBound)
+        elidedAssert(lowerBound <= upperBound)
 
         if (upperBound.toLong - lowerBound.toLong <= maxCardinalityOfIntegerSets)
             IntegerSet(SortedSet[Int]((lowerBound to upperBound)*))
@@ -579,7 +580,7 @@ trait IntegerSetValues
         operands: Operands,
         locals:   Locals
     ): (Operands, Locals) = {
-        assert(value1 ne value2, "the values are definitively equal; impossible refinement \"!=\"")
+        elidedAssert(value1 ne value2, "the values are definitively equal; impossible refinement \"!=\"")
 
         intValue(value1) { v1 =>
             value2 match {
@@ -612,7 +613,7 @@ trait IntegerSetValues
         //        println("intEstablishIsLessThan"+System.identityHashCode(left).toHexString + left+" .... "+System.identityHashCode(right).toHexString + right)
         //        println(locals.map(v => System.identityHashCode(v).toHexString+"."+v).mkString("", ";   ", ""))
 
-        assert(left ne right, "the values are definitively equal; impossible refinement \"<\"")
+        elidedAssert(left ne right, "the values are definitively equal; impossible refinement \"<\"")
 
         val result = (left, right) match {
             case (IntegerSetLike(ls), IntegerSetLike(rs)) =>
@@ -821,7 +822,7 @@ trait IntegerSetValues
         results:   SortedSet[Int]
     ): IntegerValueOrArithmeticException = {
 
-        assert(exception || results.nonEmpty)
+        elidedAssert(exception || results.nonEmpty)
 
         if (results.nonEmpty) {
             val newValue = IntegerSet(pc, results)

--- a/OPAL/ai/src/main/scala/org/opalj/ai/domain/l1/LongSetValues.scala
+++ b/OPAL/ai/src/main/scala/org/opalj/ai/domain/l1/LongSetValues.scala
@@ -7,6 +7,7 @@ package l1
 import scala.collection.immutable.SortedSet
 
 import org.opalj.br.*
+import org.opalj.util.elidedAssert
 import org.opalj.value.IsLongValue
 
 /**
@@ -272,7 +273,7 @@ trait LongSetValues extends LongValuesDomain with ConcreteLongValues {
     ): LongValueOrArithmeticException = {
 
         val hasResults = results.nonEmpty
-        assert(exception || hasResults)
+        elidedAssert(exception || hasResults)
 
         if (hasResults) {
             if (results.size <= maxCardinalityOfLongSets) {

--- a/OPAL/ai/src/main/scala/org/opalj/ai/domain/l1/ReferenceValues.scala
+++ b/OPAL/ai/src/main/scala/org/opalj/ai/domain/l1/ReferenceValues.scala
@@ -26,6 +26,7 @@ import org.opalj.collection.immutable.IdentityPair
 import org.opalj.collection.immutable.UIDSet
 import org.opalj.collection.immutable.UIDSet1
 import org.opalj.collection.immutable.UIDSet2
+import org.opalj.util.elidedAssert
 import org.opalj.value.IsMultipleReferenceValue
 import org.opalj.value.IsNullValue
 import org.opalj.value.IsReferenceValue
@@ -127,7 +128,7 @@ trait ReferenceValues extends l0.DefaultTypeLevelReferenceValues with Origin {
      * values are definitively not reference equal unless they are type incompatible.
      */
     override def refAreEqual(pc: Int, v1: DomainValue, v2: DomainValue): Answer = {
-        assert(v1.isInstanceOf[TheReferenceValue] && v2.isInstanceOf[TheReferenceValue])
+        elidedAssert(v1.isInstanceOf[TheReferenceValue] && v2.isInstanceOf[TheReferenceValue])
         if (v1 eq v2)
             return Yes;
 
@@ -325,7 +326,7 @@ trait ReferenceValues extends l0.DefaultTypeLevelReferenceValues with Origin {
             @tailrec def refine(value: AReferenceValue): AReferenceValue = {
                 val refinedValue = refinements.get(value)
                 if (refinedValue != null) {
-                    assert(refinedValue ne value)
+                    elidedAssert(refinedValue ne value)
                     refine(refinedValue)
                 } else {
                     value
@@ -367,7 +368,7 @@ trait ReferenceValues extends l0.DefaultTypeLevelReferenceValues with Origin {
             operands: Operands,
             locals:   Locals
         ): (Operands, Locals) = {
-            assert(oldValue ne newValue)
+            elidedAssert(oldValue ne newValue)
 
             val refinements = new Refinements()
             refinements.put(oldValue, newValue)
@@ -430,8 +431,8 @@ trait ReferenceValues extends l0.DefaultTypeLevelReferenceValues with Origin {
             operands: Operands,
             locals:   Locals
         ): (Operands, Locals) = {
-            assert(this.isNull.isUnknown)
-            assert( /*parameter*/ isNull.isYesOrNo)
+            elidedAssert(this.isNull.isUnknown)
+            elidedAssert( /*parameter*/ isNull.isYesOrNo)
 
             val refinedValue = doRefineIsNull(isNull)
             propagateRefinement(this, refinedValue, operands, locals)
@@ -455,7 +456,7 @@ trait ReferenceValues extends l0.DefaultTypeLevelReferenceValues with Origin {
         def doRefineUpperTypeBound(
             supertypes: UIDSet[? <: ReferenceType]
         ): DomainSingleOriginReferenceValue = {
-            assert(supertypes.nonEmpty)
+            elidedAssert(supertypes.nonEmpty)
 
             if (supertypes.isSingletonSet) {
                 doRefineUpperTypeBound(supertypes.head)
@@ -529,7 +530,7 @@ trait ReferenceValues extends l0.DefaultTypeLevelReferenceValues with Origin {
             other:  DomainValue
         ): Update[DomainValue] = {
 
-            assert(this ne other)
+            elidedAssert(this ne other)
 
             other match {
                 case DomainSingleOriginReferenceValueTag(that) =>
@@ -566,8 +567,8 @@ trait ReferenceValues extends l0.DefaultTypeLevelReferenceValues with Origin {
             origin: ValueOrigin = this.origin,
             isNull: Answer      = Yes
         ): DomainNullValue = {
-            assert(refId == domain.nullRefId, "null value with unexpected reference id")
-            assert(isNull.isYes, "a Null value's isNull property must be Yes")
+            elidedAssert(refId == domain.nullRefId, "null value with unexpected reference id")
+            elidedAssert(isNull.isYes, "a Null value's isNull property must be Yes")
 
             NullValue(origin)
         }
@@ -694,8 +695,8 @@ trait ReferenceValues extends l0.DefaultTypeLevelReferenceValues with Origin {
         with NonNullSingleOriginSReferenceValue[ArrayType] {
         this: DomainArrayValue =>
 
-        assert(this.isNull.isNoOrUnknown)
-        assert(this.isPrecise || !classHierarchy.isKnownToBeFinal(theUpperTypeBound))
+        elidedAssert(this.isNull.isNoOrUnknown)
+        elidedAssert(this.isPrecise || !classHierarchy.isKnownToBeFinal(theUpperTypeBound))
 
         override def updateRefId(
             refId:  RefId,
@@ -792,9 +793,9 @@ trait ReferenceValues extends l0.DefaultTypeLevelReferenceValues with Origin {
         with ObjectValue {
         this: DomainObjectValue =>
 
-        assert(this.isNull.isNoOrUnknown)
-        assert(!classHierarchy.isKnownToBeFinal(theUpperTypeBound) || this.isPrecise)
-        assert(
+        elidedAssert(this.isNull.isNoOrUnknown)
+        elidedAssert(!classHierarchy.isKnownToBeFinal(theUpperTypeBound) || this.isPrecise)
+        elidedAssert(
             !this.isPrecise ||
                 !classHierarchy.isKnown(theUpperTypeBound) ||
                 classHierarchy.isInterface(theUpperTypeBound).isNo,
@@ -814,8 +815,8 @@ trait ReferenceValues extends l0.DefaultTypeLevelReferenceValues with Origin {
         def doRefineUpperTypeBound(supertype: ReferenceType): DomainSingleOriginReferenceValue = {
             val thisUTB = this.theUpperTypeBound
 
-            assert(thisUTB ne supertype)
-            assert(
+            elidedAssert(thisUTB ne supertype)
+            elidedAssert(
                 !this.isPrecise || !domain.isSubtypeOf(supertype, thisUTB),
                 s"this type is precise ${thisUTB.toJava}; " +
                     s"refinement goal: ${supertype.toJava} " +
@@ -970,7 +971,7 @@ trait ReferenceValues extends l0.DefaultTypeLevelReferenceValues with Origin {
                  * models the upper type bound "Serializable & Cloneable"; otherwise
                  * the refinement is illegal
                  */
-                assert(this.upperTypeBound == ClassType.SerializableAndCloneable)
+                elidedAssert(this.upperTypeBound == ClassType.SerializableAndCloneable)
                 ArrayValue(origin, this.isNull, isPrecise = false, supertype.asArrayType, refId)
             }
         }
@@ -1075,12 +1076,12 @@ trait ReferenceValues extends l0.DefaultTypeLevelReferenceValues with Origin {
                 nextRefId()
             )
 
-        assert(values.size > 1, "a MultipleReferenceValue must have multiple values")
-        assert(
+        elidedAssert(values.size > 1, "a MultipleReferenceValue must have multiple values")
+        elidedAssert(
             isNull.isNoOrUnknown || values.forall(_.isNull.isYesOrUnknown),
             s"inconsistent null property(isNull == $isNull): ${values.mkString(",")}"
         )
-        assert(
+        elidedAssert(
             (isNull.isYes && isPrecise) || {
                 val nonNullValues = values.filter(_.isNull.isNoOrUnknown)
                 (nonNullValues.isEmpty && isPrecise) || (
@@ -1091,13 +1092,13 @@ trait ReferenceValues extends l0.DefaultTypeLevelReferenceValues with Origin {
             },
             s"unexpected precision (precise == $isPrecise): $this"
         )
-        assert(
+        elidedAssert(
             !upperTypeBound.isSingletonSet || (
                 !classHierarchy.isKnownToBeFinal(upperTypeBound.head) || isPrecise
             ),
             s"isPrecise has to be true if the upper type bound belongs to final type $upperTypeBound"
         )
-        assert(
+        elidedAssert(
             (isNull.isYes && upperTypeBound.isEmpty) || (
                 isNull.isNoOrUnknown &&
                 upperTypeBound.nonEmpty && (
@@ -1112,7 +1113,7 @@ trait ReferenceValues extends l0.DefaultTypeLevelReferenceValues with Origin {
                 s"== ${domain.upperTypeBound(values)} which is a strict subtype of " +
                 s"the given bound $upperTypeBound"
         )
-        assert(
+        elidedAssert(
             upperTypeBound.size < 2 || upperTypeBound.forall(_.isClassType),
             s"invalid upper type bound: $upperTypeBound for: ${values.mkString("[", ";", "]")}"
         )
@@ -1140,7 +1141,7 @@ trait ReferenceValues extends l0.DefaultTypeLevelReferenceValues with Origin {
 
         def addValue(newValue: DomainSingleOriginReferenceValue): DomainMultipleReferenceValues = {
 
-            assert(!values.exists(_.origin == newValue.origin))
+            elidedAssert(!values.exists(_.origin == newValue.origin))
 
             val thisUTB = this.upperTypeBound
             val newValueUTB = newValue.upperTypeBound
@@ -1167,12 +1168,12 @@ trait ReferenceValues extends l0.DefaultTypeLevelReferenceValues with Origin {
             joinedValue: DomainSingleOriginReferenceValue
         ): DomainMultipleReferenceValues = {
 
-            assert(oldValue ne joinValue)
-            assert(oldValue ne joinedValue)
-            assert(oldValue.origin == joinValue.origin)
-            assert(oldValue.origin == joinedValue.origin)
+            elidedAssert(oldValue ne joinValue)
+            elidedAssert(oldValue ne joinedValue)
+            elidedAssert(oldValue.origin == joinValue.origin)
+            elidedAssert(oldValue.origin == joinedValue.origin)
 
-            assert(values.exists(_ eq oldValue))
+            elidedAssert(values.exists(_ eq oldValue))
 
             val newValues = this.values - oldValue + joinedValue
             val newRefId = if (oldValue.refId == joinedValue.refId) this.refId else nextRefId()
@@ -1304,7 +1305,7 @@ trait ReferenceValues extends l0.DefaultTypeLevelReferenceValues with Origin {
                         val refinedSingleOriginValue =
                             refinedValue.asInstanceOf[DomainSingleOriginReferenceValue]
 
-                        assert(refinedSingleOriginValue.origin == value.origin)
+                        elidedAssert(refinedSingleOriginValue.origin == value.origin)
 
                         refinedValues += refinedSingleOriginValue
                     }
@@ -1432,8 +1433,8 @@ trait ReferenceValues extends l0.DefaultTypeLevelReferenceValues with Origin {
             locals:   Locals
         ): (Operands, Locals) = {
 
-            assert(this.isNull.isUnknown)
-            assert(isNull.isYesOrNo)
+            elidedAssert(this.isNull.isUnknown)
+            elidedAssert(isNull.isYesOrNo)
 
             // Recall that this value's property – as a whole – can be undefined also
             // each individual value's property is well defined (Yes, No).
@@ -1628,7 +1629,7 @@ trait ReferenceValues extends l0.DefaultTypeLevelReferenceValues with Origin {
         }
 
         override protected def doJoin(joinPC: Int, other: DomainValue): Update[DomainValue] = {
-            assert(this ne other)
+            elidedAssert(this ne other)
 
             other match {
 
@@ -1736,8 +1737,8 @@ trait ReferenceValues extends l0.DefaultTypeLevelReferenceValues with Origin {
             if (isNull.isYes)
                 return justThrows(VMNullPointerException(pc));
 
-            assert(upperTypeBound.isSingletonSet, s"$upperTypeBound is not an array type")
-            assert(upperTypeBound.head.isArrayType, s"$upperTypeBound is not an array type")
+            elidedAssert(upperTypeBound.isSingletonSet, s"$upperTypeBound is not an array type")
+            elidedAssert(upperTypeBound.head.isArrayType, s"$upperTypeBound is not an array type")
 
             if (values.exists(_.isInstanceOf[ObjectValue])) {
                 var thrownExceptions: List[ExceptionValue] = Nil
@@ -1757,8 +1758,8 @@ trait ReferenceValues extends l0.DefaultTypeLevelReferenceValues with Origin {
             if (isNull.isYes)
                 return justThrows(VMNullPointerException(pc));
 
-            assert(upperTypeBound.isSingletonSet)
-            assert(upperTypeBound.head.isArrayType, s"$upperTypeBound is not an array type")
+            elidedAssert(upperTypeBound.isSingletonSet)
+            elidedAssert(upperTypeBound.head.isArrayType, s"$upperTypeBound is not an array type")
 
             if (values.exists(_.isInstanceOf[ObjectValue])) {
                 var thrownExceptions: List[ExceptionValue] = Nil
@@ -1781,8 +1782,8 @@ trait ReferenceValues extends l0.DefaultTypeLevelReferenceValues with Origin {
             if (isNull.isYes)
                 return throws(VMNullPointerException(pc)); // <====== early return
 
-            assert(upperTypeBound.isSingletonSet)
-            assert(upperTypeBound.head.isArrayType, s"$upperTypeBound (values=$values)")
+            elidedAssert(upperTypeBound.isSingletonSet)
+            elidedAssert(upperTypeBound.head.isArrayType, s"$upperTypeBound (values=$values)")
 
             if (values.exists(_.isInstanceOf[ObjectValue])) {
                 if (isNull.isUnknown && throwNullPointerExceptionOnArrayAccess)

--- a/OPAL/ai/src/main/scala/org/opalj/ai/domain/l1/StringBuilderValues.scala
+++ b/OPAL/ai/src/main/scala/org/opalj/ai/domain/l1/StringBuilderValues.scala
@@ -7,6 +7,7 @@ package l1
 import java.lang.StringBuilder as JStringBuilder
 
 import org.opalj.br.ClassType
+import org.opalj.util.elidedAssert
 
 /**
  * Enables the tracing of `StringBuilders`.
@@ -49,8 +50,8 @@ trait StringBuilderValues extends StringValues {
     ) extends SObjectValue {
         this: DomainStringValue =>
 
-        assert(builder != null)
-        assert((builderType eq ClassType.StringBuffer) || (builderType eq ClassType.StringBuilder))
+        elidedAssert(builder != null)
+        elidedAssert((builderType eq ClassType.StringBuffer) || (builderType eq ClassType.StringBuilder))
 
         override final def isNull: No.type = No
         override final def isPrecise: Boolean = true

--- a/OPAL/ai/src/main/scala/org/opalj/ai/domain/l1/package.scala
+++ b/OPAL/ai/src/main/scala/org/opalj/ai/domain/l1/package.scala
@@ -7,6 +7,7 @@ import org.opalj.ai.collectPCWithOperands
 import org.opalj.br.Code
 import org.opalj.br.instructions.INVOKESPECIAL
 import org.opalj.br.instructions.NEW
+import org.opalj.util.elidedAssert
 
 /**
  * Commonly useful methods.
@@ -31,15 +32,15 @@ package object l1 {
 
         val instructions = code.instructions
 
-        assert(
+        elidedAssert(
             receiverOriginPC >= 0 && receiverOriginPC < instructions.length,
             s"the origin $receiverOriginPC is outside the scope of the method "
         )
-        assert(
+        elidedAssert(
             instructions(receiverOriginPC).opcode == NEW.opcode,
             s"${instructions(receiverOriginPC)} is not a NEW instruction"
         )
-        assert(
+        elidedAssert(
             operandsArray(receiverOriginPC) ne null,
             s"the (new) instruction with pc=$receiverOriginPC was never executed"
         )

--- a/OPAL/ai/src/main/scala/org/opalj/ai/domain/l2/PerformInvocations.scala
+++ b/OPAL/ai/src/main/scala/org/opalj/ai/domain/l2/PerformInvocations.scala
@@ -12,6 +12,7 @@ import org.opalj.br.VoidType
 import org.opalj.log.Error
 import org.opalj.log.OPALLogger
 import org.opalj.log.Warn
+import org.opalj.util.elidedAssert
 
 /**
  * Mix in this trait if methods that are called by `invokeXYZ` instructions should
@@ -140,7 +141,7 @@ trait PerformInvocations extends MethodCallsHandling {
         fallback: () => MethodCallResult
     ): MethodCallResult = {
 
-        assert(
+        elidedAssert(
             method.body.isDefined,
             s"${project.source(method.classFile.thisType)} - the method: " +
                 s"${method.toJava} does not have a body (is the project self-consistent?)"

--- a/OPAL/ai/src/main/scala/org/opalj/ai/fpcf/analyses/LBMethodReturnValuesAnalysis.scala
+++ b/OPAL/ai/src/main/scala/org/opalj/ai/fpcf/analyses/LBMethodReturnValuesAnalysis.scala
@@ -92,7 +92,7 @@ class LBMethodReturnValuesAnalysis private[analyses] (
             // In this case, it may happen that the returned value (Object in the above case)
             // suddenly becomes "less precise" than the declared return type.
             //
-            // assert(
+            // elidedAssert(
             //    returnedReferenceValue.isNull.isYes ||
             //         classHierarchy.isASubtypeOf(
             //             returnedReferenceValue.upperTypeBound,

--- a/OPAL/ai/src/main/scala/org/opalj/ai/fpcf/properties/MethodReturnValue.scala
+++ b/OPAL/ai/src/main/scala/org/opalj/ai/fpcf/properties/MethodReturnValue.scala
@@ -12,6 +12,7 @@ import org.opalj.fpcf.PropertyKey
 import org.opalj.fpcf.PropertyMetaInformation
 import org.opalj.fpcf.PropertyStore
 import org.opalj.si.Project
+import org.opalj.util.elidedAssert
 import org.opalj.value.ValueInformation
 
 sealed trait MethodReturnValuePropertyMetaInformation extends PropertyMetaInformation {
@@ -40,7 +41,7 @@ trait MethodReturnValue extends Property with MethodReturnValuePropertyMetaInfor
  */
 case class TheMethodReturnValue(theReturnValue: ValueInformation) extends MethodReturnValue {
 
-    assert(theReturnValue ne null, "returnValue must not be null")
+    elidedAssert(theReturnValue ne null, "returnValue must not be null")
 
     override def returnValue: Option[ValueInformation] = Some(theReturnValue)
 

--- a/OPAL/ai/src/main/scala/org/opalj/ai/package.scala
+++ b/OPAL/ai/src/main/scala/org/opalj/ai/package.scala
@@ -16,6 +16,7 @@ import org.opalj.log.GlobalLogContext
 import org.opalj.log.LogContext
 import org.opalj.log.OPALLogger
 import org.opalj.util.AnyToAnyThis
+import org.opalj.util.elidedAssert
 
 /**
  * Implementation of an abstract interpretation (ai) framework.
@@ -49,7 +50,7 @@ package object ai {
         implicit val logContext: LogContext = GlobalLogContext
         import OPALLogger.info
         try {
-            assert(false) // <= tests whether assertions are on or off...
+            elidedAssert(false) // <= tests whether assertions are on or off...
             info(FrameworkName, "Production Build")
         } catch {
             case _: AssertionError => info(FrameworkName, "Development Build with Assertions")

--- a/OPAL/ai/src/main/scala/org/opalj/ai/package.scala
+++ b/OPAL/ai/src/main/scala/org/opalj/ai/package.scala
@@ -185,12 +185,12 @@ package object ai {
      */
     final val SUBROUTINE = -900000009
 
-    assert(SUBROUTINE_START <= SpecialValuesOriginOffset)
-    assert(SUBROUTINE_END <= SpecialValuesOriginOffset)
-    assert(SUBROUTINE_INFORMATION_BLOCK_SEPARATOR_BOUND <= SpecialValuesOriginOffset)
-    assert(SUBROUTINE_RETURN_ADDRESS_LOCAL_VARIABLE <= SpecialValuesOriginOffset)
-    assert(SUBROUTINE_RETURN_TO_TARGET <= SpecialValuesOriginOffset)
-    assert(SUBROUTINE <= SpecialValuesOriginOffset)
+    elidedAssert(SUBROUTINE_START <= SpecialValuesOriginOffset)
+    elidedAssert(SUBROUTINE_END <= SpecialValuesOriginOffset)
+    elidedAssert(SUBROUTINE_INFORMATION_BLOCK_SEPARATOR_BOUND <= SpecialValuesOriginOffset)
+    elidedAssert(SUBROUTINE_RETURN_ADDRESS_LOCAL_VARIABLE <= SpecialValuesOriginOffset)
+    elidedAssert(SUBROUTINE_RETURN_TO_TARGET <= SpecialValuesOriginOffset)
+    elidedAssert(SUBROUTINE <= SpecialValuesOriginOffset)
 
     /**
      * Identifies the ''upper bound for those origin values that encode origin
@@ -241,13 +241,13 @@ package object ai {
      */
     final def ValueOriginForImmediateVMException(pc: PC): ValueOrigin = {
         val origin = ImmediateVMExceptionsOriginOffset - pc
-        assert(
+        elidedAssert(
             origin <= ImmediateVMExceptionsOriginOffset,
             s"[pc:$pc] " +
                 s"origin($origin) > " +
                 s"ImmediateVMExceptionsOriginOffset($ImmediateVMExceptionsOriginOffset)"
         )
-        assert(origin > MethodExternalExceptionsOriginOffset)
+        elidedAssert(origin > MethodExternalExceptionsOriginOffset)
         origin
     }
 
@@ -258,7 +258,7 @@ package object ai {
      * @see [[ValueOriginForImmediateVMException]] for further information.
      */
     final def pcOfImmediateVMException(valueOrigin: ValueOrigin): PC = {
-        assert(valueOrigin <= ImmediateVMExceptionsOriginOffset)
+        elidedAssert(valueOrigin <= ImmediateVMExceptionsOriginOffset)
         -valueOrigin + ImmediateVMExceptionsOriginOffset
     }
 
@@ -290,13 +290,13 @@ package object ai {
      */
     final def ValueOriginForMethodExternalException(pc: Int): Int = {
         val origin = MethodExternalExceptionsOriginOffset - pc
-        assert(
+        elidedAssert(
             origin <= MethodExternalExceptionsOriginOffset,
             s"[pc:$pc] " +
                 s"origin($origin) > " +
                 s"MethodExternalExceptionsOriginOffset($MethodExternalExceptionsOriginOffset)"
         )
-        assert(SpecialValuesOriginOffset < origin)
+        elidedAssert(SpecialValuesOriginOffset < origin)
         origin
     }
 
@@ -307,7 +307,7 @@ package object ai {
      * @see [[MethodExternalExceptionsOriginOffset]] for further information.
      */
     final def pcOfMethodExternalException(valueOrigin: Int): Int = {
-        assert(valueOrigin <= MethodExternalExceptionsOriginOffset)
+        elidedAssert(valueOrigin <= MethodExternalExceptionsOriginOffset)
         -valueOrigin + MethodExternalExceptionsOriginOffset
     }
 
@@ -369,7 +369,7 @@ package object ai {
         descriptor:     MethodDescriptor,
         parameterIndex: Int
     ): Int /*ValueOrigin*/ = {
-        assert(descriptor.parametersCount > 0)
+        elidedAssert(descriptor.parametersCount > 0)
 
         var origin = if (isStatic) -1 else -2 // this handles the case parameterIndex == 0
         val parameterTypes = descriptor.parameterTypes
@@ -538,7 +538,7 @@ package object ai {
         targetDomain: ValuesDomain & ValuesFactory
     ): Locals[targetDomain.DomainValue] = {
 
-        assert(
+        elidedAssert(
             operands.size == calledMethod.actualArgumentsCount,
             (if (calledMethod.isStatic) "static " else "/*virtual*/ ") +
                 s"${calledMethod.signatureToJava()}(Arguments: ${calledMethod.actualArgumentsCount}) " +

--- a/OPAL/ai/src/main/scala/org/opalj/issues/Issue.scala
+++ b/OPAL/ai/src/main/scala/org/opalj/issues/Issue.scala
@@ -8,6 +8,8 @@ import scala.xml.Group
 import scala.xml.Node
 import scala.xml.Unparsed
 
+import org.opalj.util.elidedAssert
+
 /**
  * Describes some issue found in source code.
  *
@@ -39,8 +41,8 @@ case class Issue(
     details:    Iterable[IssueDetails] = Nil
 ) extends IssueRepresentations {
 
-    assert(!summary.contains('\n'), s"the summary must not contain new lines:\n$summary")
-    assert(locations.nonEmpty, "at least one location must be specified")
+    elidedAssert(!summary.contains('\n'), s"the summary must not contain new lines:\n$summary")
+    elidedAssert(locations.nonEmpty, "at least one location must be specified")
 
     def toXHTML(basicInfoOnly: Boolean): Node = {
 

--- a/OPAL/ai/src/main/scala/org/opalj/issues/IssueLocation.scala
+++ b/OPAL/ai/src/main/scala/org/opalj/issues/IssueLocation.scala
@@ -2,7 +2,6 @@
 package org.opalj
 package issues
 
-import java.lang.Comparable
 import play.api.libs.json.JsNull
 import play.api.libs.json.JsNumber
 import play.api.libs.json.JsObject
@@ -24,6 +23,7 @@ import org.opalj.br.classAccessFlagsToString
 import org.opalj.br.classAccessFlagsToXHTML
 import org.opalj.br.methodToXHTML
 import org.opalj.br.typeToXHTML
+import org.opalj.util.elidedAssert
 
 /**
  * The location of an issue.
@@ -218,7 +218,7 @@ class InstructionLocation(
     details:     Seq[IssueDetails] = List.empty
 ) extends MethodLocation(description, theProject, method, details) with PCLineComprehension {
 
-    assert(method.body.isDefined)
+    elidedAssert(method.body.isDefined)
 
     def code: Code = method.body.get
 

--- a/OPAL/apk/src/main/scala/org/opalj/apk/package.scala
+++ b/OPAL/apk/src/main/scala/org/opalj/apk/package.scala
@@ -7,6 +7,7 @@ import com.typesafe.config.ConfigFactory
 import org.opalj.log.GlobalLogContext
 import org.opalj.log.LogContext
 import org.opalj.log.OPALLogger.info
+import org.opalj.util.elidedAssert
 
 package object apk {
 
@@ -15,7 +16,7 @@ package object apk {
     {
         implicit val logContext: LogContext = GlobalLogContext
         try {
-            assert(false) // <= test whether assertions are turned on or off...
+            elidedAssert(false) // <= test whether assertions are turned on or off...
             info(FrameworkName, "Production Build")
         } catch {
             case _: AssertionError => info(FrameworkName, "Development Build with Assertions")

--- a/OPAL/av/src/main/scala/org/opalj/av/checking/BinaryString.scala
+++ b/OPAL/av/src/main/scala/org/opalj/av/checking/BinaryString.scala
@@ -3,6 +3,8 @@ package org.opalj
 package av
 package checking
 
+import org.opalj.util.elidedAssert
+
 /**
  * Helper class to mark those places where a string using binary notation (i.e.,
  * where packages are separated using "/" instead of ".") is expected.
@@ -11,7 +13,7 @@ package checking
  */
 final class BinaryString private (private val string: String) {
 
-    assert(string.indexOf('.') == -1)
+    elidedAssert(string.indexOf('.') == -1)
 
     def asString: String = this.string
 

--- a/OPAL/av/src/main/scala/org/opalj/av/checking/FieldMatcher.scala
+++ b/OPAL/av/src/main/scala/org/opalj/av/checking/FieldMatcher.scala
@@ -10,6 +10,7 @@ import org.opalj.br.Field
 import org.opalj.br.FieldType
 import org.opalj.br.VirtualSourceElement
 import org.opalj.br.analyses.SomeProject
+import org.opalj.util.elidedAssert
 
 /**
  * Matches fields based on their name, type, annotations and declaring class.
@@ -64,7 +65,7 @@ object FieldMatcher {
         matchPrefix:          Boolean              = false
     ): FieldMatcher = {
 
-        assert(theName.isDefined || !matchPrefix)
+        elidedAssert(theName.isDefined || !matchPrefix)
 
         val nameMatcher: Option[NamePredicate] =
             theName match {

--- a/OPAL/ba/src/main/scala/org/opalj/ba/CLASS.scala
+++ b/OPAL/ba/src/main/scala/org/opalj/ba/CLASS.scala
@@ -9,6 +9,7 @@ import org.opalj.br.ClassType
 import org.opalj.br.MethodSignature
 import org.opalj.br.MethodTemplate
 import org.opalj.collection.immutable.UShortPair
+import org.opalj.util.elidedAssert
 
 /**
  * Builder for [[org.opalj.br.ClassFile]] objects.
@@ -67,7 +68,7 @@ class CLASS[T](
                 map + ((m.signature, t))
             }
 
-        assert(annotationsMap.size == brAnnotatedMethods.size, "duplicate method signatures found")
+        elidedAssert(annotationsMap.size == brAnnotatedMethods.size, "duplicate method signatures found")
 
         var brMethods = brAnnotatedMethods.map[MethodTemplate](m => m._1)
         if (!(

--- a/OPAL/ba/src/main/scala/org/opalj/ba/package.scala
+++ b/OPAL/ba/src/main/scala/org/opalj/ba/package.scala
@@ -58,6 +58,7 @@ import org.opalj.collection.immutable.UShortPair
 import org.opalj.log.GlobalLogContext
 import org.opalj.log.LogContext
 import org.opalj.log.OPALLogger
+import org.opalj.util.elidedAssert
 
 /**
  * Implementation of an eDSL for creating Java bytecode. The eDSL is designed to facilitate
@@ -80,7 +81,7 @@ package object ba { ba =>
         implicit val logContext: LogContext = GlobalLogContext
         import OPALLogger.info
         try {
-            scala.Predef.assert(false)
+            elidedAssert(false)
             // when we reach this point assertions are off...
             info(FrameworkName, s"Production Build")
         } catch {

--- a/OPAL/bi/src/main/scala/org/opalj/bi/package.scala
+++ b/OPAL/bi/src/main/scala/org/opalj/bi/package.scala
@@ -12,6 +12,7 @@ import org.opalj.log.OPALLogger
 import org.opalj.log.OPALLogger.error
 import org.opalj.log.OPALLogger.info
 import org.opalj.log.Warn
+import org.opalj.util.elidedAssert
 
 /**
  * Implementation of a library for parsing Java bytecode and creating arbitrary
@@ -33,7 +34,7 @@ package object bi {
         // Log the information whether a production build or a development build is used.
         implicit val logContext: LogContext = GlobalLogContext
         try {
-            assert(false)
+            elidedAssert(false)
             info("OPAL Bytecode Infrastructure", "Production Build")
         } catch {
             case _: AssertionError =>

--- a/OPAL/br/src/main/scala/org/opalj/br/ClassFile.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/ClassFile.scala
@@ -23,6 +23,7 @@ import org.opalj.collection.binarySearch
 import org.opalj.collection.immutable.UShortPair
 import org.opalj.collection.insertedAt
 import org.opalj.log.OPALLogger
+import org.opalj.util.elidedAssert
 
 /**
  * Represents a single class file which either defines a class type or an interface type.
@@ -84,10 +85,10 @@ final class ClassFile private (
 ) extends ConcreteSourceElement {
 
     methods.foreach { m =>
-        assert(m.declaringClassFile == null); m.declaringClassFile = this
+        elidedAssert(m.declaringClassFile == null); m.declaringClassFile = this
     }
     fields.foreach { f =>
-        assert(f.declaringClassFile == null); f.declaringClassFile = this
+        elidedAssert(f.declaringClassFile == null); f.declaringClassFile = this
     }
 
     /**
@@ -249,8 +250,8 @@ final class ClassFile private (
      * @note This method is primarily intended to be used to perform load-time transformations!
      */
     def _UNSAFE_replaceMethod(oldMethod: Method, newMethod: MethodTemplate): this.type = {
-        assert(oldMethod.name == newMethod.name)
-        assert(oldMethod.descriptor == newMethod.descriptor)
+        elidedAssert(oldMethod.name == newMethod.name)
+        elidedAssert(oldMethod.descriptor == newMethod.descriptor)
 
         val index = binarySearch[Method, JVMMethod](this.methods, oldMethod)
         val newPreparedMethod: Method = newMethod.prepareClassFileAttachement()
@@ -277,7 +278,7 @@ final class ClassFile private (
     def _UNSAFE_addMethod(methodTemplate: MethodTemplate): ClassFile = {
         val newMethod = methodTemplate.prepareClassFileAttachement()
 
-        assert(this.findMethod(newMethod.name, newMethod.descriptor).isEmpty)
+        elidedAssert(this.findMethod(newMethod.name, newMethod.descriptor).isEmpty)
 
         val index = binarySearch[Method, JVMMethod](this.methods, newMethod)
         if (index >= 0)
@@ -842,7 +843,7 @@ final class ClassFile private (
         name:        String,
         descriptor:  MethodDescriptor
     ): Result[Method] = {
-        assert(visibility.isEmpty || visibility.get != ACC_PRIVATE)
+        elidedAssert(visibility.isEmpty || visibility.get != ACC_PRIVATE)
 
         findMethod(name, descriptor).filter(m => !m.isStatic) match {
 

--- a/OPAL/br/src/main/scala/org/opalj/br/ClassHierarchy.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/ClassHierarchy.scala
@@ -38,6 +38,7 @@ import org.opalj.log.GlobalLogContext
 import org.opalj.log.LogContext
 import org.opalj.log.OPALLogger
 import org.opalj.log.Warn
+import org.opalj.util.elidedAssert
 
 import it.unimi.dsi.fastutil.ints.Int2IntArrayMap
 
@@ -2223,8 +2224,8 @@ class ClassHierarchy private (
         reflexive:        Boolean
     ): UIDSet[ClassType] = {
 
-        assert(upperTypeBoundsA.nonEmpty)
-        assert(upperTypeBoundsB.nonEmpty)
+        elidedAssert(upperTypeBoundsA.nonEmpty)
+        elidedAssert(upperTypeBoundsB.nonEmpty)
 
         upperTypeBoundsA.compare(upperTypeBoundsB) match {
             case StrictSubset     => upperTypeBoundsA
@@ -2375,7 +2376,7 @@ class ClassHierarchy private (
         reflexive:       Boolean
     ): UIDSet[ClassType] = {
 
-        assert(
+        elidedAssert(
             reflexive || (
                 (upperTypeBoundA ne ClassType.Object) && (upperTypeBoundB ne ClassType.Object)
             )
@@ -2918,7 +2919,7 @@ object ClassHierarchy {
                     ensureHasSet(subclassTypesMap, aSuperinterfaceTypeId)
                 } else {
                     addToSet(subclassTypesMap, aSuperinterfaceTypeId, classType)
-                    // assert(subclassTypesMap(aSuperinterfaceTypeId).contains(classType))
+                    // elidedAssert(subclassTypesMap(aSuperinterfaceTypeId).contains(classType))
                     ensureHasSet(subinterfaceTypesMap, aSuperinterfaceTypeId)
                 }
             }
@@ -2993,13 +2994,13 @@ object ClassHierarchy {
         // _____________________________________________________________________________________
         //
 
-        assert(knownTypesMap.length == isInterfaceTypeMap.length)
-        assert(knownTypesMap.length == isKnownToBeFinalMap.length)
-        assert(knownTypesMap.length == superclassTypeMap.length)
-        assert(knownTypesMap.length == superinterfaceTypesMap.length)
-        assert(knownTypesMap.length == subclassTypesMap.length)
-        assert(knownTypesMap.length == subinterfaceTypesMap.length)
-        assert(
+        elidedAssert(knownTypesMap.length == isInterfaceTypeMap.length)
+        elidedAssert(knownTypesMap.length == isKnownToBeFinalMap.length)
+        elidedAssert(knownTypesMap.length == superclassTypeMap.length)
+        elidedAssert(knownTypesMap.length == superinterfaceTypesMap.length)
+        elidedAssert(knownTypesMap.length == subclassTypesMap.length)
+        elidedAssert(knownTypesMap.length == subinterfaceTypesMap.length)
+        elidedAssert(
             knownTypesMap.indices forall { i =>
                 (knownTypesMap(i) ne null) ||
                 ((subclassTypesMap(i) eq null) && (subinterfaceTypesMap(i) eq null))

--- a/OPAL/br/src/main/scala/org/opalj/br/EnclosingMethod.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/EnclosingMethod.scala
@@ -2,6 +2,8 @@
 package org.opalj
 package br
 
+import org.opalj.util.elidedAssert
+
 /**
  * The optional enclosing method attribute of a class.
  *
@@ -9,7 +11,6 @@ package br
  *            The name is optional, but if defined, the descriptor also has to be defined.
  * @param     descriptor The method descriptor of the enclosing method.
  *            The descriptor is optional, but if defined, the name also has to be defined.
- *
  * @author Michael Eichberg
  */
 case class EnclosingMethod(
@@ -18,7 +19,7 @@ case class EnclosingMethod(
     descriptor: Option[MethodDescriptor]
 ) extends Attribute {
 
-    assert(name.isDefined == descriptor.isDefined)
+    elidedAssert(name.isDefined == descriptor.isDefined)
 
     override def kindId: Int = EnclosingMethod.KindId
 

--- a/OPAL/br/src/main/scala/org/opalj/br/Method.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/Method.scala
@@ -4,7 +4,6 @@ package br
 
 import scala.collection.Map as SomeMap
 import scala.collection.immutable.ArraySeq
-import scala.math.Ordered
 
 import org.opalj.bi.ACC_ABSTRACT
 import org.opalj.bi.ACC_BRIDGE
@@ -22,6 +21,7 @@ import org.opalj.br.instructions.ALOAD_0
 import org.opalj.br.instructions.Instruction
 import org.opalj.br.instructions.INVOKESPECIAL
 import org.opalj.br.instructions.RETURN
+import org.opalj.util.elidedAssert
 
 /**
  * Represents a single method.
@@ -100,7 +100,7 @@ sealed abstract class JVMMethod
         attributes:  Attributes       = this.attributes
     ): MethodTemplate = {
         // ensure invariant that the code attribute is explicitly extracted...
-        assert(attributes.forall { a => a.kindId != Code.KindId })
+        elidedAssert(attributes.forall { a => a.kindId != Code.KindId })
 
         val n = if (this.name eq name) name else name.intern()
 
@@ -545,8 +545,8 @@ object Method {
         import MethodDescriptor.JustReturnsObject
         import MethodDescriptor.NoArgsAndReturnVoid
         import MethodDescriptor.ReadObjectDescriptor
-        import MethodDescriptor.WriteObjectDescriptor
         import MethodDescriptor.ReadObjectInputDescriptor
+        import MethodDescriptor.WriteObjectDescriptor
         import MethodDescriptor.WriteObjectOutputDescriptor
 
         val name = method.name

--- a/OPAL/br/src/main/scala/org/opalj/br/Type.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/Type.scala
@@ -15,6 +15,7 @@ import scala.math.Ordered
 import org.opalj.collection.UIDValue
 import org.opalj.collection.immutable.UIDSet
 import org.opalj.collection.immutable.UIDSet2
+import org.opalj.util.elidedAssert
 
 /**
  * Represents a JVM type.
@@ -518,12 +519,12 @@ sealed abstract class NumericType protected () extends BaseType {
      *
      * @example
      * {{{
-     * assert(IntegerType.isWiderThan(IntegerType) == false)
-     * assert(IntegerType.isWiderThan(LongType) == false)
-     * assert(IntegerType.isWiderThan(ByteType) == true)
-     * assert(LongType.isWiderThan(FloatType) == false)
-     * assert(ByteType.isWiderThan(CharType) == false)
-     * assert(LongType.isWiderThan(ShortType) == true)
+     * elidedAssert(IntegerType.isWiderThan(IntegerType) == false)
+     * elidedAssert(IntegerType.isWiderThan(LongType) == false)
+     * elidedAssert(IntegerType.isWiderThan(ByteType) == true)
+     * elidedAssert(LongType.isWiderThan(FloatType) == false)
+     * elidedAssert(ByteType.isWiderThan(CharType) == false)
+     * elidedAssert(LongType.isWiderThan(ShortType) == true)
      * }}}
      */
     def isWiderThan(targetType: NumericType): Boolean
@@ -974,7 +975,7 @@ final class ClassType private ( // DO NOT MAKE THIS A CASE CLASS!
     final val fqn: String
 ) extends ReferenceType {
 
-    assert(fqn.indexOf('.') == -1, s"invalid class type name: $fqn")
+    elidedAssert(fqn.indexOf('.') == -1, s"invalid class type name: $fqn")
 
     final val packageName: String = ClassType.packageName(fqn).intern()
 
@@ -1151,7 +1152,7 @@ object ClassType {
      *         comparison is explicitly supported.
      */
     def apply(fqn: String): ClassType = {
-        assert(!fqn.endsWith(";")) // Catch errors where we accidentally use a JVMTypeName instead
+        elidedAssert(!fqn.endsWith(";")) // Catch errors where we accidentally use a JVMTypeName instead
 
         val readLock = cacheRWLock.readLock()
         readLock.lock()
@@ -1672,7 +1673,7 @@ object ArrayType {
      * dimension.
      */
     @tailrec def apply(dimension: Int, componentType: FieldType): ArrayType = {
-        assert(dimension >= 1, s"dimension=$dimension, componentType=$componentType")
+        elidedAssert(dimension >= 1, s"dimension=$dimension, componentType=$componentType")
 
         val at = apply(componentType)
         if (dimension > 1)

--- a/OPAL/br/src/main/scala/org/opalj/br/analyses/DeclaredMethods.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/analyses/DeclaredMethods.scala
@@ -15,6 +15,7 @@ import org.opalj.br.analyses.DeclaredMethodsKey.MethodContext
 import org.opalj.br.analyses.DeclaredMethodsKey.MethodContextQuery
 import org.opalj.log.LogContext
 import org.opalj.log.OPALLogger.info
+import org.opalj.util.elidedAssert
 
 /**
  * The set of all [[org.opalj.br.DeclaredMethod]]s (potentially used by the property store).
@@ -119,7 +120,7 @@ class DeclaredMethods(
         }
 
         method = dmSet.get(context)
-        assert(method ne null)
+        elidedAssert(method ne null)
         method
     }
 

--- a/OPAL/br/src/main/scala/org/opalj/br/analyses/DeclaredMethodsKey.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/analyses/DeclaredMethodsKey.scala
@@ -14,6 +14,7 @@ import org.opalj.br.ClassType.VarHandle
 import org.opalj.br.MethodDescriptor.SignaturePolymorphicMethodBoolean
 import org.opalj.br.MethodDescriptor.SignaturePolymorphicMethodObject
 import org.opalj.br.MethodDescriptor.SignaturePolymorphicMethodVoid
+import org.opalj.util.elidedAssert
 
 /**
  * The ''key'' object to get information about all declared methods.
@@ -102,7 +103,7 @@ object DeclaredMethodsKey extends ProjectInformationKey[DeclaredMethods, Nothing
                 }
             )
 
-            assert(
+            elidedAssert(
                 (computedDM ne null) || {
                     computedDM = computeDeclaredMethod(0)
                     oldDm match {

--- a/OPAL/br/src/main/scala/org/opalj/br/analyses/MethodDeclarationContext.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/analyses/MethodDeclarationContext.scala
@@ -7,6 +7,7 @@ import org.opalj.bi.ACC_PRIVATE
 import org.opalj.bi.ACC_PROTECTED
 import org.opalj.bi.ACC_PUBLIC
 import org.opalj.bi.VisibilityModifier
+import org.opalj.util.elidedAssert
 
 /**
  * Encapsulates the information about a '''non-abstract''', '''non-static''' method which is
@@ -25,8 +26,8 @@ import org.opalj.bi.VisibilityModifier
  */
 final class MethodDeclarationContext(val method: Method) extends Ordered[MethodDeclarationContext] {
 
-    assert(!method.isStatic)
-    assert(!method.isInitializer)
+    elidedAssert(!method.isStatic)
+    elidedAssert(!method.isInitializer)
 
     def declaringClassType: ClassType = method.declaringClassFile.thisType
     def packageName: String = declaringClassType.packageName
@@ -74,7 +75,7 @@ final class MethodDeclarationContext(val method: Method) extends Ordered[MethodD
     }
 
     def compareWithPublicMethod(thatMethod: Method): Int = {
-        assert(thatMethod.isPublic, s"${thatMethod.toJava} is not public")
+        elidedAssert(thatMethod.isPublic, s"${thatMethod.toJava} is not public")
         this.method.compare(thatMethod)
     }
 

--- a/OPAL/br/src/main/scala/org/opalj/br/analyses/Project.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/analyses/Project.scala
@@ -293,8 +293,8 @@ class Project[Source] private (
         // for which we have not enough information
         def noSAMInterface(interfaceType: ClassType): Unit = {
             // println("non-functional interface: "+interfaceType.toJava)
-            // assert(!irrelevantInterfaces.contains(interfaceType))
-            // assert(!functionalInterfaces.contains(interfaceType))
+            // elidedAssert(!irrelevantInterfaces.contains(interfaceType))
+            // elidedAssert(!functionalInterfaces.contains(interfaceType))
 
             otherInterfaces += interfaceType
             classHierarchy.foreachSubinterfaceType(interfaceType) { i =>

--- a/OPAL/br/src/main/scala/org/opalj/br/analyses/ProjectLike.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/analyses/ProjectLike.scala
@@ -29,6 +29,7 @@ import org.opalj.log.LogContext
 import org.opalj.log.OPALLogger
 import org.opalj.log.OPALLogger.error
 import org.opalj.log.OPALLogger.info
+import org.opalj.util.elidedAssert
 
 /**
  * Enables project wide lookups of methods and fields as required to determine the target(s) of an
@@ -199,9 +200,9 @@ trait ProjectLike extends ClassFileRepository { project =>
      * }}}
      */
     def overriddenBy(m: Method): SomeSet[Method] = {
-        assert(!m.isPrivate, s"private methods $m cannot be overridden")
-        assert(!m.isStatic, s"static methods $m cannot be overridden")
-        assert(!m.isInitializer, s"initializers $m cannot be overridden")
+        elidedAssert(!m.isPrivate, s"private methods $m cannot be overridden")
+        elidedAssert(!m.isStatic, s"static methods $m cannot be overridden")
+        elidedAssert(!m.isInitializer, s"initializers $m cannot be overridden")
 
         overridingMethods.getOrElse(m, Set.empty)
     }
@@ -510,7 +511,7 @@ trait ProjectLike extends ClassFileRepository { project =>
         }
 
         project.classFile(declaringClassType) flatMap { classFile =>
-            assert(classFile.isInterfaceDeclaration)
+            elidedAssert(classFile.isInterfaceDeclaration)
             classFile.findMethod(name, descriptor) orElse {
                 lookupInObject() orElse {
                     classHierarchy.superinterfaceTypes(declaringClassType) flatMap { superT =>

--- a/OPAL/br/src/main/scala/org/opalj/br/cfg/BasicBlock.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/cfg/BasicBlock.scala
@@ -3,13 +3,14 @@ package org.opalj
 package br
 package cfg
 
+import org.opalj.util.elidedAssert
+
 /**
  * Represents a basic block of a method's control flow graph (CFG). The basic block
  * is identified by referring to the first and last instruction belonging to the
  * basic block.
  *
  * @param startPC The pc of the first instruction belonging to the `BasicBlock`.
- *
  * @author Erich Wittenbeck
  * @author Michael Eichberg
  */
@@ -75,7 +76,7 @@ final class BasicBlock(
      * @param code The code to which this basic block belongs.
      */
     def index(pc: Int)(implicit code: Code): Int = {
-        assert(pc >= startPC && pc <= endPC)
+        elidedAssert(pc >= startPC && pc <= endPC)
 
         var index = 0
         var currentPC = startPC

--- a/OPAL/br/src/main/scala/org/opalj/br/cfg/CFG.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/cfg/CFG.scala
@@ -20,6 +20,7 @@ import org.opalj.graphs.PostDominatorTree
 import org.opalj.log.GlobalLogContext
 import org.opalj.log.LogContext
 import org.opalj.log.OPALLogger.info
+import org.opalj.util.elidedAssert
 
 /**
  * Represents the control flow graph of a method.
@@ -680,7 +681,7 @@ case class CFG[I <: AnyRef, C <: CodeSequence[I]](
                        (tempBB eq null) || pcToIndex(tempBB.startPC) < 0
                    }
             ) {
-                assert(tempBB ne oldBB)
+                elidedAssert(tempBB ne oldBB)
                 // This (index < 0) handles the case where the initial CFG was created using
                 // a simple algorithm that actually resulted in a CFG with detached basic blocks;
                 // we now kill these basic blocks by jumping over them!
@@ -721,7 +722,7 @@ case class CFG[I <: AnyRef, C <: CodeSequence[I]](
         bbMapping iterate { (oldBB, newBB) =>
             oldBB.successors foreach { oldSuccBB =>
                 val newSuccBB = bbMapping(oldSuccBB)
-                assert(newSuccBB ne null, s"no mapping for $oldSuccBB")
+                elidedAssert(newSuccBB ne null, s"no mapping for $oldSuccBB")
                 newBB.addSuccessor(newSuccBB)
                 // Instead of iterating over the predecessors, we just iterate over
                 // the successors; this way, we only include the nodes that are
@@ -732,7 +733,7 @@ case class CFG[I <: AnyRef, C <: CodeSequence[I]](
         }
 
         val newCatchNodes = catchNodes.map(bbMapping(_).asInstanceOf[CatchNode])
-        assert(newCatchNodes.forall { _ ne null })
+        elidedAssert(newCatchNodes.forall { _ ne null })
 
         // let's see if we can merge the first two basic blocks
         if (requiresNewStartBlock && basicBlocks(0).predecessors.isEmpty) {

--- a/OPAL/br/src/main/scala/org/opalj/br/cfg/CFGFactory.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/cfg/CFGFactory.scala
@@ -26,6 +26,7 @@ import org.opalj.br.instructions.RET
 import org.opalj.br.instructions.TABLESWITCH
 import org.opalj.br.instructions.UnconditionalBranchInstruction
 import org.opalj.collection.immutable.IntArraySet
+import org.opalj.util.elidedAssert
 
 /**
  * A factory for computing control flow graphs for methods.
@@ -181,7 +182,7 @@ object CFGFactory {
                     sourceBB.addSuccessor(newTargetBB)
                     (sourceBB, newTargetBB)
                 } else {
-                    assert(
+                    elidedAssert(
                         targetBB.startPC == targetBBStartPC,
                         s"targetBB's startPC ${targetBB.startPC} does not equal $pc"
                     )
@@ -318,7 +319,7 @@ object CFGFactory {
                     runningBB = null
 
                 case _ /* INSTRUCTIONS THAT EITHER FALL THROUGH OR THROW A (JVM-BASED) EXCEPTION*/ =>
-                    assert(instruction.nextInstructions(pc, regularSuccessorsOnly = true).size == 1)
+                    elidedAssert(instruction.nextInstructions(pc, regularSuccessorsOnly = true).size == 1)
 
                     val currentBB = useRunningBB()
 

--- a/OPAL/br/src/main/scala/org/opalj/br/cfg/CFGNode.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/cfg/CFGNode.scala
@@ -5,6 +5,7 @@ package cfg
 import scala.collection.mutable
 
 import org.opalj.graphs.Node
+import org.opalj.util.elidedAssert
 
 /**
  * The common super trait of all nodes belonging to a method's control flow graph.
@@ -136,7 +137,7 @@ trait CFGNode extends Node {
      *        graph containing subroutines.
      */
     private[cfg] def subroutineFrontier(code: Code, bbs: Array[BasicBlock]): List[BasicBlock] = {
-        assert(this.isStartOfSubroutine)
+        elidedAssert(this.isStartOfSubroutine)
 
         var frontier: List[BasicBlock] = Nil
 

--- a/OPAL/br/src/main/scala/org/opalj/br/cp/CONSTANT_MethodHandle_info.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/cp/CONSTANT_MethodHandle_info.scala
@@ -4,6 +4,7 @@ package br
 package cp
 
 import org.opalj.bi.ConstantPoolTags
+import org.opalj.util.elidedAssert
 
 /**
  * Represents a method handle.
@@ -55,11 +56,11 @@ case class CONSTANT_MethodHandle_info(
 
             case bi.REF_newInvokeSpecial.referenceKind =>
                 val (receiverType, _, name, methodDescriptor) = cp(referenceIndex).asMethodref(cp)
-                assert(
+                elidedAssert(
                     receiverType.isClassType,
                     "receiver for newInvokeSpecial must be classtype"
                 )
-                assert(
+                elidedAssert(
                     name == "<init>",
                     "invalid bytecode: newInvokeSpecial name must be <init> (see JVM spc 4.4.8)"
                 )

--- a/OPAL/br/src/main/scala/org/opalj/br/cp/ConstantsBuffer.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/cp/ConstantsBuffer.scala
@@ -15,6 +15,7 @@ import org.opalj.br.instructions.LoadInt
 import org.opalj.br.instructions.LoadMethodHandle
 import org.opalj.br.instructions.LoadMethodType
 import org.opalj.br.instructions.LoadString
+import org.opalj.util.elidedAssert
 
 /**
  * This class can be used to (re)build a [[org.opalj.br.ClassFile]]'s constant pool.
@@ -413,7 +414,7 @@ object ConstantsBuffer {
         constantsBuffer.nextIndex = nextIndexAfterLDCRelatedEntries
         bootstrapMethods.foreach(_.arguments.foreach(CPEntryForBootstrapArgument))
 
-        assert(
+        elidedAssert(
             buffer.size == constantsBuffer.nextIndex,
             "constant pool contains holes:\n\t" +
                 ldcs.mkString("LDCs={", ", ", "}\n\t") +

--- a/OPAL/br/src/main/scala/org/opalj/br/fpcf/analyses/L1ThrownExceptionsAnalysis.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/fpcf/analyses/L1ThrownExceptionsAnalysis.scala
@@ -69,6 +69,7 @@ import org.opalj.fpcf.PropertyStore
 import org.opalj.fpcf.Result
 import org.opalj.fpcf.SomeEPS
 import org.opalj.fpcf.UBP
+import org.opalj.util.elidedAssert
 
 /**
  * Analysis of thrown exceptions; computes the [[org.opalj.br.fpcf.properties.ThrownExceptions]]
@@ -305,7 +306,7 @@ class L1ThrownExceptionsAnalysis(
         val areAllExceptionsCollected = code.forall(collectAllExceptions(_, _))
 
         if (!areAllExceptionsCollected) {
-            assert(
+            elidedAssert(
                 result ne null,
                 "all exceptions are expected to be collected but the set is null"
             )

--- a/OPAL/br/src/main/scala/org/opalj/br/fpcf/analyses/immutability/TypeImmutabilityAnalysis.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/fpcf/analyses/immutability/TypeImmutabilityAnalysis.scala
@@ -39,6 +39,7 @@ import org.opalj.fpcf.PropertyStore
 import org.opalj.fpcf.Result
 import org.opalj.fpcf.SomeEPS
 import org.opalj.fpcf.UBP
+import org.opalj.util.elidedAssert
 
 /**
  * Determines the immutability of a specific type by checking if all subtypes of a specific
@@ -204,7 +205,7 @@ class TypeImmutabilityAnalysis(final val project: SomeProject) extends FPCFAnaly
                                 }
                             }
                             if (joinedImmutability == maxImmutability) {
-                                assert(maxImmutability == NonTransitivelyImmutableType)
+                                elidedAssert(maxImmutability == NonTransitivelyImmutableType)
                                 Result(t, maxImmutability)
                             } else {
                                 InterimResult(

--- a/OPAL/br/src/main/scala/org/opalj/br/fpcf/properties/MethodComplexity.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/fpcf/properties/MethodComplexity.scala
@@ -7,6 +7,7 @@ package properties
 import org.opalj.fpcf.Property
 import org.opalj.fpcf.PropertyKey
 import org.opalj.fpcf.PropertyMetaInformation
+import org.opalj.util.elidedAssert
 
 sealed trait MethodComplexityPropertyMetaInformation extends PropertyMetaInformation {
     final type Self = MethodComplexity
@@ -54,7 +55,7 @@ case class MethodComplexity(
 ) extends Property
     with MethodComplexityPropertyMetaInformation {
 
-    assert(value >= 0)
+    elidedAssert(value >= 0)
 
     final def key = MethodComplexity.key
 

--- a/OPAL/br/src/main/scala/org/opalj/br/fpcf/properties/ThrownExceptionsFallback.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/fpcf/properties/ThrownExceptionsFallback.scala
@@ -51,6 +51,7 @@ import org.opalj.fpcf.PropertyComputationResult
 import org.opalj.fpcf.PropertyStore
 import org.opalj.fpcf.Result
 import org.opalj.si.Project
+import org.opalj.util.elidedAssert
 
 /**
  * A very straight forward flow-insensitive analysis which can successfully analyze methods
@@ -244,7 +245,7 @@ object ThrownExceptionsFallback extends ((PropertyStore, FallbackReason, Entity)
         }
         val areAllExceptionsCollected = code.forall(collectAllExceptions(_, _))
         if (!areAllExceptionsCollected) {
-            assert(result ne null)
+            elidedAssert(result ne null)
             return result;
         }
         if (fieldAccessMayThrowNullPointerException ||

--- a/OPAL/br/src/main/scala/org/opalj/br/fpcf/properties/cg/Callers.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/fpcf/properties/cg/Callers.scala
@@ -17,6 +17,7 @@ import org.opalj.fpcf.PropertyIsNotDerivedByPreviouslyExecutedAnalysis
 import org.opalj.fpcf.PropertyKey
 import org.opalj.fpcf.PropertyMetaInformation
 import org.opalj.fpcf.PropertyStore
+import org.opalj.util.elidedAssert
 
 /**
  * For a given [[org.opalj.br.DeclaredMethod]], and for each call site (represented by the PC),
@@ -350,8 +351,8 @@ class CallersImplWithOtherCalls(
     val size:                          Int,
     private val specialCallSitesFlags: Byte // last bit vm lvl, second last bit unknown context
 ) extends CallersImplementation {
-    assert(encodedCallers.nonEmpty)
-    assert(specialCallSitesFlags >= 0 && specialCallSitesFlags <= 3)
+    elidedAssert(encodedCallers.nonEmpty)
+    elidedAssert(specialCallSitesFlags >= 0 && specialCallSitesFlags <= 3)
 
     override def hasVMLevelCallers: Boolean = (specialCallSitesFlags & 1) != 0
 
@@ -407,8 +408,8 @@ object CallersImplWithOtherCalls {
         hasVMLevelCallers:            Boolean,
         hasCallersWithUnknownContext: Boolean
     ): CallersImplWithOtherCalls = {
-        assert(hasVMLevelCallers | hasCallersWithUnknownContext)
-        assert(encodedCallers.nonEmpty)
+        elidedAssert(hasVMLevelCallers | hasCallersWithUnknownContext)
+        elidedAssert(encodedCallers.nonEmpty)
 
         val vmLvlCallers = if (hasVMLevelCallers) 1 else 0
         val unknownContext = if (hasCallersWithUnknownContext) 2 else 0
@@ -437,7 +438,7 @@ object Callers extends CallersPropertyMetaInformation {
     }
 
     def toLong(contextId: Int, pc: Int, isDirect: Boolean): Long = {
-        assert(pc >= 0 && pc <= 0xFFFF)
+        elidedAssert(pc >= 0 && pc <= 0xFFFF)
         (contextId.toLong << 16) | pc.toLong | (if (isDirect) Long.MinValue else 0)
     }
 

--- a/OPAL/br/src/main/scala/org/opalj/br/fpcf/properties/cg/ForNameClasses.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/fpcf/properties/cg/ForNameClasses.scala
@@ -14,6 +14,7 @@ import org.opalj.fpcf.PropertyKey
 import org.opalj.fpcf.PropertyMetaInformation
 import org.opalj.fpcf.PropertyStore
 import org.opalj.log.OPALLogger
+import org.opalj.util.elidedAssert
 
 sealed trait ForNameClassesMetaInformation extends PropertyMetaInformation {
     final type Self = ForNameClasses
@@ -29,7 +30,7 @@ sealed class ForNameClasses private[properties] (
     final val classes:        UIDSet[ReferenceType]
 ) extends OrderedProperty with ForNameClassesMetaInformation {
 
-    assert(orderedClasses == null || orderedClasses.size == classes.size)
+    elidedAssert(orderedClasses == null || orderedClasses.size == classes.size)
 
     override def checkIsEqualOrBetterThan(e: Entity, other: ForNameClasses): Unit = {
         if (other.classes != null && !classes.subsetOf(other.classes)) {

--- a/OPAL/br/src/main/scala/org/opalj/br/fpcf/properties/cg/InstantiatedTypes.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/fpcf/properties/cg/InstantiatedTypes.scala
@@ -18,6 +18,7 @@ import org.opalj.fpcf.PropertyIsNotDerivedByPreviouslyExecutedAnalysis
 import org.opalj.fpcf.PropertyKey
 import org.opalj.fpcf.PropertyMetaInformation
 import org.opalj.fpcf.PropertyStore
+import org.opalj.util.elidedAssert
 
 /**
  * Represent the set of types that have allocations reachable from the respective entry points.
@@ -36,7 +37,7 @@ case class InstantiatedTypes private[properties] (
 ) extends OrderedProperty
     with InstantiatedTypesPropertyMetaInformation {
 
-    assert(orderedTypes == null || orderedTypes.size == types.size)
+    elidedAssert(orderedTypes == null || orderedTypes.size == types.size)
 
     final def key: PropertyKey[InstantiatedTypes] = InstantiatedTypes.key
 

--- a/OPAL/br/src/main/scala/org/opalj/br/fpcf/properties/cg/LoadedClasses.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/fpcf/properties/cg/LoadedClasses.scala
@@ -14,6 +14,7 @@ import org.opalj.fpcf.PropertyKey
 import org.opalj.fpcf.PropertyMetaInformation
 import org.opalj.fpcf.PropertyStore
 import org.opalj.log.OPALLogger
+import org.opalj.util.elidedAssert
 
 sealed trait LoadedClassesMetaInformation extends PropertyMetaInformation {
     final type Self = LoadedClasses
@@ -30,7 +31,7 @@ sealed class LoadedClasses private[properties] (
     final val classes:        UIDSet[ClassType]
 ) extends OrderedProperty with LoadedClassesMetaInformation {
 
-    assert(orderedClasses == null || orderedClasses.size == classes.size)
+    elidedAssert(orderedClasses == null || orderedClasses.size == classes.size)
 
     override def checkIsEqualOrBetterThan(e: Entity, other: LoadedClasses): Unit = {
         if (other.classes != null && !classes.subsetOf(other.classes)) {

--- a/OPAL/br/src/main/scala/org/opalj/br/fpcf/properties/pointsto/AllocationSitePointsToSet.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/fpcf/properties/pointsto/AllocationSitePointsToSet.scala
@@ -16,6 +16,7 @@ import org.opalj.fpcf.PropertyIsNotDerivedByPreviouslyExecutedAnalysis
 import org.opalj.fpcf.PropertyKey
 import org.opalj.fpcf.PropertyMetaInformation
 import org.opalj.fpcf.PropertyStore
+import org.opalj.util.elidedAssert
 
 /**
  * Represent the set of types that have allocations reachable from the respective entry points.
@@ -169,14 +170,14 @@ sealed trait AllocationSitePointsToSet
         AllocationSitePointsToSet(newAllocationSites, newTypes, newOrderedTypes)
     }
 
-    assert {
+    elidedAssert {
         var asTypes = IntTrieSet.empty
         elements.foreach { allocationSite => asTypes += allocationSiteLongToTypeId(allocationSite) }
 
         val typeIds = types.foldLeft(IntTrieSet.empty) { (r, t) => r + t.id }
         typeIds == asTypes
     }
-    assert(numElements >= numTypes)
+    elidedAssert(numElements >= numTypes)
 }
 
 object AllocationSitePointsToSet extends AllocationSitePointsToSetPropertyMetaInformation {
@@ -194,7 +195,7 @@ object AllocationSitePointsToSet extends AllocationSitePointsToSetPropertyMetaIn
         allocationSiteOld: AllocationSite,
         allocatedTypeOld:  ReferenceType
     ): AllocationSitePointsToSet = {
-        assert(allocationSiteOld != allocationSiteNew)
+        elidedAssert(allocationSiteOld != allocationSiteNew)
         new AllocationSitePointsToSetN(
             LongTrieSetWithList(allocationSiteNew, allocationSiteOld),
             UIDSet(allocatedTypeOld, allocatedTypeNew),
@@ -306,11 +307,11 @@ object NoAllocationSites extends AllocationSitePointsToSet {
     override def elements: LongLinkedSet = LongTrieSetWithList.empty
 
     override def forNewestNTypes[U](n: Int)(f: ReferenceType => U): Unit = {
-        assert(n == 0)
+        elidedAssert(n == 0)
     }
 
     override def forNewestNElements[U](n: Int)(f: AllocationSite => U): Unit = {
-        assert(n == 0)
+        elidedAssert(n == 0)
     }
 
     override def getNewestElement(): AllocationSite = throw new NoSuchElementException
@@ -372,7 +373,7 @@ case class AllocationSitePointsToSet1(
         other:        AllocationSitePointsToSet,
         seenElements: Int
     ): AllocationSitePointsToSet = {
-        assert(seenElements >= 0 && seenElements <= other.numElements)
+        elidedAssert(seenElements >= 0 && seenElements <= other.numElements)
         // Note, that we can not assert, that seenElements is between 0 and 1, as this can
         // happen by unordered partial results.
         included(other)
@@ -451,13 +452,13 @@ case class AllocationSitePointsToSet1(
     }
 
     override def forNewestNTypes[U](n: Int)(f: ReferenceType => U): Unit = {
-        assert(n == 0 || n == 1)
+        elidedAssert(n == 0 || n == 1)
         if (n == 1)
             f(allocatedType)
     }
 
     override def forNewestNElements[U](n: Int)(f: AllocationSite => U): Unit = {
-        assert(n == 0 || n == 1)
+        elidedAssert(n == 0 || n == 1)
         if (n == 1)
             f(allocationSite)
     }

--- a/OPAL/br/src/main/scala/org/opalj/br/fpcf/properties/pointsto/TypeBasedPointsToSet.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/fpcf/properties/pointsto/TypeBasedPointsToSet.scala
@@ -13,6 +13,7 @@ import org.opalj.fpcf.PropertyIsNotDerivedByPreviouslyExecutedAnalysis
 import org.opalj.fpcf.PropertyKey
 import org.opalj.fpcf.PropertyMetaInformation
 import org.opalj.fpcf.PropertyStore
+import org.opalj.util.elidedAssert
 
 /**
  * Represent the set of types that have allocations reachable from the respective entry points.
@@ -31,7 +32,7 @@ case class TypeBasedPointsToSet private[properties] (
     with OrderedProperty
     with TypeBasedPointsToSetPropertyMetaInformation {
 
-    assert(orderedTypes == null || orderedTypes.size == types.size)
+    elidedAssert(orderedTypes == null || orderedTypes.size == types.size)
 
     final def key: PropertyKey[TypeBasedPointsToSet] = TypeBasedPointsToSet.key
 

--- a/OPAL/br/src/main/scala/org/opalj/br/fpcf/properties/pointsto/package.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/fpcf/properties/pointsto/package.scala
@@ -5,6 +5,7 @@ package fpcf
 package properties
 
 import org.opalj.br.fpcf.analyses.ContextProvider
+import org.opalj.util.elidedAssert
 
 package object pointsto {
     // we encode allocation sites (method, pc, emptyArray, typeid tuples) as longs
@@ -20,9 +21,9 @@ package object pointsto {
         val contextId = if (context eq NoContext) 0x3FFFFFF else context.id
         val typeId = tpe.id
         val emptyArray = if (isEmptyArray) 1L else 0L
-        assert(pc >= -0x10000 && pc <= 0xFFFF)
-        assert(contextId >= 0 && contextId <= 0x3FFFFFF)
-        assert(typeId >= -0x80000 && typeId <= 0x7FFFF)
+        elidedAssert(pc >= -0x10000 && pc <= 0xFFFF)
+        elidedAssert(contextId >= 0 && contextId <= 0x3FFFFFF)
+        elidedAssert(typeId >= -0x80000 && typeId <= 0x7FFFF)
         contextId.toLong | ((pc.toLong & 0x1FFFF) << 26) | (emptyArray << 43) | (typeId.toLong << 44)
     }
 

--- a/OPAL/br/src/main/scala/org/opalj/br/fpcf/properties/string/StringTreeNode.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/fpcf/properties/string/StringTreeNode.scala
@@ -9,6 +9,8 @@ import scala.util.Try
 import scala.util.hashing.MurmurHash3
 import scala.util.matching.Regex
 
+import org.opalj.util.elidedAssert
+
 /**
  * A single node that can be nested to create string trees that represent a set of possible string values. Its canonical
  * reduction is a regex of all possible strings.
@@ -90,7 +92,7 @@ sealed trait StringTreeNode {
      * @return The modified string tree if something could be replaced or the same instance otherwise.
      */
     final def replaceParameters(parameters: Map[Int, StringTreeNode]): StringTreeNode = {
-        assert(parameters.nonEmpty)
+        elidedAssert(parameters.nonEmpty)
         if (parameterIndices.isEmpty || parameters.keySet.intersect(parameterIndices).isEmpty)
             this
         else

--- a/OPAL/br/src/main/scala/org/opalj/br/instructions/ClassFileFactory.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/instructions/ClassFileFactory.scala
@@ -13,6 +13,7 @@ import org.opalj.bi.ACC_SYNTHETIC
 import org.opalj.br.MethodDescriptor.DefaultConstructorDescriptor
 import org.opalj.log.GlobalLogContext
 import org.opalj.log.OPALLogger
+import org.opalj.util.elidedAssert
 
 /**
  * Provides helper methods to facilitate the generation of classes.
@@ -1013,7 +1014,7 @@ object ClassFileFactory {
         invocationInstruction: Opcode
     ): Code = {
 
-        assert(!receiverIsInterface || invocationInstruction != INVOKEVIRTUAL.opcode)
+        elidedAssert(!receiverIsInterface || invocationInstruction != INVOKEVIRTUAL.opcode)
 
         // If we have a constructor, we have to fix the method descriptor. Usually, the instruction
         // doesn't have a return type. For the proxy method, it is important to return the instance

--- a/OPAL/br/src/main/scala/org/opalj/br/instructions/Instruction.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/instructions/Instruction.scala
@@ -3,6 +3,8 @@ package org.opalj
 package br
 package instructions
 
+import org.opalj.util.elidedAssert
+
 /**
  * Common superclass of all instructions which are in their final form.
  *
@@ -142,7 +144,7 @@ object Instruction {
      * @see [[Instruction.isIsomorphic]] for further details.
      */
     def areIsomorphic(aPC: Int, bPC: Int)(implicit code: Code): Boolean = {
-        assert(aPC != bPC)
+        elidedAssert(aPC != bPC)
 
         code.instructions(aPC).isIsomorphic(aPC, bPC)
     }

--- a/OPAL/br/src/main/scala/org/opalj/br/instructions/package.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/instructions/package.scala
@@ -2,6 +2,8 @@
 package org.opalj
 package br
 
+import org.opalj.util.elidedAssert
+
 /**
  * Common instruction sequences.
  *
@@ -241,7 +243,7 @@ package object instructions {
 
             def unboxValue(wrapperType: Type): Array[Instruction] = {
                 val wid = wrapperType.id
-                assert(wid >= ClassType.Boolean.id && wid <= ClassType.Double.id)
+                elidedAssert(wid >= ClassType.Boolean.id && wid <= ClassType.Double.id)
 
                 unboxInstructions(wid)
             }

--- a/OPAL/br/src/main/scala/org/opalj/br/package.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/package.scala
@@ -17,6 +17,7 @@ import org.opalj.collection.immutable.UIDSet
 import org.opalj.log.GlobalLogContext
 import org.opalj.log.LogContext
 import org.opalj.log.OPALLogger.info
+import org.opalj.util.elidedAssert
 
 /**
  * In this representation of Java bytecode references to a Java class file's constant
@@ -40,7 +41,7 @@ package object br {
     {
         implicit val logContext: LogContext = GlobalLogContext
         try {
-            assert(false) // <= test whether assertions are turned on or off...
+            elidedAssert(false) // <= test whether assertions are turned on or off...
             info(FrameworkName, "Production Build")
         } catch {
             case _: AssertionError => info(FrameworkName, "Development Build with Assertions")

--- a/OPAL/br/src/main/scala/org/opalj/br/reader/InvokedynamicRewriting.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/reader/InvokedynamicRewriting.scala
@@ -30,6 +30,7 @@ import org.opalj.log.OPALLogger
 import org.opalj.log.OPALLogger.error
 import org.opalj.log.OPALLogger.info
 import org.opalj.log.StandardLogMessage
+import org.opalj.util.elidedAssert
 
 /**
  * Provides support for rewriting Java 8/Scala lambda or method reference expressions that
@@ -488,7 +489,7 @@ trait InvokedynamicRewriting
 
                     if (nextInsert < recipe.length) {
                         if (nextInsert == nextParam) {
-                            assert(recipe.charAt(nextInsert) == '\u0001')
+                            elidedAssert(recipe.charAt(nextInsert) == '\u0001')
                             val paramType = descriptor.parameterType(paramIndex)
                             appendParam(paramType, lvIndex)
                             val opSize = paramType.computationalType.operandSize
@@ -497,7 +498,7 @@ trait InvokedynamicRewriting
                             paramIndex += 1
                             nextParam = recipe.indexOf('\u0001', nextParam + 1)
                         } else {
-                            assert(recipe.charAt(nextInsert) == '\u0002')
+                            elidedAssert(recipe.charAt(nextInsert) == '\u0002')
                             val constant = constants(constantIndex)
                             val constantStack = appendConstant(constant)
                             maxStack = Math.max(maxStack, constantStack + 1)
@@ -1145,7 +1146,7 @@ trait InvokedynamicRewriting
                 m.name == targetMethodName && m.descriptor == targetMethodDescriptor
             }
 
-            assert(targetMethod.isDefined)
+            elidedAssert(targetMethod.isDefined)
             val m = targetMethod.get
 
             if (m.isPrivate) {

--- a/OPAL/br/src/main/scala/org/opalj/value/ValueInformation.scala
+++ b/OPAL/br/src/main/scala/org/opalj/value/ValueInformation.scala
@@ -35,6 +35,7 @@ import org.opalj.br.VerificationTypeInfo
 import org.opalj.br.VoidType
 import org.opalj.collection.immutable.UIDSet
 import org.opalj.collection.immutable.UIDSet1
+import org.opalj.util.elidedAssert
 
 /**
  * Encapsulates the available type information about a `DomainValue`.
@@ -657,7 +658,7 @@ trait IsMObjectValue extends IsBaseReferenceValue {
 
     override final def isArrayValue: Answer = No
 
-    assert(upperTypeBound.size > 1)
+    elidedAssert(upperTypeBound.size > 1)
 
     override final def verificationTypeInfo: VerificationTypeInfo = {
         ObjectVariableInfo(leastUpperType.get)
@@ -987,7 +988,7 @@ object TypeOfReferenceValue {
 
 trait IsMultipleReferenceValue extends IsReferenceValue {
 
-    assert(baseValues.nonEmpty)
+    elidedAssert(baseValues.nonEmpty)
 
     override def allValues: Iterable[IsReferenceValue] = this.baseValues
 
@@ -1062,8 +1063,8 @@ case class AMultipleReferenceValue(
     leastUpperType: Option[ReferenceType] // None in case of "null"
 ) extends IsMultipleReferenceValue {
 
-    assert((isNull.isYes && leastUpperType.isEmpty) || (isNull.isNoOrUnknown && leastUpperType.isDefined))
-    assert(baseValues.forall(_.getClass.getPackage.getName == ("org.opalj.value")))
+    elidedAssert((isNull.isYes && leastUpperType.isEmpty) || (isNull.isNoOrUnknown && leastUpperType.isDefined))
+    elidedAssert(baseValues.forall(_.getClass.getPackage.getName == ("org.opalj.value")))
 
     override final def isArrayValue: Answer = {
         leastUpperType match {

--- a/OPAL/common/src/main/scala/org/opalj/ReleaseFlags.scala
+++ b/OPAL/common/src/main/scala/org/opalj/ReleaseFlags.scala
@@ -1,0 +1,12 @@
+/* BSD 2-Clause License - see OPAL/LICENSE for details. */
+package org.opalj
+
+/**
+ * Defines `inline val`s that control compile-time behavior for production builds. This file is automatically rewritten,
+ * replacing all `false` flags with `true` when compiling non-SNAPSHOT builds.
+ * For now, this determines whether assertions ([[org.opalj.util.elidedAssert]]) are to be elided during compilation.
+ */
+object ReleaseFlags {
+    /** Elide assertions ([[org.opalj.util.elidedAssert]]) during compilation. */
+    inline val elideAssertions = false
+}

--- a/OPAL/common/src/main/scala/org/opalj/collection/immutable/BitArraySet.scala
+++ b/OPAL/common/src/main/scala/org/opalj/collection/immutable/BitArraySet.scala
@@ -5,6 +5,8 @@ package immutable
 
 import java.lang.Integer.toUnsignedLong
 
+import org.opalj.util.elidedAssert
+
 /**
  * An immutable bit set for storing positive int values.
  *
@@ -57,7 +59,7 @@ private[immutable] object BitArraySet0 extends BitArraySet { thisSet =>
 
 private[immutable] final class BitArraySet32(val set: Int) extends BitArraySet { thisSet =>
 
-    assert(set != 0L)
+    elidedAssert(set != 0L)
 
     override def isEmpty: Boolean = false
 
@@ -154,7 +156,7 @@ private[immutable] final class BitArraySet32(val set: Int) extends BitArraySet {
 
 private[immutable] final class BitArraySet64(val set: Long) extends BitArraySet { thisSet =>
 
-    assert(set != 0L)
+    elidedAssert(set != 0L)
 
     override def isEmpty: Boolean = false
 

--- a/OPAL/common/src/main/scala/org/opalj/collection/immutable/IntArraySet.scala
+++ b/OPAL/common/src/main/scala/org/opalj/collection/immutable/IntArraySet.scala
@@ -7,6 +7,8 @@ import java.util.Arrays as JArrays
 import scala.collection.mutable.Builder
 import scala.compiletime.uninitialized
 
+import org.opalj.util.elidedAssert
+
 /**
  * A sorted set of integer values backed by an ordered array to store the values; this
  * guarantees log2(n) lookup.
@@ -136,7 +138,7 @@ case class IntArraySet1(i: Int) extends IntArraySet {
  */
 private[immutable] case class IntArraySet2(i1: Int, i2: Int) extends IntArraySet {
 
-    assert(i1 < i2)
+    elidedAssert(i1 < i2)
 
     override def apply(index: Int): Int = {
         index match {
@@ -222,8 +224,8 @@ private[immutable] case class IntArraySet2(i1: Int, i2: Int) extends IntArraySet
  */
 private[immutable] case class IntArraySet3(i1: Int, i2: Int, i3: Int) extends IntArraySet {
 
-    assert(i1 < i2, s"i1 < i2: $i1 >= $i2")
-    assert(i2 < i3, s"i2 < i3: $i2 >= $i3")
+    elidedAssert(i1 < i2, s"i1 < i2: $i1 >= $i2")
+    elidedAssert(i2 < i3, s"i2 < i3: $i2 >= $i3")
 
     override def apply(index: Int): Int = {
         index match {
@@ -339,7 +341,7 @@ case class IntArraySetN private[immutable] (
     private[immutable] val is: Array[Int]
 ) extends IntArraySet {
 
-    assert(is.length > 3)
+    elidedAssert(is.length > 3)
 
     override def apply(index: Int): Int = is(index)
     override def size: Int = is.length

--- a/OPAL/common/src/main/scala/org/opalj/collection/immutable/IntTrieSet.scala
+++ b/OPAL/common/src/main/scala/org/opalj/collection/immutable/IntTrieSet.scala
@@ -3,6 +3,8 @@ package org.opalj
 package collection
 package immutable
 
+import org.opalj.util.elidedAssert
+
 /**
  * An unordered set of integer values backed by a trie set. The branching is done using
  * the least significant bit and values are only stored in leaf nodes. This ensure that
@@ -659,8 +661,8 @@ private[immutable] final class IntTrieSetN private[immutable] (
     var size:                     Int
 ) extends IntTrieSetNN { intSet =>
 
-    assert(left.size + right.size == size)
-    assert(size > 0) // <= can be "one" at construction time
+    elidedAssert(left.size + right.size == size)
+    elidedAssert(size > 0) // <= can be "one" at construction time
 
     override def hasMultipleElements: Boolean = size > 1
     override def exists(p: Int => Boolean): Boolean = left.exists(p) || right.exists(p)
@@ -761,7 +763,7 @@ private[immutable] final class IntTrieSetN private[immutable] (
      * a cannonical representation.
      */
     override private[immutable] def constringe(): IntTrieSet = {
-        assert(size <= 2)
+        elidedAssert(size <= 2)
         if (left.isEmpty)
             right.constringe()
         else if (right.isEmpty)
@@ -855,7 +857,7 @@ private[immutable] final class IntTrieSetN private[immutable] (
             }
         } else {
             // ...leftSize <= right.size
-            assert(right.nonEmpty)
+            elidedAssert(right.nonEmpty)
             if (right.isSingletonSet) {
                 // left.size \in {0,1}
                 IntRefPair(right.head, left.constringe())
@@ -917,7 +919,7 @@ private[immutable] final class IntTrieSetNJustRight private[immutable] (
     private[immutable] var right: IntTrieSet // can't be empty, left is already empty
 ) extends IntTrieSetNN { intSet =>
 
-    assert(size > 0) // <= can be "one" at construction time
+    elidedAssert(size > 0) // <= can be "one" at construction time
 
     override def hasMultipleElements: Boolean = right.hasMultipleElements
     override def size: Int = right.size
@@ -983,7 +985,7 @@ private[immutable] final class IntTrieSetNJustRight private[immutable] (
      * a cannonical representation.
      */
     override private[immutable] def constringe(): IntTrieSet = {
-        assert(size <= 2)
+        elidedAssert(size <= 2)
         right.constringe()
     }
 
@@ -1047,7 +1049,7 @@ private[immutable] final class IntTrieSetNJustLeft private[immutable] (
     private[immutable] var left: IntTrieSet // cannot be empty; right is empty
 ) extends IntTrieSetNN { intSet =>
 
-    assert(size > 0) // <= can be "one" at construction time
+    elidedAssert(size > 0) // <= can be "one" at construction time
 
     override def size: Int = left.size
     override def hasMultipleElements: Boolean = left.hasMultipleElements
@@ -1113,7 +1115,7 @@ private[immutable] final class IntTrieSetNJustLeft private[immutable] (
      * a cannonical representation.
      */
     override private[immutable] def constringe(): IntTrieSet = {
-        assert(size <= 2)
+        elidedAssert(size <= 2)
         left.constringe()
     }
 
@@ -1203,7 +1205,7 @@ object IntTrieSet {
 
     /** Constructs a new IntTrie from the two distinct(!) values. */
     def from(i1: Int, i2: Int): IntTrieSet = {
-        assert(i1 != i2)
+        elidedAssert(i1 != i2)
         // we have to ensure the same ordering as used when the values are
         // stored in the trie
         if ((Integer.lowestOneBit(i1 ^ i2) & i1) == 0) {

--- a/OPAL/common/src/main/scala/org/opalj/collection/immutable/LongLinkedTrieSet.scala
+++ b/OPAL/common/src/main/scala/org/opalj/collection/immutable/LongLinkedTrieSet.scala
@@ -8,6 +8,8 @@ import scala.annotation.switch
 import java.lang.Integer as JInt
 import java.lang.Long as JLong
 
+import org.opalj.util.elidedAssert
+
 /**
  * An effectively immutable trie set of long values where the elements are sorted based on the
  * insertion order.
@@ -324,7 +326,7 @@ private[immutable] object LongLinkedTrieSetNShared {
 
     def apply(sharedBits: Long, length: Int, n: LongLinkedTrieSetNode): LongLinkedTrieSetNode = {
 
-        assert(length >= 1)
+        elidedAssert(length >= 1)
 
         length match {
             case 1 =>

--- a/OPAL/common/src/main/scala/org/opalj/collection/immutable/LongTrieSet.scala
+++ b/OPAL/common/src/main/scala/org/opalj/collection/immutable/LongTrieSet.scala
@@ -450,7 +450,7 @@ private[immutable] final class LongTrieSetN(
     final val root: LongTrieSetNode
 ) extends LongTrieSet {
 
-    // assert(size >= 4)
+    // elidedAssert(size >= 4)
 
     override def isEmpty: Boolean = false
     override def isSingletonSet: Boolean = false

--- a/OPAL/common/src/main/scala/org/opalj/collection/immutable/LongTrieSetWithList.scala
+++ b/OPAL/common/src/main/scala/org/opalj/collection/immutable/LongTrieSetWithList.scala
@@ -215,7 +215,7 @@ private[immutable] final class LongTrieSetWithListN(
     final val list: Long2List
 ) extends LongTrieSetWithList {
 
-    // assert(size >= 4)
+    // elidedAssert(size >= 4)
 
     override def isEmpty: Boolean = false
     override def isSingletonSet: Boolean = false

--- a/OPAL/common/src/main/scala/org/opalj/collection/immutable/UIDSet.scala
+++ b/OPAL/common/src/main/scala/org/opalj/collection/immutable/UIDSet.scala
@@ -904,7 +904,7 @@ sealed abstract private[immutable] class UIDSetNodeLike[T <: UID] extends NonEmp
     }
 
     private def remove(eId: Int, shiftedEId: Int): UIDSetNodeLike[T] = {
-        // assert( size > 3) // i.e., after removal we still have a tree
+        // elidedAssert( size > 3) // i.e., after removal we still have a tree
         val value = this.value
         if (value.id == eId) {
             dropHead

--- a/OPAL/common/src/main/scala/org/opalj/collection/immutable/UIDTrieSet.scala
+++ b/OPAL/common/src/main/scala/org/opalj/collection/immutable/UIDTrieSet.scala
@@ -455,7 +455,7 @@ private[immutable] final class UIDTrieSetN[T <: UID](
     root:     UIDTrieSetNode[T]
 ) extends UIDTrieSet[T] {
 
-    // assert(size >= 4)
+    // elidedAssert(size >= 4)
 
     override def isEmpty: Boolean = false
     override def nonEmpty: Boolean = true

--- a/OPAL/common/src/main/scala/org/opalj/collection/immutable/UShortPair.scala
+++ b/OPAL/common/src/main/scala/org/opalj/collection/immutable/UShortPair.scala
@@ -3,6 +3,8 @@ package org.opalj
 package collection
 package immutable
 
+import org.opalj.util.elidedAssert
+
 /**
  * A representation of a pair of unsigned short values.
  *
@@ -11,7 +13,6 @@ package immutable
  * scala> val p = org.opalj.collection.immutable.UShortPair(2323,332)
  * p: org.opalj.collection.immutable.UShortPair = UShortPair(2323,332)
  * }}}
- *
  * @author Michael Eichberg
  */
 final class UShortPair private (val pair: Int) extends AnyVal {
@@ -33,8 +34,8 @@ final class UShortPair private (val pair: Int) extends AnyVal {
 object UShortPair {
 
     def apply(a: UShort, b: UShort): UShortPair = {
-        assert(a >= UShort.MinValue && a <= UShort.MaxValue)
-        assert(b >= UShort.MinValue && b <= UShort.MaxValue)
+        elidedAssert(a >= UShort.MinValue && a <= UShort.MaxValue)
+        elidedAssert(b >= UShort.MinValue && b <= UShort.MaxValue)
 
         new UShortPair(a | b << 16)
     }

--- a/OPAL/common/src/main/scala/org/opalj/collection/mutable/ArrayMap.scala
+++ b/OPAL/common/src/main/scala/org/opalj/collection/mutable/ArrayMap.scala
@@ -8,6 +8,8 @@ import scala.reflect.ClassTag
 import java.util.Arrays
 import scala.collection.AbstractIterator
 
+import org.opalj.util.elidedAssert
+
 /**
  * Conceptually, a map where the (implicit) keys are positive `Int` values and the values are
  * non-`null`; `null` values are not permitted!
@@ -87,7 +89,7 @@ class ArrayMap[T >: Null <: AnyRef: ClassTag] private (private var data: Array[T
      */
     @throws[IndexOutOfBoundsException]("if the key is negative")
     final def update(key: Int, value: T): Unit = {
-        assert(value ne null, "ArrayMap only supports non-null values")
+        elidedAssert(value ne null, "ArrayMap only supports non-null values")
         val data = this.data
         val max = data.length
         if (key < max) {

--- a/OPAL/common/src/main/scala/org/opalj/collection/mutable/FixedSizeBitSet.scala
+++ b/OPAL/common/src/main/scala/org/opalj/collection/mutable/FixedSizeBitSet.scala
@@ -3,7 +3,7 @@ package org.opalj
 package collection
 package mutable
 
-import java.io.Serializable
+import org.opalj.util.elidedAssert
 
 /**
  * A bit set with a given upper bound for the largest value that can be stored in the set.
@@ -178,7 +178,7 @@ private[mutable] final class FixedSizeBitSetN private[mutable] (
     private val set: Array[Long]
 ) extends FixedSizeBitSet { thisSet =>
 
-    assert(set.length > 2)
+    elidedAssert(set.length > 2)
 
     override def isEmpty: Boolean = {
         val set = this.set

--- a/OPAL/common/src/main/scala/org/opalj/concurrent/Locking.scala
+++ b/OPAL/common/src/main/scala/org/opalj/concurrent/Locking.scala
@@ -7,6 +7,8 @@ import java.util.concurrent.locks.ReentrantLock
 import java.util.concurrent.locks.ReentrantReadWriteLock
 import java.util.concurrent.locks.ReentrantReadWriteLock.WriteLock
 
+import org.opalj.util.elidedAssert
+
 /**
  * A basic facility to model shared and exclusive access to some functionality/data structure.
  *
@@ -78,7 +80,7 @@ object Locking {
                 }
             }
 
-        assert(allLocked || (error ne null))
+        elidedAssert(allLocked || (error ne null))
 
         try {
             if (allLocked) {

--- a/OPAL/common/src/main/scala/org/opalj/graphs/AbstractDominatorTree.scala
+++ b/OPAL/common/src/main/scala/org/opalj/graphs/AbstractDominatorTree.scala
@@ -6,6 +6,8 @@ import scala.annotation.tailrec
 
 import scala.collection.immutable.ArraySeq
 
+import org.opalj.util.elidedAssert
+
 /**
  * Representation of a (post) dominator tree of, for example, a control flow graph.
  * To construct a '''(post)dominator tree''' use the companion objects' factory methods (`apply`).
@@ -50,7 +52,7 @@ abstract class AbstractDominatorTree {
 
     final def maxNode: Int = idom.length - 1
 
-    assert(startNode <= maxNode, s"start node ($startNode) out of range ([0,$maxNode])")
+    elidedAssert(startNode <= maxNode, s"start node ($startNode) out of range ([0,$maxNode])")
 
     /**
      * Returns the immediate dominator of the node with the given id.

--- a/OPAL/common/src/main/scala/org/opalj/graphs/package.scala
+++ b/OPAL/common/src/main/scala/org/opalj/graphs/package.scala
@@ -6,6 +6,7 @@ import scala.collection.mutable.ArrayBuffer
 
 import org.opalj.collection.IntIterator
 import org.opalj.collection.mutable.IntArrayStack
+import org.opalj.util.elidedAssert
 
 /**
  * This package defines graph algorithms as well as factory methods to describe and compute graphs
@@ -246,7 +247,7 @@ package object graphs {
                     if (path.nonEmpty) {
                         val nDFSNum = dfsNum(n)
                         val cSCCDFSNum = dfsNum(path.last)
-                        assert(cSCCDFSNum != ProcessedNodeNum)
+                        elidedAssert(cSCCDFSNum != ProcessedNodeNum)
 
                         if (nDFSNum != cSCCDFSNum) {
                             // This is the trivial case... obviously the end of the path is a
@@ -313,7 +314,7 @@ package object graphs {
                     }
                 }
             }
-            assert(path.isEmpty)
+            elidedAssert(path.isEmpty)
         }
 
         ns.foreach(n => if (!hasDFSNum(n)) dfs(n))
@@ -362,7 +363,7 @@ package object graphs {
     ): List[Iterable[N]] = {
         /* The following is not a strict requirement, more an expectation (however, (c)sccs
      * not reachable from a node in ns will not be detected!
-        assert(
+        elidedAssert(
             { val allNodes = ns.toSet; allNodes.forall { n => es(n).forall(allNodes.contains) } },
             "the graph references nodes which are not in the set of all nodes"
         )
@@ -403,7 +404,7 @@ package object graphs {
 
             // HELPER METHODS
             def addToPath(n: N): Int = {
-                assert(!hasDFSNum(n))
+                elidedAssert(!hasDFSNum(n))
                 val dfsNum = nextDFSNum
                 setDFSNum(n, dfsNum)
                 path += n
@@ -448,7 +449,7 @@ package object graphs {
 
                             case someCSCCId =>
                                 /*nothing to do*/
-                                assert(
+                                elidedAssert(
                                     // nDFSNum == 0 ???
                                     nDFSNum == initialDFSNum || someCSCCId == cSCCId(path.last),
                                     s"nDFSNum=$nDFSNum; nCSCCId=$nCSCCId; "+

--- a/OPAL/common/src/main/scala/org/opalj/log/OPALLogger.scala
+++ b/OPAL/common/src/main/scala/org/opalj/log/OPALLogger.scala
@@ -2,6 +2,8 @@
 package org.opalj
 package log
 
+import org.opalj.util.elidedAssert
+
 /**
  * Facilitates the logging of messages that are relevant for the end user.
  *
@@ -11,7 +13,6 @@ package log
  * @note   The OPALLogger framework is not intended to be used by developers to help
  *         debug analysis; it is intended to be used to inform (end)-users about the
  *         analysis progress.
- *
  * @author Michael Eichberg
  */
 trait OPALLogger {
@@ -71,8 +72,8 @@ object OPALLogger extends OPALLogger {
 
     def updateLogger(ctx: LogContext, logger: OPALLogger): Unit = this.synchronized {
         val id = ctx.id
-        assert(id != -1, "context is not yet registered")
-        assert(id != -2, "context is already unregistered")
+        elidedAssert(id != -1, "context is not yet registered")
+        elidedAssert(id != -2, "context is already unregistered")
         loggers(id) = logger
     }
 

--- a/OPAL/common/src/main/scala/org/opalj/package.scala
+++ b/OPAL/common/src/main/scala/org/opalj/package.scala
@@ -9,6 +9,7 @@ import com.typesafe.config.ConfigFactory
 import org.opalj.log.GlobalLogContext
 import org.opalj.log.LogContext
 import org.opalj.log.OPALLogger
+import org.opalj.util.elidedAssert
 
 /**
  * OPAL is a Scala-based framework for the static analysis, manipulation and creation of
@@ -74,7 +75,7 @@ package object opalj {
         implicit val logContext: LogContext = GlobalLogContext
         import OPALLogger.info
         try {
-            assert(false)
+            elidedAssert(false)
             // when we reach this point assertions are turned off
             info("OPAL Common", "Production Build")
         } catch {

--- a/OPAL/common/src/main/scala/org/opalj/util/package.scala
+++ b/OPAL/common/src/main/scala/org/opalj/util/package.scala
@@ -12,6 +12,7 @@ import scala.util.Using
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigRenderOptions
 
+import org.opalj.ReleaseFlags.elideAssertions
 import org.opalj.log.GlobalLogContext
 import org.opalj.log.LogContext
 import org.opalj.log.OPALLogger
@@ -136,6 +137,22 @@ package object util {
                 error(category, "Reflected object is invalid", cce)
                 None
         }
+    }
+
+    /**
+     * Assertion that is elided in production builds, controlled by [[ReleaseFlags.elideAssertions]] which is
+     * automatically rewritten for non-SNAPSHOT builds.
+     */
+    inline def elidedAssert(inline assertion: => Boolean): Unit = {
+        inline if (!elideAssertions) assert(assertion)
+    }
+
+    /**
+     * Assertion that is elided in production builds, controlled by [[ReleaseFlags.elideAssertions]] which is
+     * automatically rewritten for non-SNAPSHOT builds.
+     */
+    inline def elidedAssert(inline assertion: => Boolean, inline message: String): Unit = {
+        inline if (!elideAssertions) assert(assertion, message)
     }
 
 }

--- a/OPAL/common/src/test/scala/org/opalj/collection/immutable/Long2ListEval.scala
+++ b/OPAL/common/src/test/scala/org/opalj/collection/immutable/Long2ListEval.scala
@@ -4,6 +4,7 @@ package collection
 package immutable
 
 import org.opalj.util.PerformanceEvaluation
+import org.opalj.util.elidedAssert
 
 object Long2ListEval extends App {
 
@@ -41,7 +42,7 @@ object Long2ListEval extends App {
                 l.iterator.sum
             } { t => println(s"iterator sum took ${t.toSeconds}") }
 
-        assert(sumForeach == sumIterator)
+        elidedAssert(sumForeach == sumIterator)
         println(s"summarized value: ${sumIterator}")
     }
 

--- a/OPAL/da/src/main/scala/org/opalj/da/ClassFile.scala
+++ b/OPAL/da/src/main/scala/org/opalj/da/ClassFile.scala
@@ -13,6 +13,7 @@ import org.opalj.bi.ACC_PUBLIC
 import org.opalj.bi.ACC_SUPER
 import org.opalj.bi.AccessFlags
 import org.opalj.io.process
+import org.opalj.util.elidedAssert
 
 /**
  * @author Michael Eichberg
@@ -34,7 +35,7 @@ case class ClassFile(
     attributes:    Attributes = NoAttributes
 ) {
 
-    assert({
+    elidedAssert({
         val cp0 = constant_pool(0)
         (cp0 eq null) || cp0.isInstanceOf[mutable.Buffer[?]] && cp0.asInstanceOf[mutable.Buffer[?]].headOption.forall(
             _.isInstanceOf[? => ?]

--- a/OPAL/da/src/main/scala/org/opalj/da/Code.scala
+++ b/OPAL/da/src/main/scala/org/opalj/da/Code.scala
@@ -8,6 +8,7 @@ import scala.xml.Text
 import scala.xml.Unparsed
 
 import org.opalj.control.repeat
+import org.opalj.util.elidedAssert
 
 /**
  * @author Wael Alkhatib
@@ -17,7 +18,7 @@ import org.opalj.control.repeat
  */
 case class Code(instructions: Array[Byte]) {
 
-    assert(instructions.length > 0)
+    elidedAssert(instructions.length > 0)
 
     import Code.id
 

--- a/OPAL/da/src/main/scala/org/opalj/da/TypeInfo.scala
+++ b/OPAL/da/src/main/scala/org/opalj/da/TypeInfo.scala
@@ -4,6 +4,8 @@ package da
 
 import scala.xml.Node
 
+import org.opalj.util.elidedAssert
+
 /**
  * Encapsulates basic type information.
  *
@@ -67,7 +69,7 @@ case object DoubleTypeInfo extends PrimitiveTypeInfo("double")
 
 case class ClassTypeInfo(asJava: String) extends FieldTypeInfo {
 
-    assert(asJava.indexOf('/') == -1)
+    elidedAssert(asJava.indexOf('/') == -1)
 
     def asJVMType: String = asJava.replace('.', '/')
 
@@ -84,7 +86,7 @@ case class ArrayTypeInfo(
     elementTypeIsBaseType: Boolean
 ) extends FieldTypeInfo {
 
-    assert(dimensions > 0)
+    elidedAssert(dimensions > 0)
 
     def asJava: String = elementTypeAsJava + ("[]" * dimensions)
 

--- a/OPAL/ide/src/main/scala/org/opalj/ide/package.scala
+++ b/OPAL/ide/src/main/scala/org/opalj/ide/package.scala
@@ -7,6 +7,7 @@ import com.typesafe.config.ConfigFactory
 import org.opalj.log.GlobalLogContext
 import org.opalj.log.LogContext
 import org.opalj.log.OPALLogger.info
+import org.opalj.util.elidedAssert
 
 /**
  * @author Robin Körkemeier
@@ -18,7 +19,7 @@ package object ide {
     {
         implicit val logContext: LogContext = GlobalLogContext
         try {
-            assert(false) // <= test whether assertions are turned on or off...
+            elidedAssert(false) // <= test whether assertions are turned on or off...
             info(FrameworkName, "Production Build")
         } catch {
             case _: AssertionError => info(FrameworkName, "Development Build with Assertions")

--- a/OPAL/ifds/src/main/scala/org/opalj/ifds/package.scala
+++ b/OPAL/ifds/src/main/scala/org/opalj/ifds/package.scala
@@ -7,6 +7,7 @@ import com.typesafe.config.ConfigFactory
 import org.opalj.log.GlobalLogContext
 import org.opalj.log.LogContext
 import org.opalj.log.OPALLogger.info
+import org.opalj.util.elidedAssert
 
 package object ifds {
 
@@ -15,7 +16,7 @@ package object ifds {
     {
         implicit val logContext: LogContext = GlobalLogContext
         try {
-            assert(false) // <= test whether assertions are turned on or off...
+            elidedAssert(false) // <= test whether assertions are turned on or off...
             info(FrameworkName, "Production Build")
         } catch {
             case _: AssertionError => info(FrameworkName, "Development Build with Assertions")

--- a/OPAL/si/src/main/scala/org/opalj/fpcf/EOptionP.scala
+++ b/OPAL/si/src/main/scala/org/opalj/fpcf/EOptionP.scala
@@ -2,6 +2,8 @@
 package org.opalj
 package fpcf
 
+import org.opalj.util.elidedAssert
+
 /**
  * An entity associated with the current extension of a property or `None` if no (preliminary)
  * property is already computed.
@@ -538,8 +540,8 @@ final class InterimELUBP[+E <: Entity, +P <: Property](
     val ub: P
 ) extends InterimEP[E, P] {
 
-    assert(lb != null)
-    assert(ub != null)
+    elidedAssert(lb != null)
+    elidedAssert(ub != null)
 
     if (PropertyStore.Debug && lb /*or ub*/ .isOrderedProperty) {
         val ubAsOP = ub.asOrderedProperty
@@ -578,7 +580,7 @@ final class InterimELUBP[+E <: Entity, +P <: Property](
 object InterimELUBP {
 
     def apply[E <: Entity, P <: Property](e: E, lb: P, ub: P): InterimELUBP[E, P] = {
-        assert(lb ne ub)
+        elidedAssert(lb ne ub)
         new InterimELUBP(e, lb, ub)
     }
 
@@ -599,7 +601,7 @@ final class InterimEUBP[+E <: Entity, +P <: Property](
     val ub: P
 ) extends InterimEP[E, P] {
 
-    assert(ub != null)
+    elidedAssert(ub != null)
 
     override lazy val pk: PropertyKey[P] = ub.key.asInstanceOf[PropertyKey[P]]
 
@@ -715,7 +717,7 @@ final class InterimELBP[+E <: Entity, +P <: Property](
     val lb: P
 ) extends InterimEP[E, P] {
 
-    assert(lb != null)
+    elidedAssert(lb != null)
 
     override lazy val pk: PropertyKey[P] = lb.key.asInstanceOf[PropertyKey[P]]
 

--- a/OPAL/si/src/main/scala/org/opalj/fpcf/PropertyComputationResult.scala
+++ b/OPAL/si/src/main/scala/org/opalj/fpcf/PropertyComputationResult.scala
@@ -3,6 +3,7 @@ package org.opalj
 package fpcf
 
 import org.opalj.collection.ForeachRefIterator
+import org.opalj.util.elidedAssert
 
 /**
  * Encapsulates the (intermediate) result of the computation of a property.
@@ -397,7 +398,7 @@ case class InterimPartialResult[SE >: Null <: Property](
     c:         OnUpdateContinuation
 ) extends ProperPropertyComputationResult {
 
-    assert(dependees.nonEmpty)
+    elidedAssert(dependees.nonEmpty)
 
     override private[fpcf] def isInterimPartialResult: Boolean = true
     override private[fpcf] def asInterimPartialResult: InterimPartialResult[SE] = this

--- a/OPAL/si/src/main/scala/org/opalj/fpcf/Schedule.scala
+++ b/OPAL/si/src/main/scala/org/opalj/fpcf/Schedule.scala
@@ -5,6 +5,7 @@ package fpcf
 import org.opalj.log.LogContext
 import org.opalj.log.OPALLogger.info
 import org.opalj.util.PerformanceEvaluation.time
+import org.opalj.util.elidedAssert
 
 /**
  * Encapsulates a computed schedule and enables the execution of it. Primarily takes care
@@ -54,7 +55,7 @@ case class Schedule[A](
             time {
                 ps.setupPhase(configuration)
                 afterPhaseSetup(configuration)
-                assert(ps.isIdle, "the property store is not idle after phase setup")
+                elidedAssert(ps.isIdle, "the property store is not idle after phase setup")
 
                 var executedAnalyses: List[(ComputationSpecification[A], A)] = Nil
 
@@ -71,13 +72,13 @@ case class Schedule[A](
                 afterPhaseScheduling(css)
 
                 ps.waitOnPhaseCompletion()
-                assert(ps.isIdle, "the property store is not idle after phase completion")
+                elidedAssert(ps.isIdle, "the property store is not idle after phase completion")
 
                 executedAnalyses.foreach { csAnalysis =>
                     val (cs, a) = csAnalysis
                     cs.afterPhaseCompletion(ps, a)
                 }
-                assert(ps.isIdle, "the property store is not idle after phase completion")
+                elidedAssert(ps.isIdle, "the property store is not idle after phase completion")
                 allExecutedAnalyses :::= executedAnalyses.reverse
             } { t =>
                 if (trace)

--- a/OPAL/si/src/main/scala/org/opalj/fpcf/package.scala
+++ b/OPAL/si/src/main/scala/org/opalj/fpcf/package.scala
@@ -4,6 +4,7 @@ package org.opalj
 import org.opalj.log.GlobalLogContext
 import org.opalj.log.LogContext
 import org.opalj.log.OPALLogger.info
+import org.opalj.util.elidedAssert
 
 /**
  * The fixpoint computations framework (`fpcf`) is a general framework to perform fixpoint
@@ -47,7 +48,7 @@ package object fpcf {
         // Log the information whether a production build or a development build is used.
         implicit val logContext: LogContext = GlobalLogContext
         try {
-            assert(false)
+            elidedAssert(false)
             // when we reach this point assertions are turned off
             info(FrameworkName, "Production Build")
         } catch {

--- a/OPAL/si/src/main/scala/org/opalj/fpcf/par/PKECPropertyStore.scala
+++ b/OPAL/si/src/main/scala/org/opalj/fpcf/par/PKECPropertyStore.scala
@@ -17,6 +17,7 @@ import com.typesafe.config.Config
 import org.opalj.control.foreachWithIndex
 import org.opalj.fpcf.PropertyKey.fallbackPropertyBasedOnPKId
 import org.opalj.log.LogContext
+import org.opalj.util.elidedAssert
 
 /**
  * Yet another parallel property store.
@@ -217,7 +218,7 @@ class PKECPropertyStore(
                 case epkState =>
                     pc(epkState.eOptP.asInstanceOf[EOptionP[E, P]])
             }
-        assert(newInterimEP.isRefinable)
+        elidedAssert(newInterimEP.isRefinable)
         val newEPKState = EPKState(newInterimEP, null, null)
         propertiesOfKind.put(e, newEPKState)
     }
@@ -849,7 +850,7 @@ case class EPKState(
             } else {
                 updateComputation(theEOptP) match {
                     case Some(interimEP) =>
-                        if (ps.debug) assert(eOptP != interimEP)
+                        if (ps.debug) elidedAssert(eOptP != interimEP)
                         dependers.synchronized {
                             eOptP = interimEP
                             notifyAndClearDependers(theEOptP, dependers)

--- a/OPAL/si/src/main/scala/org/opalj/fpcf/seq/PKESequentialPropertyStore.scala
+++ b/OPAL/si/src/main/scala/org/opalj/fpcf/seq/PKESequentialPropertyStore.scala
@@ -16,6 +16,7 @@ import org.opalj.fpcf.PropertyKind.SupportedPropertyKinds
 import org.opalj.log.LogContext
 import org.opalj.log.OPALLogger.debug as trace
 import org.opalj.log.OPALLogger.info
+import org.opalj.util.elidedAssert
 
 /**
  * A reasonably optimized, complete, but non-concurrent implementation of the property store.
@@ -181,7 +182,7 @@ final class PKESequentialPropertyStore protected (
     override def entities[P <: Property](lb: P, ub: P): Iterator[Entity] = {
         require(lb ne null)
         require(ub ne null)
-        assert(lb.key == ub.key)
+        elidedAssert(lb.key == ub.key)
         for { case ELUBP(e, `lb`, `ub`) <- ps(lb.id).valuesIterator } yield { e }
     }
 
@@ -652,7 +653,7 @@ final class PKESequentialPropertyStore protected (
                 } else {
                     // There was an update and we already scheduled the computation... hence,
                     // we have no live dependees any more.
-                    assert(newDependees == null || newDependees.isEmpty)
+                    elidedAssert(newDependees == null || newDependees.isEmpty)
                 }
 
             case InterimResult.id =>
@@ -665,8 +666,8 @@ final class PKESequentialPropertyStore protected (
                 val (newEPS, newDependees, newC) =
                     processDependeesOfInterimResult(eps, dependees, c)
 
-                assert(newEPS.e == eps.e)
-                assert(newEPS.pk == eps.pk)
+                elidedAssert(newEPS.e == eps.e)
+                elidedAssert(newEPS.pk == eps.pk)
 
                 // 2. update the value and trigger dependers/clear old dependees;
                 update(newEPS, newDependees)

--- a/OPAL/tac/src/main/scala/org/opalj/tac/DUVar.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/DUVar.scala
@@ -13,6 +13,7 @@ import org.opalj.br.PDUVar
 import org.opalj.br.PDVar
 import org.opalj.br.PUVar
 import org.opalj.collection.immutable.IntTrieSet
+import org.opalj.util.elidedAssert
 import org.opalj.value.ValueInformation
 
 /**
@@ -120,7 +121,7 @@ class DVar[+Value <: ValueInformation /*org.opalj.ai.ValuesDomain#DomainValue*/ 
     private[tac] var useSites: IntTrieSet
 ) extends DUVar[Value] {
 
-    assert(origin >= 0)
+    elidedAssert(origin >= 0)
 
     def copy[V >: Value <: ValueInformation /*org.opalj.ai.ValuesDomain#DomainValue*/ ](
         origin:   ValueOrigin = this.origin,
@@ -157,7 +158,7 @@ class DVar[+Value <: ValueInformation /*org.opalj.ai.ValuesDomain#DomainValue*/ 
         pcToIndex:                    Array[Int],
         isIndexOfCaughtExceptionStmt: Int => Boolean
     ): Unit = {
-        assert(
+        elidedAssert(
             origin >= 0,
             s"DVars are not intended to be used to model parameters/exceptions (origin=$origin)"
         )
@@ -213,9 +214,9 @@ object DVar {
         useSites: IntTrieSet
     ): DVar[d.DomainValue] = {
 
-        assert(useSites != null, s"no uses (null) for $origin: $value")
-        assert(value != null)
-        assert(
+        elidedAssert(useSites != null, s"no uses (null) for $origin: $value")
+        elidedAssert(value != null)
+        elidedAssert(
             value == d.TheIllegalValue || value.computationalType != ComputationalTypeReturnAddress,
             s"value has unexpected computational type: $value"
         )

--- a/OPAL/tac/src/main/scala/org/opalj/tac/Expr.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/Expr.scala
@@ -25,6 +25,7 @@ import org.opalj.br.PC
 import org.opalj.br.ReferenceType
 import org.opalj.br.Type
 import org.opalj.br.analyses.ProjectLike
+import org.opalj.util.elidedAssert
 import org.opalj.value.ValueInformation
 
 /**
@@ -610,7 +611,7 @@ case class ArrayLength[+V](pc: PC, arrayRef: Expr[V]) extends ArrayExpr[V] {
     override final def astID: Int = ArrayLength.ASTID
     override final def cTpe: ComputationalType = ComputationalTypeInt
 
-    override final def isSideEffectFree: Boolean = { assert(arrayRef.isVar); false /* potential NPE */ }
+    override final def isSideEffectFree: Boolean = { elidedAssert(arrayRef.isVar); false /* potential NPE */ }
 
     override final def subExprCount: Int = 1
     override final def subExpr(index: Int): Expr[V] = arrayRef
@@ -681,7 +682,7 @@ case class GetField[+V](
     }
 
     final def isSideEffectFree: Boolean = {
-        assert(objRef.isValueExpression)
+        elidedAssert(objRef.isValueExpression)
         // IMPROVE if the access is non-null, it is side-effect free
         false
     }

--- a/OPAL/tac/src/main/scala/org/opalj/tac/Stmt.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/Stmt.scala
@@ -8,6 +8,7 @@ import org.opalj.br.*
 import org.opalj.br.analyses.ProjectLike
 import org.opalj.collection.immutable.IntIntPair
 import org.opalj.collection.immutable.IntTrieSet
+import org.opalj.util.elidedAssert
 import org.opalj.value.ValueInformation
 
 /**
@@ -148,7 +149,7 @@ case class If[+V](
     }
 
     override final def isSideEffectFree: Boolean = {
-        assert(left.isValueExpression && right.isValueExpression)
+        elidedAssert(left.isValueExpression && right.isValueExpression)
         true
     }
 
@@ -310,7 +311,7 @@ case class Switch[+V](
     ): Unit = {
         npairs = npairs.map { x =>
             val newIndex = pcToIndex(x._2)
-            // assert(newIndex >= 0)
+            // elidedAssert(newIndex >= 0)
             x.copy(_2 = newIndex)
         }
         defaultTarget = pcToIndex(defaultTarget)
@@ -324,7 +325,7 @@ case class Switch[+V](
     }
 
     override final def isSideEffectFree: Boolean = {
-        assert(index.isValueExpression)
+        elidedAssert(index.isValueExpression)
         true
     }
 
@@ -1051,7 +1052,7 @@ case class ExprStmt[+V](pc: Int, expr: Expr[V]) extends AssignmentLikeStmt[V] {
     }
 
     override final def isSideEffectFree: Boolean = {
-        assert(
+        elidedAssert(
             !expr.isSideEffectFree,
             "useless ExprStmt - the referenced expression is side-effect free"
         )

--- a/OPAL/tac/src/main/scala/org/opalj/tac/TACAI.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/TACAI.scala
@@ -35,6 +35,7 @@ import org.opalj.bytecode.BytecodeProcessingFailedException
 import org.opalj.collection.immutable.IntIntPair
 import org.opalj.collection.immutable.IntTrieSet
 import org.opalj.tac.JSR
+import org.opalj.util.elidedAssert
 
 /**
  * Factory to convert the bytecode of a method into a three address representation using the
@@ -358,7 +359,7 @@ object TACAI {
             ): Unit = {
                 val usedBy = domain.usedBy(pc)
                 if (usedBy ne null) {
-                    // assert(usedBy.forall(_ >= 0)) // internal consistency only
+                    // elidedAssert(usedBy.forall(_ >= 0)) // internal consistency only
                     val localVal = DVar(aiResult.domain)(pc, v, usedBy)
                     addStmt(Assignment(pc, localVal, expr))
                 } else if (expr.isSideEffectFree) {
@@ -519,7 +520,7 @@ object TACAI {
                         addNOPAndKillOperandBasedUsages(2)
                     } else {
                         // This "if" is just a goto...
-                        assert(targetPC != nextPC)
+                        elidedAssert(targetPC != nextPC)
                         killOperandBasedUsages(pc, 2)
                         addStmt(Goto(pc, targetPC))
                     }
@@ -551,7 +552,7 @@ object TACAI {
                         addNOPAndKillOperandBasedUsages(1)
                     } else {
                         // This "if" is just a goto...
-                        assert(targetPC != nextPC)
+                        elidedAssert(targetPC != nextPC)
                         killOperandBasedUsages(pc, 1)
                         addStmt(Goto(pc, targetPC))
                     }

--- a/OPAL/tac/src/main/scala/org/opalj/tac/TACNaive.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/TACNaive.scala
@@ -16,6 +16,7 @@ import org.opalj.collection.immutable.IntIntPair
 import org.opalj.collection.immutable.IntTrieSet
 import org.opalj.collection.mutable.FixedSizeBitSet
 import org.opalj.tac.JSR
+import org.opalj.util.elidedAssert
 
 /**
  * Converts the bytecode of a method into a three address representation using a very naive
@@ -910,7 +911,7 @@ object TACNaive {
                     newEndIndex += 1
                 }
             }
-            assert(newStartIndex < newEndIndex, s"old: $oldEH => [$newStartIndex,$newEndIndex]")
+            elidedAssert(newStartIndex < newEndIndex, s"old: $oldEH => [$newStartIndex,$newEndIndex]")
             (newStartIndex, newEndIndex)
         }
 
@@ -941,7 +942,7 @@ object TACNaive {
                     endPC = newEndIndex,
                     handlerPC = newIndexes(old.handlerPC)
                 )
-                assert(
+                elidedAssert(
                     newEH.startPC <= newEH.endPC,
                     s"startPC=${old.startPC} => ${newEH.startPC};endPC=${old.endPC} => ${newEH.endPC}"
                 )

--- a/OPAL/tac/src/main/scala/org/opalj/tac/ToTxt.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/ToTxt.scala
@@ -14,6 +14,7 @@ import org.opalj.br.cfg.CatchNode
 import org.opalj.br.cfg.CFG
 import org.opalj.br.cfg.ExitNode
 import org.opalj.br.cfg.cfgNodeOrdering
+import org.opalj.util.elidedAssert
 
 /**
  * Converts a list of three-address instructions into a text-based representation for comprehension
@@ -257,7 +258,7 @@ object ToTxt {
             def catchTypeToString(t: Option[Type]): String = t.map(_.toJava).getOrElse("<FINALLY>")
 
             val bb = cfg.bb(index)
-            assert(
+            elidedAssert(
                 bb ne null,
                 s"index: $index; max: $max; catchNodes:${cfg.catchNodes.mkString("{", ", ", "}")}"
             )

--- a/OPAL/tac/src/main/scala/org/opalj/tac/cg/CallGraph.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/cg/CallGraph.scala
@@ -11,6 +11,7 @@ import org.opalj.br.fpcf.properties.cg.NoCallers
 import org.opalj.fpcf.EUBP
 import org.opalj.fpcf.PropertyStore
 import org.opalj.tac.fpcf.analyses.cg.TypeIterator
+import org.opalj.util.elidedAssert
 
 /**
  * The proxy class for all call-graph related properties.
@@ -22,8 +23,8 @@ import org.opalj.tac.fpcf.analyses.cg.TypeIterator
  * @author Florian Kuebler
  */
 class CallGraph private[cg] ()(implicit ps: PropertyStore, typeIterator: TypeIterator) {
-    assert(ps.entities(_.pk == Callees.key).forall(ps(_, Callees.key).isFinal))
-    assert(ps.entities(_.pk == Callers.key).forall(ps(_, Callers.key).isFinal))
+    elidedAssert(ps.entities(_.pk == Callees.key).forall(ps(_, Callees.key).isFinal))
+    elidedAssert(ps.entities(_.pk == Callers.key).forall(ps(_, Callers.key).isFinal))
 
     def calleesOf(m: DeclaredMethod, pc: Int): Iterator[Context] = {
         val callees = ps(m, Callees.key).ub

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/APIBasedAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/APIBasedAnalysis.scala
@@ -17,6 +17,7 @@ import org.opalj.fpcf.ProperPropertyComputationResult
 import org.opalj.fpcf.Results
 import org.opalj.fpcf.SomeEOptionP
 import org.opalj.tac.fpcf.analyses.cg.ContextualAnalysis
+import org.opalj.util.elidedAssert
 
 /**
  * A trait for analyses that model the result of the invocation of a specific
@@ -64,7 +65,7 @@ trait APIBasedAnalysis extends FPCFAnalysis with ContextualAnalysis {
                                 val caller = callerContext.method
 
                                 // the call graph is only computed for virtual and single defined methods
-                                assert(caller.isVirtualOrHasSingleDefinedMethod)
+                                elidedAssert(caller.isVirtualOrHasSingleDefinedMethod)
 
                                 // we can not analyze virtual methods, as we do not have their bytecode
                                 if (caller.hasSingleDefinedMethod) {

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/TACAIBasedAnalysisState.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/TACAIBasedAnalysisState.scala
@@ -11,6 +11,7 @@ import org.opalj.fpcf.SomeEOptionP
 import org.opalj.tac.fpcf.analyses.cg.AnalysisState
 import org.opalj.tac.fpcf.analyses.cg.ContextualAnalysis
 import org.opalj.tac.fpcf.properties.TACAI
+import org.opalj.util.elidedAssert
 import org.opalj.value.ValueInformation
 
 /**
@@ -26,7 +27,7 @@ trait TACAIBasedAnalysisState[TheContextType <: Context]
     def callContext: ContextType
 
     protected var _tacDependee: EOptionP[Method, TACAI]
-    assert(_tacDependee != null && _tacDependee.hasUBP)
+    elidedAssert(_tacDependee != null && _tacDependee.hasUBP)
 
     abstract override def hasOpenDependencies: Boolean = _tacDependee.isRefinable || super.hasOpenDependencies
     final def isTACDependeeRefinable: Boolean = _tacDependee.isRefinable

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/FinalizerAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/FinalizerAnalysis.scala
@@ -28,6 +28,7 @@ import org.opalj.fpcf.PropertyComputationResult
 import org.opalj.fpcf.PropertyKind
 import org.opalj.fpcf.PropertyStore
 import org.opalj.fpcf.Results
+import org.opalj.util.elidedAssert
 
 /**
  * Computes the set of finalize methods that are being called by the VM during the execution of the
@@ -67,7 +68,7 @@ class FinalizerAnalysis private[analyses] (final val project: SomeProject) exten
             "finalize",
             MethodDescriptor.NoArgsAndReturnVoid
         )
-        assert(finalizers.size < 2)
+        elidedAssert(finalizers.size < 2)
 
         val r = finalizers.map { finalizerMethod =>
             val finalizer = declaredMethods(finalizerMethod)

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/LoadedClassesAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/LoadedClassesAnalysis.scala
@@ -33,6 +33,7 @@ import org.opalj.fpcf.PropertyStore
 import org.opalj.fpcf.SomeEPS
 import org.opalj.fpcf.UBP
 import org.opalj.tac.fpcf.properties.TACAI
+import org.opalj.util.elidedAssert
 
 /**
  * For a reachable methods (see [[Callers]]) this class computes the
@@ -131,7 +132,7 @@ class LoadedClassesAnalysis(
         declaredMethod: DeclaredMethod,
         tacaiEP:        EPS[Method, TACAI]
     ): PropertyComputationResult = {
-        assert(tacaiEP.hasUBP && tacaiEP.ub.tac.isDefined)
+        elidedAssert(tacaiEP.hasUBP && tacaiEP.ub.tac.isDefined)
 
         // the method has callers. we have to analyze it
         val newLoadedClasses =

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/ThreadRelatedCallsAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/ThreadRelatedCallsAnalysis.scala
@@ -35,6 +35,7 @@ import org.opalj.fpcf.SomeEPS
 import org.opalj.tac.cg.TypeIteratorKey
 import org.opalj.tac.fpcf.properties.TACAI
 import org.opalj.tac.fpcf.properties.TheTACAI
+import org.opalj.util.elidedAssert
 import org.opalj.value.IsReferenceValue
 
 class ThreadStartAnalysisResults extends IndirectCalls with VMReachableMethodsBase
@@ -448,7 +449,7 @@ class ThreadStartAnalysis private[cg] (
                 ThreadRelatedCallsAnalysisScheduler.uncaughtExceptionDescriptor
             )
 
-            assert(!declTgt.hasSingleDefinedMethod)
+            elidedAssert(!declTgt.hasSingleDefinedMethod)
 
             vmReachableMethods.addIncompleteCallSite(callPC)
             vmReachableMethods.addVMReachableMethod(declTgt)
@@ -616,7 +617,7 @@ class UncaughtExceptionHandlerAnalysis private[analyses] (
                 ThreadRelatedCallsAnalysisScheduler.uncaughtExceptionDescriptor
             )
 
-            assert(!declTgt.hasSingleDefinedMethod)
+            elidedAssert(!declTgt.hasSingleDefinedMethod)
 
             vmReachableMethods.addIncompleteCallSite(callPC)
             vmReachableMethods.addVMReachableMethod(declTgt)

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/TypeIterator.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/TypeIterator.scala
@@ -72,6 +72,7 @@ import org.opalj.tac.fpcf.analyses.pointsto.AllocationSiteBasedAnalysis.stringBu
 import org.opalj.tac.fpcf.analyses.pointsto.AllocationSiteBasedAnalysis.stringConstPointsToSet
 import org.opalj.tac.fpcf.properties.TACAI
 import org.opalj.tac.fpcf.properties.TheTACAI
+import org.opalj.util.elidedAssert
 import org.opalj.value.IsMObjectValue
 import org.opalj.value.IsNullValue
 import org.opalj.value.IsSArrayValue
@@ -1197,7 +1198,7 @@ class CFA_k_l_TypeIterator(project: SomeProject, val k: Int, val l: Int)
     extends AbstractAllocationSitesPointsToTypeIterator(project)
     with CallStringContextProvider {
 
-    assert(k > 0 && l > 0 && k >= l - 1)
+    elidedAssert(k > 0 && l > 0 && k >= l - 1)
 
     override def typesProperty(
         field:    DeclaredField,

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/TypeIteratorState.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/TypeIteratorState.scala
@@ -13,6 +13,7 @@ import org.opalj.fpcf.EPK
 import org.opalj.fpcf.Property
 import org.opalj.fpcf.SomeEOptionP
 import org.opalj.fpcf.SomeEPS
+import org.opalj.util.elidedAssert
 
 /**
  * A trait to implement state classes that have to manage the state of a [[TypeIterator]], i.e.,
@@ -85,7 +86,7 @@ trait TypeIteratorState extends AnalysisState {
             if (_dependeeToDependers(dependee).isEmpty) {
                 removeDependee(dependee)
             }
-            assert((!_dependeeToDependers.contains(dependee) && !_dependees.contains(dependee)) ||
+            elidedAssert((!_dependeeToDependers.contains(dependee) && !_dependees.contains(dependee)) ||
                 (_dependeeToDependers(dependee).nonEmpty && _dependees.contains(dependee)))
         }
 
@@ -96,7 +97,7 @@ trait TypeIteratorState extends AnalysisState {
     }
 
     final def hasDependee(dependee: EPK[Entity, Property]): Boolean = {
-        assert(!_dependeeToDependers.contains(dependee) || _dependeeToDependers(dependee).nonEmpty)
+        elidedAssert(!_dependeeToDependers.contains(dependee) || _dependeeToDependers(dependee).nonEmpty)
         _dependees.contains(dependee)
     }
 
@@ -105,7 +106,7 @@ trait TypeIteratorState extends AnalysisState {
     }
 
     private final def hasDependees: Boolean = {
-        assert(
+        elidedAssert(
             (_dependees.isEmpty == _dependeeToDependers.isEmpty) &&
             (_dependeeToDependers.isEmpty == _dependerToDependees.isEmpty)
         )
@@ -121,7 +122,7 @@ trait TypeIteratorState extends AnalysisState {
         var allDependees = super.dependees
 
         _dependees.valuesIterator.foreach { d =>
-            assert(_dependeeToDependers.contains(d.toEPK))
+            elidedAssert(_dependeeToDependers.contains(d.toEPK))
             allDependees += d
         }
 
@@ -135,7 +136,7 @@ trait TypeIteratorState extends AnalysisState {
     final def updateDependency(eps: SomeEPS): Unit = {
         val dependeeEPK = eps.toEPK
 
-        assert(_dependees.contains(dependeeEPK))
+        elidedAssert(_dependees.contains(dependeeEPK))
         _dependees(dependeeEPK) = eps
     }
 

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/reflection/MethodHandlesUtil.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/reflection/MethodHandlesUtil.scala
@@ -12,6 +12,7 @@ import org.opalj.br.MethodDescriptor
 import org.opalj.br.ReferenceType
 import org.opalj.br.VoidType
 import org.opalj.br.analyses.SomeProject
+import org.opalj.util.elidedAssert
 
 object MethodHandlesUtil {
     // TODO what about the case of an constructor?
@@ -24,7 +25,7 @@ object MethodHandlesUtil {
         isStatic:            Boolean,
         isConstructor:       Boolean
     )(implicit project: SomeProject): Set[MethodMatcher] = {
-        assert(!isStatic || !isConstructor)
+        elidedAssert(!isStatic || !isConstructor)
         Set(
             new DescriptorBasedMethodMatcher(
                 Set(

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/reflection/ReflectionRelatedCallsAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/reflection/ReflectionRelatedCallsAnalysis.scala
@@ -58,6 +58,7 @@ import org.opalj.tac.fpcf.analyses.cg.reflection.MatcherUtil.retrieveSuitableMat
 import org.opalj.tac.fpcf.analyses.cg.reflection.MethodHandlesUtil.retrieveDescriptorBasedMethodMatcher
 import org.opalj.tac.fpcf.properties.TACAI
 import org.opalj.tac.fpcf.properties.TheTACAI
+import org.opalj.util.elidedAssert
 import org.opalj.value.ASObjectValue
 import org.opalj.value.ValueInformation
 
@@ -161,7 +162,7 @@ class ClassForNameAnalysis private[analyses] (
         def hasNewLoadedClasses: Boolean = _newLoadedClasses.nonEmpty
 
         def loadedClassesPartialResult: PartialResult[SomeProject, LoadedClasses] = {
-            assert(hasNewLoadedClasses)
+            elidedAssert(hasNewLoadedClasses)
             val newLoadedClasses = _newLoadedClasses
             PartialResult[SomeProject, LoadedClasses](
                 project,

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/xta/InstantiatedTypesAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/xta/InstantiatedTypesAnalysis.scala
@@ -51,6 +51,7 @@ import org.opalj.fpcf.PropertyStore
 import org.opalj.fpcf.Results
 import org.opalj.fpcf.SomeEPS
 import org.opalj.fpcf.UBP
+import org.opalj.util.elidedAssert
 
 /**
  * Marks types as instantiated if their constructor is invoked. Constructors invoked by subclass
@@ -210,7 +211,7 @@ class InstantiatedTypesAnalysis private[analyses] (
             case pcAndInstr @ PCAndInstruction(_, `supercall`) => pcAndInstr
         }
 
-        assert(pcsOfSuperCalls.nonEmpty)
+        elidedAssert(pcsOfSuperCalls.nonEmpty)
 
         // there can be only one super call, so there must be an explicit call
         if (pcsOfSuperCalls.size > 1) {

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/xta/TypePropagationAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/xta/TypePropagationAnalysis.scala
@@ -44,6 +44,7 @@ import org.opalj.fpcf.SomePartialResult
 import org.opalj.tac.cg.TypeIteratorKey
 import org.opalj.tac.fpcf.properties.NoTACAI
 import org.opalj.tac.fpcf.properties.TACAI
+import org.opalj.util.elidedAssert
 
 /**
  * This analysis handles the type propagation of XTA, MTA, FTA and CTA call graph
@@ -136,21 +137,21 @@ final class TypePropagationAnalysis private[analyses] (
 
         case EUBP(e: DeclaredMethod, _: Callees) =>
             if (debug) {
-                assert(e == state.callContext.method)
+                elidedAssert(e == state.callContext.method)
                 _trace.traceCalleesUpdate(e)
             }
             handleUpdateOfCallees(eps.asInstanceOf[EPS[DeclaredMethod, Callees]])(using state)
 
         case EUBP(e: Method, _: MethodFieldReadAccessInformation) =>
             if (debug) {
-                assert(e == state.callContext.method.definedMethod)
+                elidedAssert(e == state.callContext.method.definedMethod)
                 _trace.traceReadAccessUpdate(e)
             }
             handleUpdateOfReadAccesses(eps.asInstanceOf[EPS[Method, MethodFieldReadAccessInformation]])(using state)
 
         case EUBP(e: Method, _: MethodFieldWriteAccessInformation) =>
             if (debug) {
-                assert(e == state.callContext.method.definedMethod)
+                elidedAssert(e == state.callContext.method.definedMethod)
                 _trace.traceWriteAccessUpdate(e)
             }
             handleUpdateOfWriteAccesses(eps.asInstanceOf[EPS[Method, MethodFieldWriteAccessInformation]])(using state)
@@ -278,11 +279,11 @@ final class TypePropagationAnalysis private[analyses] (
         } {
             // Some sanity checks ...
             // Methods with multiple defined methods should never appear as callees.
-            assert(!callee.hasMultipleDefinedMethods)
+            elidedAssert(!callee.hasMultipleDefinedMethods)
             // Instances of DefinedMethod we see should only be those where the method is defined in the class file of
             // the declaring class type (i.e., it is not a DefinedMethod instance of some inherited method).  However,
             // in inconsistent bytecode scenarios, the call graph may resolve to a non-implemented abstract method.
-            assert(!callee.hasSingleDefinedMethod ||
+            elidedAssert(!callee.hasSingleDefinedMethod ||
                 (callee.declaringClassType == callee.asDefinedMethod.definedMethod.classFile.thisType) ||
                 callee.asDefinedMethod.definedMethod.isAbstract)
 

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/xta/TypePropagationState.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/xta/TypePropagationState.scala
@@ -27,6 +27,7 @@ import org.opalj.fpcf.EOptionP
 import org.opalj.fpcf.SomeEOptionP
 import org.opalj.tac.fpcf.analyses.cg.BaseAnalysisState
 import org.opalj.tac.fpcf.properties.TACAI
+import org.opalj.util.elidedAssert
 
 /**
  * Manages the state of each method analyzed by [[TypePropagationAnalysis]].
@@ -89,7 +90,7 @@ final class TypePropagationState[ContextType <: Context](
     def isSeenCallee(pc: PC, callee: DeclaredMethod): Boolean = _seenCallees.contains((pc, callee))
 
     def addSeenCallee(pc: PC, callee: DeclaredMethod): Unit = {
-        assert(!isSeenCallee(pc, callee))
+        elidedAssert(!isSeenCallee(pc, callee))
         _seenCallees.add((pc, callee))
     }
 
@@ -161,7 +162,7 @@ final class TypePropagationState[ContextType <: Context](
     )(
         implicit classHierarchy: ClassHierarchy
     ): Boolean = {
-        assert(typeFilters.nonEmpty)
+        elidedAssert(typeFilters.nonEmpty)
         val alreadyExists = _forwardPropagationEntities.contains(typeSetEntity)
         if (!alreadyExists) {
             val compactedFilters = rootTypes(typeFilters)
@@ -207,7 +208,7 @@ final class TypePropagationState[ContextType <: Context](
     )(
         implicit classHierarchy: ClassHierarchy
     ): Boolean = {
-        assert(typeFilters.nonEmpty)
+        elidedAssert(typeFilters.nonEmpty)
         val alreadyExists = _backwardPropagationFilters.containsKey(typeSetEntity)
         if (!alreadyExists) {
             val compactedFilters = rootTypes(typeFilters)

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/xta/TypePropagationTrace.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/cg/xta/TypePropagationTrace.scala
@@ -23,6 +23,7 @@ import org.opalj.collection.immutable.UIDSet
 import org.opalj.fpcf.Entity
 import org.opalj.fpcf.PropertyStore
 import org.opalj.tac.fpcf.analyses.cg.xta.TypePropagationTrace.Trace
+import org.opalj.util.elidedAssert
 
 /**
  * This is used in [[TypePropagationAnalysis]] and logs all individual steps of the type propagation
@@ -134,7 +135,7 @@ object TypePropagationTrace {
     // turned on.
     def isEnabled: Boolean = {
         try {
-            assert(false)
+            elidedAssert(false)
             false
         } catch {
             case _: AssertionError => true

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/escape/AbstractEscapeAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/escape/AbstractEscapeAnalysis.scala
@@ -31,6 +31,7 @@ import org.opalj.fpcf.SomeEPS
 import org.opalj.fpcf.UBP
 import org.opalj.tac.common.DefinitionSiteLike
 import org.opalj.tac.fpcf.properties.TACAI
+import org.opalj.util.elidedAssert
 
 /**
  * An abstract escape analysis for a [[org.opalj.tac.common.DefinitionSiteLike]] or a
@@ -84,7 +85,7 @@ trait AbstractEscapeAnalysis extends FPCFAnalysis {
         context: AnalysisContext,
         state:   AnalysisState
     ): ProperPropertyComputationResult = {
-        assert(state.tacai.isDefined)
+        elidedAssert(state.tacai.isDefined)
         // for every use-site, check its escape state
         for (use <- state.uses) {
             checkStmtForEscape(state.tacai.get.stmts(use))

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/escape/AbstractEscapeAnalysisState.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/escape/AbstractEscapeAnalysisState.scala
@@ -17,6 +17,7 @@ import org.opalj.fpcf.EOptionP
 import org.opalj.fpcf.Property
 import org.opalj.fpcf.SomeEOptionP
 import org.opalj.tac.common.DefinitionSiteLike
+import org.opalj.util.elidedAssert
 
 /**
  * Stores the state associated with a specific [[AbstractEscapeAnalysisContext]] computed by an
@@ -49,7 +50,7 @@ trait AbstractEscapeAnalysisState {
      * given one.
      */
     @inline private[escape] final def meetMostRestrictive(prop: EscapeProperty): Unit = {
-        assert {
+        elidedAssert {
             _mostRestrictiveProperty.meet(prop).lessOrEqualRestrictive(_mostRestrictiveProperty)
         }
         _mostRestrictiveProperty = _mostRestrictiveProperty.meet(prop)
@@ -59,7 +60,7 @@ trait AbstractEscapeAnalysisState {
      * Adds an entity property pair (or epk) into the set of dependees.
      */
     @inline private[escape] final def addDependency(eOptionP: EOptionP[Entity, Property]): Unit = {
-        assert(!_dependees.contains(eOptionP.e))
+        elidedAssert(!_dependees.contains(eOptionP.e))
         _dependees += eOptionP.e -> eOptionP
         _dependeesSet += eOptionP
     }
@@ -71,7 +72,7 @@ trait AbstractEscapeAnalysisState {
     @inline private[escape] final def removeDependency(
         ep: EOptionP[Entity, Property]
     ): Unit = {
-        assert(_dependees.contains(ep.e))
+        elidedAssert(_dependees.contains(ep.e))
         val oldEOptionP = _dependees(ep.e)
         _dependees -= ep.e
         _dependeesSet -= oldEOptionP
@@ -137,7 +138,7 @@ trait AbstractEscapeAnalysisState {
      * the expression is expected to be a [[org.opalj.tac.Var]].
      */
     @inline private[escape] final def usesDefSite(expr: Expr[V]): Boolean = {
-        assert(expr.isVar)
+        elidedAssert(expr.isVar)
         expr.asVar.definedBy.contains(_defSite)
     }
 
@@ -146,7 +147,7 @@ trait AbstractEscapeAnalysisState {
      * current entity's def-site return true.
      */
     @inline private[escape] final def anyParameterUsesDefSite(params: Seq[Expr[V]]): Boolean = {
-        assert(params.forall(_.isVar))
+        elidedAssert(params.forall(_.isVar))
         params.exists { case UVar(_, defSites) => defSites.contains(_defSite) }
     }
 }

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/escape/ConfigurationBasedConstructorEscapeAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/escape/ConfigurationBasedConstructorEscapeAnalysis.scala
@@ -7,8 +7,9 @@ package escape
 
 import org.opalj.br.ClassType
 import org.opalj.br.fpcf.properties.EscapeProperty
+import org.opalj.util.elidedAssert
 
-import pureconfig._
+import pureconfig.*
 
 /**
  * In the configuration system it is possible to define escape information for the this local in the
@@ -45,9 +46,9 @@ trait ConfigurationBasedConstructorEscapeAnalysis extends AbstractEscapeAnalysis
     abstract override protected def handleThisLocalOfConstructor(
         call: NonVirtualMethodCall[V]
     )(implicit context: AnalysisContext, state: AnalysisState): Unit = {
-        assert(call.name == "<init>")
-        assert(state.usesDefSite(call.receiver))
-        assert(call.declaringClass.isClassType)
+        elidedAssert(call.name == "<init>")
+        elidedAssert(state.usesDefSite(call.receiver))
+        elidedAssert(call.declaringClass.isClassType)
 
         val propertyOption = predefinedConstructors.get(call.declaringClass.asClassType)
 

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/escape/ConstructorSensitiveEscapeAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/escape/ConstructorSensitiveEscapeAnalysis.scala
@@ -27,6 +27,7 @@ import org.opalj.fpcf.ProperPropertyComputationResult
 import org.opalj.fpcf.Property
 import org.opalj.fpcf.SomeEPS
 import org.opalj.fpcf.SomeInterimEP
+import org.opalj.util.elidedAssert
 
 /**
  * Special handling for constructor calls, as the receiver of an constructor is always an
@@ -53,8 +54,8 @@ trait ConstructorSensitiveEscapeAnalysis extends AbstractEscapeAnalysis {
         context: AnalysisContext,
         state:   AnalysisState
     ): Unit = {
-        assert(call.name == "<init>", "method is not a constructor")
-        assert(state.usesDefSite(call.receiver), "call receiver does not use def-site")
+        elidedAssert(call.name == "<init>", "method is not a constructor")
+        elidedAssert(state.usesDefSite(call.receiver), "call receiver does not use def-site")
 
         // the object constructor will not escape the this local
         if (call.declaringClass eq ClassType.Object)

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/escape/DefaultEscapeAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/escape/DefaultEscapeAnalysis.scala
@@ -8,6 +8,7 @@ package escape
 import org.opalj.br.fpcf.properties.AtMost
 import org.opalj.br.fpcf.properties.EscapeInCallee
 import org.opalj.br.fpcf.properties.NoEscape
+import org.opalj.util.elidedAssert
 
 /**
  * A safe default implementation of the [[AbstractEscapeAnalysis]] that uses fallback values.
@@ -66,7 +67,7 @@ trait DefaultEscapeAnalysis extends AbstractEscapeAnalysis {
     override protected def handleThisLocalOfConstructor(
         call: NonVirtualMethodCall[V]
     )(implicit context: AnalysisContext, state: AnalysisState): Unit = {
-        assert(call.name == "<init>")
+        elidedAssert(call.name == "<init>")
         if (state.usesDefSite(call.receiver))
             state.meetMostRestrictive(AtMost(NoEscape))
     }
@@ -81,7 +82,7 @@ trait DefaultEscapeAnalysis extends AbstractEscapeAnalysis {
     override protected def handleNonVirtualAndNonConstructorCall(
         call: NonVirtualMethodCall[V]
     )(implicit context: AnalysisContext, state: AnalysisState): Unit = {
-        assert(call.name != "<init>")
+        elidedAssert(call.name != "<init>")
         if (state.usesDefSite(call.receiver) || state.anyParameterUsesDefSite(call.params))
             state.meetMostRestrictive(AtMost(EscapeInCallee))
     }

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/escape/InterProceduralEscapeAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/escape/InterProceduralEscapeAnalysis.scala
@@ -43,6 +43,7 @@ import org.opalj.fpcf.Result
 import org.opalj.fpcf.SomeEOptionP
 import org.opalj.tac.common.DefinitionSitesKey
 import org.opalj.tac.fpcf.properties.TACAI
+import org.opalj.util.elidedAssert
 import org.opalj.value.ValueInformation
 
 class InterProceduralEscapeAnalysisContext(
@@ -186,7 +187,7 @@ object EagerInterProceduralEscapeAnalysis
 
         val methods = declaredMethods.declaredMethods
         val callersProperties = ps(methods.to(Iterable), Callers)
-        assert(callersProperties.forall(_.isFinal))
+        elidedAssert(callersProperties.forall(_.isFinal))
 
         val reachableMethods = callersProperties.filterNot(_.asFinal.p == NoCallers).map {
             v => v.e -> v.ub

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/escape/ReturnValueFreshnessAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/escape/ReturnValueFreshnessAnalysis.scala
@@ -49,7 +49,6 @@ import org.opalj.br.fpcf.properties.cg.Callers
 import org.opalj.collection.immutable.IntTrieSet
 import org.opalj.fpcf.Entity
 import org.opalj.fpcf.EOptionP
-import org.opalj.fpcf.FinalEP
 import org.opalj.fpcf.FinalP
 import org.opalj.fpcf.InterimLUBP
 import org.opalj.fpcf.InterimResult
@@ -67,6 +66,7 @@ import org.opalj.tac.cg.CallGraphKey
 import org.opalj.tac.common.DefinitionSite
 import org.opalj.tac.common.DefinitionSitesKey
 import org.opalj.tac.fpcf.properties.TACAI
+import org.opalj.util.elidedAssert
 
 class ReturnValueFreshnessState(val context: Context) {
     private var returnValueDependees: Map[Context, EOptionP[Context, ReturnValueFreshness]] = Map.empty
@@ -102,17 +102,17 @@ class ReturnValueFreshnessState(val context: Context) {
     def hasTacaiDependee: Boolean = tacaiDependee.isDefined
 
     def addMethodDependee(epOrEpk: EOptionP[Context, ReturnValueFreshness]): Unit = {
-        assert(!returnValueDependees.contains(epOrEpk.e))
+        elidedAssert(!returnValueDependees.contains(epOrEpk.e))
         returnValueDependees += epOrEpk.e -> epOrEpk
     }
 
     def addFieldDependee(epOrEpk: EOptionP[Field, FieldLocality]): Unit = {
-        assert(!fieldDependees.contains(epOrEpk.e))
+        elidedAssert(!fieldDependees.contains(epOrEpk.e))
         fieldDependees += epOrEpk.e -> epOrEpk
     }
 
     def addDefSiteDependee(epOrEpk: EOptionP[(Context, DefinitionSite), EscapeProperty]): Unit = {
-        assert(!defSiteDependees.contains(epOrEpk.e))
+        elidedAssert(!defSiteDependees.contains(epOrEpk.e))
         defSiteDependees += epOrEpk.e -> epOrEpk
     }
 

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/PointsToAnalysisState.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/pointsto/PointsToAnalysisState.scala
@@ -36,6 +36,7 @@ import org.opalj.log.OPALLogger
 import org.opalj.log.Warn
 import org.opalj.tac.fpcf.analyses.cg.BaseAnalysisState
 import org.opalj.tac.fpcf.properties.TACAI
+import org.opalj.util.elidedAssert
 
 /**
  * Encapsulates the state of the analysis, analyzing a certain method using the
@@ -100,7 +101,7 @@ class PointsToAnalysisState[
     }
 
     def setAllocationSitePointsToSet(ds: Entity, pointsToSet: PointsToSet): Unit = {
-        assert(!_allocationSitePointsToSets.contains(ds))
+        elidedAssert(!_allocationSitePointsToSets.contains(ds))
         _allocationSitePointsToSets(ds) = pointsToSet
     }
 
@@ -144,7 +145,7 @@ class PointsToAnalysisState[
     }
 
     final def hasDependees(depender: Entity): Boolean = {
-        assert(!_dependerToDependees.contains(depender) || _dependerToDependees(depender).nonEmpty)
+        elidedAssert(!_dependerToDependees.contains(depender) || _dependerToDependees(depender).nonEmpty)
         _dependerToDependees.contains(depender)
     }
 
@@ -155,13 +156,13 @@ class PointsToAnalysisState[
     ): Unit = {
         val dependeeEPK = dependee.toEPK
 
-        assert(
+        elidedAssert(
             !_dependerToDependees.contains(depender) ||
             !_dependerToDependees(depender).exists(other =>
                 other._1.e == dependee.e && other._1.pk.id == dependee.pk.id
             )
         )
-        assert(!_dependees.contains(dependeeEPK) || _dependees(dependeeEPK) == dependee)
+        elidedAssert(!_dependees.contains(dependeeEPK) || _dependees(dependeeEPK) == dependee)
         if (_dependerToDependees.contains(depender)) {
             _dependerToDependees(depender) += ((dependee, typeFilter))
         } else {
@@ -188,7 +189,7 @@ class PointsToAnalysisState[
 
     // IMPROVE: make it efficient
     final def dependeesOf(depender: Entity): Map[SomeEPK, (SomeEOptionP, ReferenceType => Boolean)] = {
-        assert(_dependerToDependees.contains(depender))
+        elidedAssert(_dependerToDependees.contains(depender))
         _dependerToDependees(depender).iterator.map(dependee => (dependee._1.toEPK, dependee)).toMap
     }
 

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/purity/DomainSpecificRater.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/purity/DomainSpecificRater.scala
@@ -12,6 +12,7 @@ import org.opalj.br.analyses.SomeProject
 import org.opalj.br.fpcf.properties.DPure
 import org.opalj.br.fpcf.properties.Pure
 import org.opalj.br.fpcf.properties.Purity
+import org.opalj.util.elidedAssert
 import org.opalj.value.ValueInformation
 
 /**
@@ -135,7 +136,7 @@ trait SystemOutErrRater extends DomainSpecificRater {
             if (defSite < 0) false
             else {
                 val stmt = code(defSite)
-                assert(stmt.astID == Assignment.ASTID, "defSite should be assignment")
+                elidedAssert(stmt.astID == Assignment.ASTID, "defSite should be assignment")
                 if (stmt.asAssignment.expr.astID != GetStatic.ASTID) false
                 else {
                     val GetStatic(_, declaringClass, name, _) = stmt.asAssignment.expr: @unchecked

--- a/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/purity/L2PurityAnalysis.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/fpcf/analyses/purity/L2PurityAnalysis.scala
@@ -77,6 +77,7 @@ import org.opalj.fpcf.SomeEPS
 import org.opalj.fpcf.UBP
 import org.opalj.tac.cg.CallGraphKey
 import org.opalj.tac.fpcf.properties.TACAI
+import org.opalj.util.elidedAssert
 import org.opalj.value.ASObjectValue
 
 import net.ceedubs.ficus.Ficus.*
@@ -391,7 +392,7 @@ class L2PurityAnalysis private[analyses] (val project: SomeProject) extends Abst
         }
 
         val stmt = state.tac.stmts(defSite)
-        assert(stmt.astID == Assignment.ASTID, "defSite should be assignment")
+        elidedAssert(stmt.astID == Assignment.ASTID, "defSite should be assignment")
 
         val rhs = stmt.asAssignment.expr
         if (rhs.isConst)
@@ -865,7 +866,7 @@ class L2PurityAnalysis private[analyses] (val project: SomeProject) extends Abst
         var s = 0
         while (s < stmtCount) {
             if (!checkPurityOfStmt(state.tac.stmts(s))) { // Early return for impure statements
-                assert(state.ubPurity.isInstanceOf[ClassifiedImpure])
+                elidedAssert(state.ubPurity.isInstanceOf[ClassifiedImpure])
                 return Result(state.context, state.ubPurity);
             }
             s += 1
@@ -873,7 +874,7 @@ class L2PurityAnalysis private[analyses] (val project: SomeProject) extends Abst
 
         val callees = propertyStore(state.context.method, Callees.key)
         if (!checkPurityOfCallees(callees)) {
-            assert(state.ubPurity.isInstanceOf[ClassifiedImpure])
+            elidedAssert(state.ubPurity.isInstanceOf[ClassifiedImpure])
             return Result(state.context, state.ubPurity)
         }
 

--- a/OPAL/tac/src/main/scala/org/opalj/tac/package.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/package.scala
@@ -23,6 +23,7 @@ import org.opalj.br.cfg.CFG
 import org.opalj.collection.immutable.EmptyIntTrieSet
 import org.opalj.collection.immutable.IntTrieSet
 import org.opalj.graphs.Node
+import org.opalj.util.elidedAssert
 import org.opalj.value.ValueInformation
 
 /**
@@ -163,7 +164,7 @@ package object tac {
 
             if (lastPC < oldStartPC) {
                 // the EH is totally dead... i.e., all code in the try block is dead
-                assert(
+                elidedAssert(
                     (oldEH.startPC until oldEH.endPC) forall { tryPC =>
                         aiResult.domain.exceptionHandlerSuccessorsOf(tryPC).isEmpty
                     },
@@ -179,7 +180,7 @@ package object tac {
 
         }
 
-        assert(
+        elidedAssert(
             newEndIndex >= newStartIndex, // both equal => EH is dead!
             s"the end of the try block $newEndIndex is before the start $newStartIndex"
         )

--- a/TOOLS/hermes/src/main/scala/org/opalj/hermes/Feature.scala
+++ b/TOOLS/hermes/src/main/scala/org/opalj/hermes/Feature.scala
@@ -2,6 +2,8 @@
 package org.opalj
 package hermes
 
+import org.opalj.util.elidedAssert
+
 /**
  * Represents the immutable results of a feature query.
  *
@@ -13,7 +15,6 @@ package hermes
  *         primarily useful when exploring the project and is optional.
  *         I.e., `extensions.size` can be  smaller than `count`. The maximum number
  *         of stored locations is set using the global setting: `org.opalj.hermes.maxLocations`.
- *
  * @author Michael Eichberg
  */
 abstract case class Feature[S] private (
@@ -21,7 +22,7 @@ abstract case class Feature[S] private (
     count:      Int,
     extensions: List[Location[S]]
 ) {
-    assert(count >= extensions.size)
+    elidedAssert(count >= extensions.size)
 }
 
 /**

--- a/build.sbt
+++ b/build.sbt
@@ -199,7 +199,17 @@ lazy val `Common` = (project in file("OPAL/common"))
     .settings(
         name := "Common",
         Compile / doc / scalacOptions := Opts.doc.title("OPAL-Common"),
-        libraryDependencies ++= Dependencies.common(scalaVersion.value)
+        libraryDependencies ++= Dependencies.common(scalaVersion.value),
+        // This tasks flips all `false` flags in the ReleaseFlags file to `true` when compiling production
+        // (non-SNAPSHOT) builds in order to elide assertions. A separate task later resets the file for development.
+        Compile / sourceGenerators += Def.task {
+            if (!(ThisBuild / version).value.endsWith("-SNAPSHOT")) {
+                val file = (Compile / sourceDirectory).value / "scala" / "org" / "opalj" / "ReleaseFlags.scala"
+                IO.write(file, releaseFlags.replace("= false", "= true"))
+                streams.value.log.info("Disabling assertions")
+                Seq(file)
+            } else Seq.empty
+        }.taskValue
     )
     .configs(IntegrationTest)
 
@@ -529,6 +539,7 @@ lazy val `ConfigurationExplorer` = (project in file("TOOLS/ce"))
  * TASKS, etc
  *
  */
+
 // To run the task: compile:generateSite
 val generateSite = Compile / taskKey[File]("creates the OPAL website")
 
@@ -550,6 +561,20 @@ compile := {
     (Compile / generateSite).value
     r
 }
+
+// This task resets the ReleaseFlags file that was rewritten in the `Common` subproject above when compiling production
+// (non-SNAPSHOT) builds to elide assertions. This restores standard development behavior, i.e., enabled assertions.
+val releaseFlagsFile = file("OPAL/common/src/main/scala/org/opalj/ReleaseFlags.scala")
+val releaseFlags = IO.read(releaseFlagsFile)
+lazy val reenableAssertions = taskKey[Unit]("Re-enables assertions")
+
+reenableAssertions := {
+    if (!(ThisBuild / version).value.endsWith("-SNAPSHOT")) {
+        IO.write(releaseFlagsFile, releaseFlags)
+        streams.value.log.info("Enabling assertions")
+    }
+}
+reenableAssertions := (reenableAssertions triggeredBy (Common / Compile / compile)).value
 
 //
 //

--- a/scalac.options.local.template
+++ b/scalac.options.local.template
@@ -19,5 +19,3 @@
 //-Yexplicit-nulls
 //-language:noAutoTupling
 //-language:strictEquality
-
-// (Should be turned-off during development; i.e., assertions are enabled at development time) -Xdisable-assertions


### PR DESCRIPTION
Since Scala 3 removed the `-Xdisable-assertions` compiler option (and other related features such as `-Xelide-below`), we need a new way to have assertions without runtime impact. This solution is somewhat hacky but seems to work reasonably well.