### PR TITLE
Disable ReflectionAllocationsAnalysis for TypeBasedPointsTo key

### DIFF
--- a/OPAL/tac/src/main/resources/reference.conf
+++ b/OPAL/tac/src/main/resources/reference.conf
@@ -1702,10 +1702,15 @@ org.opalj {
         "UnsafePointsTo",
         "SerializationAllocations",
         "NewInstance",
-        "ReflectionAllocationsAnalysisScheduler",
         "org.opalj.tac.fpcf.analyses.fieldaccess.TriggeredFieldAccessInformationAnalysis",
         "org.opalj.tac.fpcf.analyses.fieldaccess.reflection.ReflectionRelatedFieldAccessesAnalysisScheduler",
       ]
+    },
+    AllocationSites {
+        # Modules (analyses for different functionalities) to be used when tracking allocation sites in call graph construction
+        modules = [
+            "org.opalj.tac.fpcf.analyses.pointsto.ReflectionAllocationsAnalysisScheduler"
+        ]
     }
   }
 }

--- a/OPAL/tac/src/main/scala/org/opalj/tac/cg/AllocationSiteBasedPointsToCallGraphKey.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/cg/AllocationSiteBasedPointsToCallGraphKey.scala
@@ -3,11 +3,31 @@ package org.opalj
 package tac
 package cg
 
+import scala.jdk.CollectionConverters.*
+
 import org.opalj.br.analyses.ProjectInformationKey
 import org.opalj.br.analyses.SomeProject
+import org.opalj.br.fpcf.FPCFAnalysisScheduler
 import org.opalj.br.fpcf.properties.SimpleContexts
 import org.opalj.br.fpcf.properties.SimpleContextsKey
+import org.opalj.log.LogContext
 import org.opalj.tac.fpcf.analyses.cg.AllocationSitesPointsToTypeIterator
+
+trait AllocationSiteBasedPointsToCallGraphKey extends PointsToCallGraphKey {
+
+    override protected def registeredAnalyses(project: SomeProject): scala.collection.Seq[FPCFAnalysisScheduler] = {
+        implicit val logContext: LogContext = project.logContext
+        val config = project.config
+
+        // TODO use FPCFAnalysesRegistry here
+        super.registeredAnalyses(project) ++ config.getStringList(
+            "org.opalj.tac.cg.AllocationSites.modules"
+        ).asScala.flatMap { moduleName =>
+            resolveAnalysisRunner(if (moduleName.contains('.')) moduleName else getModuleFQN(moduleName))
+        }
+    }
+
+}
 
 /**
  * A [[org.opalj.br.analyses.ProjectInformationKey]] to compute a [[CallGraph]] based on
@@ -17,7 +37,7 @@ import org.opalj.tac.fpcf.analyses.cg.AllocationSitesPointsToTypeIterator
  *
  * @author Florian Kuebler
  */
-object AllocationSiteBasedPointsToCallGraphKey extends PointsToCallGraphKey {
+object AllocationSiteBasedPointsToCallGraphKey extends AllocationSiteBasedPointsToCallGraphKey {
 
     override val pointsToType: String = "AllocationSiteBased"
     override val contextKey: ProjectInformationKey[SimpleContexts, Nothing] = SimpleContextsKey

--- a/OPAL/tac/src/main/scala/org/opalj/tac/cg/CFA_1_0_CallGraphKey.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/cg/CFA_1_0_CallGraphKey.scala
@@ -20,7 +20,7 @@ import org.opalj.tac.fpcf.analyses.cg.TypesBasedPointsToTypeIterator
  *
  * @author Dominik Helm
  */
-object CFA_1_0_CallGraphKey extends PointsToCallGraphKey {
+object CFA_1_0_CallGraphKey extends AllocationSiteBasedPointsToCallGraphKey {
 
     override val pointsToType: String = "TypeBased"
     override val contextKey: ProjectInformationKey[CallStringContexts, Nothing] = CallStringContextsKey

--- a/OPAL/tac/src/main/scala/org/opalj/tac/cg/CFA_1_1_CallGraphKey.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/cg/CFA_1_1_CallGraphKey.scala
@@ -18,7 +18,7 @@ import org.opalj.tac.fpcf.analyses.cg.CFA_k_l_TypeIterator
  *
  * @author Dominik Helm
  */
-object CFA_1_1_CallGraphKey extends PointsToCallGraphKey {
+object CFA_1_1_CallGraphKey extends AllocationSiteBasedPointsToCallGraphKey {
 
     override val pointsToType: String = "AllocationSiteBased"
     override val contextKey: ProjectInformationKey[CallStringContexts, Nothing] = CallStringContextsKey

--- a/OPAL/tac/src/main/scala/org/opalj/tac/cg/PointsToCallGraphKey.scala
+++ b/OPAL/tac/src/main/scala/org/opalj/tac/cg/PointsToCallGraphKey.scala
@@ -52,7 +52,7 @@ trait PointsToCallGraphKey extends CallGraphKey {
         }
     }
 
-    private def getModuleFQN(moduleName: String): String = {
+    protected def getModuleFQN(moduleName: String): String = {
         s"org.opalj.tac.fpcf.analyses.pointsto.${pointsToType}${moduleName}AnalysisScheduler"
     }
 }


### PR DESCRIPTION
As mentioned in #357 the `ReflectionAllocationsAnalysisScheduler` should not be executed with the `TypeBasedPointsToCallGraphKey`, but it should be run for all other implementations of `PointsToCallGraphKey`. This PR proposes one possible solution for the issue - i am however open for discussion, there are many ways this could be realized.

This PR moves the `ReflectionAllocationsAnalysisScheduler` into a separate configuration section, which is not loaded by the `PointsToCallGraphKey` trait, but instead by the new and more specific `trait AllocationSiteBasedPointsToCallGraphKey extends PointsToCallGraphKey`. The `TypeBasedPointsToCallGraphKey` only implements `PointsToCallGraphKey`, so the incompatible analysis is not loaded. I made all other direct children of `PointsToCallGraphKey` inherit from `AllocationSiteBasedPointsToCallGraphKey` instead, so they all still load the desired analysis.