### PR TITLE
Fixes scala-reflect issue with GitHub pureconfig (https://github.com/opalj/JCG/issues/17)

### DIFF
--- a/OPAL/br/src/main/scala/org/opalj/br/analyses/cg/EntryPointFinder.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/analyses/cg/EntryPointFinder.scala
@@ -380,7 +380,8 @@ trait ConfigurationEntryPointsFinder extends EntryPointFinder {
 
     // Implement ConfigReader manually to avoid issue with scala-reflect: https://github.com/opalj/JCG/issues/17
     implicit private val entryPointContainerReader: ConfigReader[EntryPointContainer] =
-        ConfigReader.forProduct3("declaringClass", "name", "descriptor")(new EntryPointContainer(_,_,_))
+        ConfigReader.forProduct3("declaring-class", "name", "descriptor")(EntryPointContainer.apply)
+          .orElse(ConfigReader.forProduct3("declaringClass", "name", "descriptor")(EntryPointContainer.apply))
 }
 
 /**

--- a/OPAL/br/src/main/scala/org/opalj/br/analyses/cg/EntryPointFinder.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/analyses/cg/EntryPointFinder.scala
@@ -379,9 +379,8 @@ trait ConfigurationEntryPointsFinder extends EntryPointFinder {
     )
 
     // Implement ConfigReader manually to avoid issue with scala-reflect: https://github.com/opalj/JCG/issues/17
-    implicit private val entryPointContainerReader: ConfigReader[EntryPointContainer] =
+    private implicit val entryPointContainerReader: ConfigReader[EntryPointContainer] =
         ConfigReader.forProduct3("declaring-class", "name", "descriptor")(EntryPointContainer.apply)
-          .orElse(ConfigReader.forProduct3("declaringClass", "name", "descriptor")(EntryPointContainer.apply))
 }
 
 /**

--- a/OPAL/br/src/main/scala/org/opalj/br/analyses/cg/EntryPointFinder.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/analyses/cg/EntryPointFinder.scala
@@ -235,8 +235,8 @@ trait LibraryEntryPointsFinder extends EntryPointFinder {
  *            InitialEntryPointKey {
  *                analysis = "org.opalj.br.analyses.cg.ConfigurationEntryPointsFinder"
  *                entryPoints = [
- *                  {declaringClass = "java/util/List+", name = "add"},
- *                  {declaringClass = "java/util/List", name = "remove", descriptor = "(I)Z"}
+ *                  {declaring-class = "java/util/List+", name = "add"},
+ *                  {declaring-class = "java/util/List", name = "remove", descriptor = "(I)Z"}
  *                ]
  *            }
  *        }
@@ -245,7 +245,7 @@ trait LibraryEntryPointsFinder extends EntryPointFinder {
  * Please note that the first entry point, by adding the "+" to the declaring class' name, considers
  * all "add" methods from all subtypes independently of the respective method's descriptor. In
  * contrast, the second entry does specify a descriptor and does not consider List's subtypes (by
- * not suffixing a plus to the declaringClass) which implies that only the remove method with this
+ * not suffixing a plus to the declaring-class) which implies that only the remove method with this
  * descriptor is considered as entry point.
  *
  * @author Michael Reif

--- a/OPAL/br/src/main/scala/org/opalj/br/analyses/cg/EntryPointFinder.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/analyses/cg/EntryPointFinder.scala
@@ -376,7 +376,11 @@ trait ConfigurationEntryPointsFinder extends EntryPointFinder {
         declaringClass: String,
         name:           String,
         descriptor:     Option[String]
-    ) derives ConfigReader
+    )
+
+    // Implement ConfigReader manually to avoid issue with scala-reflect: https://github.com/opalj/JCG/issues/17
+    implicit private val entryPointContainerReader: ConfigReader[EntryPointContainer] =
+        ConfigReader.forProduct3("declaringClass", "name", "descriptor")(new EntryPointContainer(_,_,_))
 }
 
 /**


### PR DESCRIPTION
Hi,

This fixes https://github.com/opalj/JCG/issues/17.

The issue is that Opal depends on scala-reflect, which is binary incompatible with Scala 3 classes.
The problem is that Githubs pureconfig generates Scala 3 code that crashes scala-reflect searches for `ConfigurationEntryPointsFinder`.

The fix reimplements the `ConfigurationEntryPointsFinder.EntryPointContainer` configuration reader to avoid the generation of problematic Scala 3 classes.

I tested the fix in JCG and it works.

Sven