### PR TITLE
Remove settings.sbt duplicating scalac.options

### DIFF
--- a/project/settings.sbt
+++ b/project/settings.sbt
@@ -1,1 +1,0 @@
-scalacOptions ++= Seq("-unchecked", "-deprecation")


### PR DESCRIPTION
These settings are loaded from scala.options anyway where they are configurable.