### PR TITLE
Fix duplicate update in callees

### DIFF
--- a/OPAL/br/src/main/scala/org/opalj/br/fpcf/properties/cg/Callees.scala
+++ b/OPAL/br/src/main/scala/org/opalj/br/fpcf/properties/cg/Callees.scala
@@ -329,7 +329,6 @@ sealed class ConcreteCallees(
         indirectCallParameters: IntMap[IntMap[Seq[Option[(ValueInformation, br.PCs)]]]]
     ): Callees = {
         val cId = callerContext.id
-        directCalleesIds.updateWith(cId, directCallees, (o, n) => o.unionWith(n, (_, l, r) => l ++ r))
         new ConcreteCallees(
             directCalleesIds.updateWith(
                 cId,

--- a/OPAL/tac/src/main/resources/reference.conf
+++ b/OPAL/tac/src/main/resources/reference.conf
@@ -1702,7 +1702,7 @@ org.opalj {
         "UnsafePointsTo",
         "SerializationAllocations",
         "NewInstance",
-        "org.opalj.tac.fpcf.analyses.pointsto.ReflectionAllocationsAnalysisScheduler",
+        "ReflectionAllocationsAnalysisScheduler",
         "org.opalj.tac.fpcf.analyses.fieldaccess.TriggeredFieldAccessInformationAnalysis",
         "org.opalj.tac.fpcf.analyses.fieldaccess.reflection.ReflectionRelatedFieldAccessesAnalysisScheduler",
       ]

--- a/OPAL/tac/src/main/resources/reference.conf
+++ b/OPAL/tac/src/main/resources/reference.conf
@@ -1702,7 +1702,7 @@ org.opalj {
         "UnsafePointsTo",
         "SerializationAllocations",
         "NewInstance",
-        "ReflectionAllocationsAnalysisScheduler",
+        "org.opalj.tac.fpcf.analyses.pointsto.ReflectionAllocationsAnalysisScheduler",
         "org.opalj.tac.fpcf.analyses.fieldaccess.TriggeredFieldAccessInformationAnalysis",
         "org.opalj.tac.fpcf.analyses.fieldaccess.reflection.ReflectionRelatedFieldAccessesAnalysisScheduler",
       ]


### PR DESCRIPTION
This PR fixes a duplicate, irrelevant call to `updateWith` for the direct callees in `Callees.scala`. I tried to test the performance improvement resulting from this, but found no measurable impact when running the `CallGraphIntegrationTest` multiple times. I did, however, see errors when loading the *TypeBased* `ReflectionAllocationsAnalysisScheduler` - an additional `AnalysisScheduler` was appended to the class name before reflectively locating the class, which resulted in a ClassNotFoundException. Using the fully qualified name in the configuration, the error disappeared.