### PR TITLE
Fix Eclipse JDT compiler library version (fixes #359)

### DIFF
--- a/DEVELOPING_OPAL/plugins/sbt-java-fixture-compiler/build.sbt
+++ b/DEVELOPING_OPAL/plugins/sbt-java-fixture-compiler/build.sbt
@@ -32,4 +32,4 @@ ThisBuild / scalacOptions ++= Seq(
 )
 
 // The version of Eclipse JDT compiler library needs to stay fixed for use within OPAL!
-libraryDependencies ++= Seq("org.eclipse.jdt" % "ecj" % "3.28.0.v20211021-2009")
+libraryDependencies ++= Seq("org.eclipse.jdt" % "ecj" % "3.28.0")

--- a/project/libraries.sbt
+++ b/project/libraries.sbt
@@ -1,6 +1,6 @@
 // Required to compile the Java projects that are used as test fixtures.
 // THE VERSION OF THIS LIBRARY MUST NOT BE UPDATED - WE RELY ON THE JAVA CLASS FILE'S INTERNALS!
-libraryDependencies += "org.eclipse.jdt" % "ecj" % "3.28.0.v20211021-2009" // <= DO *NOT* CHANGE!
+libraryDependencies += "org.eclipse.jdt" % "ecj" % "3.28.0" // <= DO *NOT* CHANGE!
 
 // Required to compile the website
 libraryDependencies += "org.playframework.twirl" %% "twirl-api" % "2.0.9"


### PR DESCRIPTION
Updated the version of the Eclipse JDT compiler library to a more specific version.