### PR TITLE
Revert back to Scala 3.7.3

### DIFF
--- a/OPAL/common/src/test/scala/org/opalj/collection/immutable/IntTrieSetProperties.scala
+++ b/OPAL/common/src/test/scala/org/opalj/collection/immutable/IntTrieSetProperties.scala
@@ -835,7 +835,7 @@ class IntTrieSetTest extends AnyFunSpec with Matchers {
             PerformanceEvaluation.time {
                 for { _ <- 0 until 10000000 } {
                     var s = org.opalj.collection.immutable.IntTrieSet.empty
-                    @nowarn("msg=mutated")
+                    @nowarn("msg=unused")
                     var hits = 0
                     for { i <- 0 to rngGen.nextInt(8) } {
                         s += setValues(i)
@@ -863,7 +863,7 @@ class IntTrieSetTest extends AnyFunSpec with Matchers {
             PerformanceEvaluation.time {
                 for { _ <- 0 until 10000000 } {
                     var s = org.opalj.collection.immutable.IntTrieSet.empty
-                    @nowarn("msg=mutated")
+                    @nowarn("msg=unused")
                     var hits = 0
                     for { i <- 0 to 8 + rngGen.nextInt(8) } {
                         s += setValues(i)
@@ -891,7 +891,7 @@ class IntTrieSetTest extends AnyFunSpec with Matchers {
             PerformanceEvaluation.time {
                 for { _ <- 0 until 1000000 } {
                     var s = org.opalj.collection.immutable.IntTrieSet.empty
-                    @nowarn("msg=mutated")
+                    @nowarn("msg=unused")
                     var hits = 0
                     for { i <- 0 to 16 + rngGen.nextInt(16) } {
                         s += setValues(i)
@@ -919,7 +919,7 @@ class IntTrieSetTest extends AnyFunSpec with Matchers {
             PerformanceEvaluation.time {
                 for { runs <- 0 until 10000 } {
                     var s = org.opalj.collection.immutable.IntTrieSet.empty
-                    @nowarn("msg=mutated")
+                    @nowarn("msg=unused")
                     var hits = 0
                     for { i <- 1 to runs } {
                         s += setValues(i)

--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ ThisBuild / licenses := Seq("BSD-2-Clause" -> url("https://opensource.org/licens
 
 usePgpKeyHex("80B9D3FB5A8508F6B4774932E71AFF01E234090C")
 
-ThisBuild / scalaVersion := "3.7.4"
+ThisBuild / scalaVersion := "3.7.3"
 
 ScalacConfiguration.globalScalacOptions
 


### PR DESCRIPTION
This PR reverts our recent update to Scala 3.7.4 back to 3.7.3. @errt and I were able to trace the current IT test failure on develop back to what seemst to be a Scala compiler bug in 3.7.4 - therefore we stay with 3.7.3 for now.